### PR TITLE
[TRIBAL 4.3] Implement write path pipeline extraction stage

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -288,6 +288,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "bstr"
+version = "1.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63044e1ae8e69f3b5a92c736ca6269b8d12fa7efe39bf34ddb06d102cf0e2cab"
+dependencies = [
+ "memchr",
+ "serde",
+]
+
+[[package]]
 name = "bumpalo"
 version = "3.19.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -347,6 +357,28 @@ dependencies = [
  "serde",
  "wasm-bindgen",
  "windows-link",
+]
+
+[[package]]
+name = "chrono-tz"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93698b29de5e97ad0ae26447b344c482a7284c737d9ddc5f9e52b74a336671bb"
+dependencies = [
+ "chrono",
+ "chrono-tz-build",
+ "phf",
+]
+
+[[package]]
+name = "chrono-tz-build"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c088aee841df9c3041febbb73934cfc39708749bf96dc827e3359cd39ef11b1"
+dependencies = [
+ "parse-zoneinfo",
+ "phf",
+ "phf_codegen",
 ]
 
 [[package]]
@@ -428,6 +460,25 @@ name = "crossbeam-channel"
 version = "0.5.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "82b8f8f868b36967f9606790d1903570de9ceaf870a7bf9fbbd3016d636a2cb2"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-deque"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9dd111b7b7f7d55b72c0a6ae361660ee5853c9af73f70c3c2ef6858b950e2e51"
+dependencies = [
+ "crossbeam-epoch",
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-epoch"
+version = "0.9.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
 dependencies = [
  "crossbeam-utils",
 ]
@@ -544,6 +595,12 @@ dependencies = [
  "powerfmt",
  "serde_core",
 ]
+
+[[package]]
+name = "deunicode"
+version = "1.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "abd57806937c9cc163efc8ea3910e00a62e2aeb0b8119f1793a978088f8f6b04"
 
 [[package]]
 name = "digest"
@@ -877,6 +934,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "globset"
+version = "0.4.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52dfc19153a48bde0cbd630453615c8151bce3a5adfac7a0aebfbf0a1e1f57e3"
+dependencies = [
+ "aho-corasick",
+ "bstr",
+ "log",
+ "regex-automata",
+ "regex-syntax",
+]
+
+[[package]]
+name = "globwalk"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0bf760ebf69878d9fd8f110c89703d90ce35095324d1f1edcb595c63945ee757"
+dependencies = [
+ "bitflags",
+ "ignore",
+ "walkdir",
+]
+
+[[package]]
 name = "h2"
 version = "0.4.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1022,6 +1103,15 @@ name = "httpdate"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
+
+[[package]]
+name = "humansize"
+version = "2.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6cb51c9a029ddc91b07a787f1d86b53ccfa49b0e86688c946ebe8d3555685dd7"
+dependencies = [
+ "libm",
+]
 
 [[package]]
 name = "hyper"
@@ -1264,6 +1354,22 @@ checksum = "3acae9609540aa318d1bc588455225fb2085b9ed0c4f6bd0d9d5bcd86f1a0344"
 dependencies = [
  "icu_normalizer",
  "icu_properties",
+]
+
+[[package]]
+name = "ignore"
+version = "0.4.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3d782a365a015e0f5c04902246139249abf769125006fbe7649e2ee88169b4a"
+dependencies = [
+ "crossbeam-deque",
+ "globset",
+ "log",
+ "memchr",
+ "regex-automata",
+ "same-file",
+ "walkdir",
+ "winapi-util",
 ]
 
 [[package]]
@@ -1673,6 +1779,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "parse-zoneinfo"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f2a05b18d44e2957b88f96ba460715e295bc1d7510468a2f3d3b44535d26c24"
+dependencies = [
+ "regex",
+]
+
+[[package]]
 name = "pem-rfc7468"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1688,12 +1803,93 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
+name = "pest"
+version = "2.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e0848c601009d37dfa3430c4666e147e49cdcf1b92ecd3e63657d8a5f19da662"
+dependencies = [
+ "memchr",
+ "ucd-trie",
+]
+
+[[package]]
+name = "pest_derive"
+version = "2.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11f486f1ea21e6c10ed15d5a7c77165d0ee443402f0780849d1768e7d9d6fe77"
+dependencies = [
+ "pest",
+ "pest_generator",
+]
+
+[[package]]
+name = "pest_generator"
+version = "2.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8040c4647b13b210a963c1ed407c1ff4fdfa01c31d6d2a098218702e6664f94f"
+dependencies = [
+ "pest",
+ "pest_meta",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "pest_meta"
+version = "2.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "89815c69d36021a140146f26659a81d6c2afa33d216d736dd4be5381a7362220"
+dependencies = [
+ "pest",
+ "sha2",
+]
+
+[[package]]
 name = "pgvector"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc58e2d255979a31caa7cabfa7aac654af0354220719ab7a68520ae7a91e8c0b"
 dependencies = [
  "sqlx",
+]
+
+[[package]]
+name = "phf"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fd6780a80ae0c52cc120a26a1a42c1ae51b247a253e4e06113d23d2c2edd078"
+dependencies = [
+ "phf_shared",
+]
+
+[[package]]
+name = "phf_codegen"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aef8048c789fa5e851558d709946d6d79a8ff88c0440c587967f8e94bfb1216a"
+dependencies = [
+ "phf_generator",
+ "phf_shared",
+]
+
+[[package]]
+name = "phf_generator"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c80231409c20246a13fddb31776fb942c38553c51e871f8cbd687a4cfb5843d"
+dependencies = [
+ "phf_shared",
+ "rand 0.8.5",
+]
+
+[[package]]
+name = "phf_shared"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67eabc2ef2a60eb7faa00097bd1ffdb5bd28e62bf39990626a582201b7a754e5"
+dependencies = [
+ "siphasher",
 ]
 
 [[package]]
@@ -2232,6 +2428,18 @@ dependencies = [
 
 [[package]]
 name = "schemars"
+version = "0.8.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3fbf2ae1b8bc8e02df939598064d22402220cd5bbcca1c76f7d6a310974d5615"
+dependencies = [
+ "dyn-clone",
+ "schemars_derive",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "schemars"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4cd191f9397d57d581cddd31014772520aa448f65ef991055d7f61582c65165f"
@@ -2252,6 +2460,18 @@ dependencies = [
  "ref-cast",
  "serde",
  "serde_json",
+]
+
+[[package]]
+name = "schemars_derive"
+version = "0.8.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32e265784ad618884abaea0600a9adf15393368d840e0222d101a072f3f7534d"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "serde_derive_internals",
+ "syn",
 ]
 
 [[package]]
@@ -2313,6 +2533,17 @@ name = "serde_derive"
 version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "serde_derive_internals"
+version = "0.29.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "18d26a20a969b9e3fdf2fc2d9f21eda6c40e2de84c9408bb5d3b05d499aae711"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2444,10 +2675,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "siphasher"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2aa850e253778c88a04c3d7323b043aeda9d3e30d5971937c1855769763678e"
+
+[[package]]
 name = "slab"
 version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
+
+[[package]]
+name = "slug"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "882a80f72ee45de3cc9a5afeb2da0331d58df69e4e7d8eeb5d3c7784ae67e724"
+dependencies = [
+ "deunicode",
+ "wasm-bindgen",
+]
 
 [[package]]
 name = "smallvec"
@@ -2779,6 +3026,28 @@ dependencies = [
  "once_cell",
  "rustix",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "tera"
+version = "1.20.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e8004bca281f2d32df3bacd59bc67b312cb4c70cea46cbd79dbe8ac5ed206722"
+dependencies = [
+ "chrono",
+ "chrono-tz",
+ "globwalk",
+ "humansize",
+ "lazy_static",
+ "percent-encoding",
+ "pest",
+ "pest_derive",
+ "rand 0.8.5",
+ "regex",
+ "serde",
+ "serde_json",
+ "slug",
+ "unicode-segmentation",
 ]
 
 [[package]]
@@ -3178,6 +3447,7 @@ name = "tribal-domain"
 version = "0.1.0"
 dependencies = [
  "chrono",
+ "schemars 0.8.22",
  "serde",
  "serde_json",
  "thiserror 2.0.18",
@@ -3260,9 +3530,11 @@ version = "0.1.0"
 dependencies = [
  "chrono",
  "dashmap",
+ "schemars 0.8.22",
  "serde",
  "serde_json",
  "sqlx",
+ "tera",
  "thiserror 2.0.18",
  "tokio",
  "tokio-util",
@@ -3307,6 +3579,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "562d481066bde0658276a35467c4af00bdc6ee726305698a55b86e61d7ad82bb"
 
 [[package]]
+name = "ucd-trie"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2896d95c02a80c6d6a5d6e953d479f5ddf2dfdb6a244441010e373ac0fb88971"
+
+[[package]]
 name = "unicode-bidi"
 version = "0.3.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3332,6 +3610,12 @@ name = "unicode-properties"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7df058c713841ad818f1dc5d3fd88063241cc61f49f5fbea4b951e8cf5a8d71d"
+
+[[package]]
+name = "unicode-segmentation"
+version = "1.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6ccf251212114b54433ec949fd6a7841275f9ada20dddd2f29e9ceea4501493"
 
 [[package]]
 name = "unicode-xid"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -69,6 +69,12 @@ dashmap = "6"
 # Async traits
 async-trait = "0.1"
 
+# Template rendering
+tera = "1"
+
+# JSON Schema generation
+schemars = "0.8"
+
 # Testing
 tempfile = "3"
 testcontainers = "0.27"

--- a/crates/tribal-db/migrations/20260224210057_extend_error_kind_internal_error.sql
+++ b/crates/tribal-db/migrations/20260224210057_extend_error_kind_internal_error.sql
@@ -1,0 +1,1 @@
+-- Add migration script here

--- a/crates/tribal-db/migrations/20260224210057_extend_error_kind_internal_error.sql
+++ b/crates/tribal-db/migrations/20260224210057_extend_error_kind_internal_error.sql
@@ -1,1 +1,8 @@
--- Add migration script here
+-- Extend the tasks.error_kind CHECK constraint to include 'internal_error'.
+
+ALTER TABLE tasks DROP CONSTRAINT IF EXISTS tasks_error_kind_check;
+ALTER TABLE tasks ADD CONSTRAINT tasks_error_kind_check CHECK (error_kind IN (
+    'provider_error', 'semaphore_timeout', 'parse_error',
+    'heartbeat_expired', 'startup_reclaim', 'ownership_lost', 'timeout',
+    'database_error', 'internal_error'
+));

--- a/crates/tribal-domain/Cargo.toml
+++ b/crates/tribal-domain/Cargo.toml
@@ -6,8 +6,12 @@ license.workspace = true
 rust-version.workspace = true
 publish.workspace = true
 
+[features]
+schema = ["dep:schemars"]
+
 [dependencies]
 chrono = { workspace = true }
+schemars = { workspace = true, optional = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 thiserror = { workspace = true }

--- a/crates/tribal-domain/src/candidate.rs
+++ b/crates/tribal-domain/src/candidate.rs
@@ -1,0 +1,131 @@
+//! Candidate types — extracted knowledge item candidates and intra-batch
+//! relation hints produced by the extraction stage.
+//!
+//! All types have private fields with accessors and are constructed via
+//! serde deserialisation, not application code.
+
+use serde::{Deserialize, Serialize};
+
+use crate::{KnowledgeKind, RelationHintType};
+
+// ---------------------------------------------------------------------------
+// Candidate
+// ---------------------------------------------------------------------------
+
+/// A knowledge item candidate extracted from raw input.
+///
+/// Candidates are the primary output of the extraction stage. Each
+/// candidate may progress through triage to become a committed
+/// knowledge item, or be discarded as a duplicate.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
+pub struct Candidate {
+    /// Classification of the candidate knowledge.
+    kind: KnowledgeKind,
+    /// The knowledge content.
+    content: String,
+    /// Suggested categorisation tags. Always expected from the
+    /// extraction prompt — an absent field is a parse error.
+    suggested_tags: Vec<String>,
+    /// Optional external references.
+    #[serde(default)]
+    suggested_references: Vec<SuggestedReference>,
+}
+
+impl Candidate {
+    /// Returns the knowledge kind.
+    pub fn kind(&self) -> KnowledgeKind {
+        self.kind
+    }
+
+    /// Returns the knowledge content.
+    pub fn content(&self) -> &str {
+        &self.content
+    }
+
+    /// Returns the suggested tags.
+    pub fn suggested_tags(&self) -> &[String] {
+        &self.suggested_tags
+    }
+
+    /// Returns the suggested references.
+    pub fn suggested_references(&self) -> &[SuggestedReference] {
+        &self.suggested_references
+    }
+}
+
+// ---------------------------------------------------------------------------
+// SuggestedReference
+// ---------------------------------------------------------------------------
+
+/// A suggested external reference for a candidate.
+///
+/// The `reference_type` is a free string — the LLM may produce values
+/// outside the expected set. Validation and mapping to [`ReferenceKind`]
+/// happens during triage, not extraction.
+///
+/// [`ReferenceKind`]: crate::ReferenceKind
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
+pub struct SuggestedReference {
+    /// Free-form reference type (e.g. "url", "file_path").
+    reference_type: String,
+    /// The reference value.
+    value: String,
+    /// Optional human-readable context.
+    #[serde(default)]
+    description: Option<String>,
+}
+
+impl SuggestedReference {
+    /// Returns the reference type.
+    pub fn reference_type(&self) -> &str {
+        &self.reference_type
+    }
+
+    /// Returns the reference value.
+    pub fn value(&self) -> &str {
+        &self.value
+    }
+
+    /// Returns the description, if present.
+    pub fn description(&self) -> Option<&str> {
+        self.description.as_deref()
+    }
+}
+
+// ---------------------------------------------------------------------------
+// RelationHint
+// ---------------------------------------------------------------------------
+
+/// An intra-batch relation hint between two candidates by index.
+///
+/// Emitted by the extraction agent to indicate that one candidate
+/// is derived from another within the same batch.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
+pub struct RelationHint {
+    /// Index of the source candidate in the batch.
+    source_index: u32,
+    /// Index of the target candidate in the batch.
+    target_index: u32,
+    /// The type of relation hinted at.
+    hint_type: RelationHintType,
+}
+
+impl RelationHint {
+    /// Returns the source candidate index.
+    pub fn source_index(&self) -> u32 {
+        self.source_index
+    }
+
+    /// Returns the target candidate index.
+    pub fn target_index(&self) -> u32 {
+        self.target_index
+    }
+
+    /// Returns the relation hint type.
+    pub fn hint_type(&self) -> RelationHintType {
+        self.hint_type
+    }
+}

--- a/crates/tribal-domain/src/candidate.rs
+++ b/crates/tribal-domain/src/candidate.rs
@@ -68,7 +68,7 @@ impl Candidate {
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
 pub struct SuggestedReference {
-    /// Free-form reference type (e.g. "url", "file_path").
+    /// Free-form reference type (e.g. `"url"`, `"file_path"`).
     reference_type: String,
     /// The reference value.
     value: String,

--- a/crates/tribal-domain/src/knowledge.rs
+++ b/crates/tribal-domain/src/knowledge.rs
@@ -13,6 +13,7 @@ use crate::{EpisodeId, KnowledgeItemId, PrincipalId, ProjectId};
 
 /// The classification of a knowledge item.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
 #[serde(rename_all = "snake_case")]
 pub enum KnowledgeKind {
     /// A discrete, verifiable piece of information.

--- a/crates/tribal-domain/src/lib.rs
+++ b/crates/tribal-domain/src/lib.rs
@@ -45,6 +45,7 @@ macro_rules! enum_text_conversions {
 }
 
 mod auth_token;
+mod candidate;
 mod database_config;
 mod discovery;
 mod embedding;
@@ -74,6 +75,7 @@ mod token_usage;
 mod triage;
 
 pub use auth_token::{AuthToken, AuthTokenBuilder};
+pub use candidate::{Candidate, RelationHint, SuggestedReference};
 pub use database_config::DatabaseConfig;
 pub use discovery::{Direction, DiscoveryField, ExplorationField};
 pub use embedding::{Embedding, EmbeddingBuilder};

--- a/crates/tribal-domain/src/relation.rs
+++ b/crates/tribal-domain/src/relation.rs
@@ -62,6 +62,7 @@ enum_text_conversions!(RelationSuggestion {
 /// Currently a single variant; the enum exists as an extension point for
 /// future hint types.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
 #[serde(rename_all = "snake_case")]
 pub enum RelationHintType {
     /// Intra-batch derivation hint from the extraction agent.

--- a/crates/tribal-domain/src/task.rs
+++ b/crates/tribal-domain/src/task.rs
@@ -60,6 +60,8 @@ pub enum TaskErrorKind {
     Timeout,
     /// Database error during stage execution.
     DatabaseError,
+    /// Internal logic error (e.g. template rendering failure).
+    InternalError,
 }
 
 enum_text_conversions!(TaskType {
@@ -84,6 +86,7 @@ enum_text_conversions!(TaskErrorKind {
     TaskErrorKind::OwnershipLost => "ownership_lost",
     TaskErrorKind::Timeout => "timeout",
     TaskErrorKind::DatabaseError => "database_error",
+    TaskErrorKind::InternalError => "internal_error",
 });
 
 /// A task in the ingest pipeline.
@@ -242,6 +245,7 @@ mod tests {
         TaskErrorKind::OwnershipLost => "ownership_lost",
         TaskErrorKind::Timeout => "timeout",
         TaskErrorKind::DatabaseError => "database_error",
+        TaskErrorKind::InternalError => "internal_error",
     });
 
     enum_text_tests!(test_task_type_text_roundtrip, TaskType {
@@ -266,5 +270,6 @@ mod tests {
         TaskErrorKind::OwnershipLost => "ownership_lost",
         TaskErrorKind::Timeout => "timeout",
         TaskErrorKind::DatabaseError => "database_error",
+        TaskErrorKind::InternalError => "internal_error",
     });
 }

--- a/crates/tribal-domain/src/task.rs
+++ b/crates/tribal-domain/src/task.rs
@@ -56,7 +56,7 @@ pub enum TaskErrorKind {
     StartupReclaim,
     /// Commit rejected because another worker reclaimed the task.
     OwnershipLost,
-    /// Task exceeded `task_timeout_seconds`.
+    /// Task exceeded the configured task timeout.
     Timeout,
     /// Database error during stage execution.
     DatabaseError,

--- a/crates/tribal-test-utils/src/duration.rs
+++ b/crates/tribal-test-utils/src/duration.rs
@@ -1,0 +1,62 @@
+//! Centralised test duration constants.
+//!
+//! Every magic sleep or backdate duration used in integration tests
+//! should be defined here with a name that explains *why* the value
+//! was chosen, not just how long it is.  This makes it easy to tune
+//! timeouts if default test configuration changes or if CI flakes.
+
+use std::time::Duration;
+
+// ---------------------------------------------------------------------------
+// Worker cycle durations
+// ---------------------------------------------------------------------------
+
+/// Time for a worker to complete at least one poll-claim-dispatch cycle.
+///
+/// Given `test_config().poll_interval_seconds = 1`, three seconds
+/// provides ample room for claim, stage dispatch, and commit.
+pub const POLL_SETTLE: Duration = Duration::from_secs(3);
+
+/// Time for a worker to process multiple tasks across several poll
+/// cycles.  Used in concurrency tests that need more than two claim
+/// rounds to exercise the concurrency limit.
+pub const MULTI_CYCLE_SETTLE: Duration = Duration::from_secs(4);
+
+/// Time for a worker to claim a task and begin dispatching, but
+/// before a long-running stage completes.  Used to inject external
+/// state changes (reclaim, heartbeat loss) while a mock provider
+/// delay is still in flight.
+pub const CLAIM_SETTLE: Duration = Duration::from_secs(2);
+
+/// Time for the heartbeat loop to detect an externally-reclaimed task.
+///
+/// Given `test_config().heartbeat_interval_seconds = 1`, three seconds
+/// gives the heartbeat at least two chances to observe the loss.
+pub const HEARTBEAT_DETECT: Duration = Duration::from_secs(3);
+
+// ---------------------------------------------------------------------------
+// Simulated staleness
+// ---------------------------------------------------------------------------
+
+/// Duration to backdate a task heartbeat to simulate staleness.
+///
+/// Must exceed `test_config().task_timeout_seconds` (10) by a wide
+/// margin to guarantee the reclaim sweep treats the task as stale.
+pub const STALE_HEARTBEAT_BACKDATE: Duration = Duration::from_secs(120);
+
+// ---------------------------------------------------------------------------
+// Mock provider simulation
+// ---------------------------------------------------------------------------
+
+/// Mock provider delay simulating a long-running LLM call.
+///
+/// Must be long enough that the test can inject external state changes
+/// (reclaim, heartbeat loss) before the call completes.
+pub const LONG_PROVIDER_DELAY: Duration = Duration::from_secs(30);
+
+/// Upper bound for asserting that an in-flight stage was aborted
+/// early.
+///
+/// Must be well under [`LONG_PROVIDER_DELAY`] to confirm the stage
+/// was interrupted rather than running to completion.
+pub const EARLY_ABORT_BOUND: Duration = Duration::from_secs(15);

--- a/crates/tribal-test-utils/src/duration.rs
+++ b/crates/tribal-test-utils/src/duration.rs
@@ -4,6 +4,11 @@
 //! should be defined here with a name that explains *why* the value
 //! was chosen, not just how long it is.  This makes it easy to tune
 //! timeouts if default test configuration changes or if CI flakes.
+//!
+//! With the poll-until test pattern these constants serve as
+//! **timeout upper bounds** rather than exact sleep durations.  Values
+//! include headroom above the theoretical minimum to avoid flakes
+//! under CI load.
 
 use std::time::Duration;
 
@@ -11,28 +16,35 @@ use std::time::Duration;
 // Worker cycle durations
 // ---------------------------------------------------------------------------
 
-/// Time for a worker to complete at least one poll-claim-dispatch cycle.
+/// Timeout for a worker to complete at least one poll-claim-dispatch
+/// cycle.
 ///
-/// Given `test_config().poll_interval_millis = 100`, 500 ms provides
-/// ample room for claim, stage dispatch, and commit.
-pub const POLL_SETTLE: Duration = Duration::from_millis(500);
+/// Theoretical minimum: `poll_interval` (100 ms) + claim + stage
+/// dispatch + commit ≈ 400 ms.  Set to 1 s for headroom.
+pub const POLL_SETTLE: Duration = Duration::from_secs(1);
 
-/// Time for a worker to process multiple tasks across several poll
+/// Timeout for a worker to process multiple tasks across several poll
 /// cycles.  Used in concurrency tests that need more than two claim
 /// rounds to exercise the concurrency limit.
-pub const MULTI_CYCLE_SETTLE: Duration = Duration::from_secs(1);
-
-/// Time for a worker to claim a task and begin dispatching, but
-/// before a long-running stage completes.  Used to inject external
-/// state changes (reclaim, heartbeat loss) while a mock provider
-/// delay is still in flight.
-pub const CLAIM_SETTLE: Duration = Duration::from_millis(300);
-
-/// Time for the heartbeat loop to detect an externally-reclaimed task.
 ///
-/// Given `test_config().heartbeat_interval_millis = 200`, 600 ms
-/// gives the heartbeat at least two chances to observe the loss.
-pub const HEARTBEAT_DETECT: Duration = Duration::from_millis(600);
+/// Multiple 100 ms poll cycles + dispatch overhead.  Set to 2 s.
+pub const MULTI_CYCLE_SETTLE: Duration = Duration::from_secs(2);
+
+/// Timeout for a worker to claim a task and begin dispatching, but
+/// before a long-running stage completes.  Used to confirm the
+/// provider has been called while a mock delay is still in flight.
+///
+/// Theoretical minimum: `poll_interval` (100 ms) + claim + DB loads
+/// for tag registry and prompt version ≈ 300 ms.  Set to 500 ms for
+/// headroom.
+pub const CLAIM_SETTLE: Duration = Duration::from_millis(500);
+
+/// Timeout for the heartbeat loop to detect an externally-reclaimed
+/// task.
+///
+/// Given `test_config().heartbeat_interval_millis = 200`, 1 s gives
+/// the heartbeat at least four chances to observe the loss.
+pub const HEARTBEAT_DETECT: Duration = Duration::from_secs(1);
 
 // ---------------------------------------------------------------------------
 // Simulated staleness

--- a/crates/tribal-test-utils/src/duration.rs
+++ b/crates/tribal-test-utils/src/duration.rs
@@ -13,26 +13,26 @@ use std::time::Duration;
 
 /// Time for a worker to complete at least one poll-claim-dispatch cycle.
 ///
-/// Given `test_config().poll_interval_seconds = 1`, three seconds
-/// provides ample room for claim, stage dispatch, and commit.
-pub const POLL_SETTLE: Duration = Duration::from_secs(3);
+/// Given `test_config().poll_interval_millis = 100`, 500 ms provides
+/// ample room for claim, stage dispatch, and commit.
+pub const POLL_SETTLE: Duration = Duration::from_millis(500);
 
 /// Time for a worker to process multiple tasks across several poll
 /// cycles.  Used in concurrency tests that need more than two claim
 /// rounds to exercise the concurrency limit.
-pub const MULTI_CYCLE_SETTLE: Duration = Duration::from_secs(4);
+pub const MULTI_CYCLE_SETTLE: Duration = Duration::from_secs(1);
 
 /// Time for a worker to claim a task and begin dispatching, but
 /// before a long-running stage completes.  Used to inject external
 /// state changes (reclaim, heartbeat loss) while a mock provider
 /// delay is still in flight.
-pub const CLAIM_SETTLE: Duration = Duration::from_secs(2);
+pub const CLAIM_SETTLE: Duration = Duration::from_millis(300);
 
 /// Time for the heartbeat loop to detect an externally-reclaimed task.
 ///
-/// Given `test_config().heartbeat_interval_seconds = 1`, three seconds
+/// Given `test_config().heartbeat_interval_millis = 200`, 600 ms
 /// gives the heartbeat at least two chances to observe the loss.
-pub const HEARTBEAT_DETECT: Duration = Duration::from_secs(3);
+pub const HEARTBEAT_DETECT: Duration = Duration::from_millis(600);
 
 // ---------------------------------------------------------------------------
 // Simulated staleness
@@ -40,7 +40,7 @@ pub const HEARTBEAT_DETECT: Duration = Duration::from_secs(3);
 
 /// Duration to backdate a task heartbeat to simulate staleness.
 ///
-/// Must exceed `test_config().task_timeout_seconds` (10) by a wide
+/// Must exceed `test_config().task_timeout_millis` (`5_000`) by a wide
 /// margin to guarantee the reclaim sweep treats the task as stale.
 pub const STALE_HEARTBEAT_BACKDATE: Duration = Duration::from_secs(120);
 
@@ -52,11 +52,11 @@ pub const STALE_HEARTBEAT_BACKDATE: Duration = Duration::from_secs(120);
 ///
 /// Must be long enough that the test can inject external state changes
 /// (reclaim, heartbeat loss) before the call completes.
-pub const LONG_PROVIDER_DELAY: Duration = Duration::from_secs(30);
+pub const LONG_PROVIDER_DELAY: Duration = Duration::from_secs(5);
 
 /// Upper bound for asserting that an in-flight stage was aborted
 /// early.
 ///
 /// Must be well under [`LONG_PROVIDER_DELAY`] to confirm the stage
 /// was interrupted rather than running to completion.
-pub const EARLY_ABORT_BOUND: Duration = Duration::from_secs(15);
+pub const EARLY_ABORT_BOUND: Duration = Duration::from_secs(2);

--- a/crates/tribal-test-utils/src/factories.rs
+++ b/crates/tribal-test-utils/src/factories.rs
@@ -73,6 +73,7 @@ macro_rules! define_factory {
 // ---------------------------------------------------------------------------
 
 mod auth_token;
+mod candidate;
 mod embedding;
 mod extraction_result;
 mod item_observation;
@@ -91,6 +92,7 @@ mod token_usage;
 mod triage;
 
 pub use auth_token::*;
+pub use candidate::*;
 pub use embedding::*;
 pub use extraction_result::*;
 pub use item_observation::*;

--- a/crates/tribal-test-utils/src/factories/candidate.rs
+++ b/crates/tribal-test-utils/src/factories/candidate.rs
@@ -1,0 +1,221 @@
+//! Factories for extraction candidate and relation hint types.
+//!
+//! These are hand-written (not `define_factory!`) because `Candidate`
+//! and `RelationHint` have private fields and no `TypedBuilder` —
+//! they are constructed via serde deserialisation only.
+
+use tribal_domain::{Candidate, KnowledgeKind, RelationHint, RelationHintType};
+
+// ---------------------------------------------------------------------------
+// CandidateFactory
+// ---------------------------------------------------------------------------
+
+/// Factory for [`Candidate`] instances.
+#[derive(Debug, Clone)]
+pub struct CandidateFactory {
+    kind: KnowledgeKind,
+    content: String,
+    suggested_tags: Vec<String>,
+    suggested_references: Vec<serde_json::Value>,
+}
+
+impl Default for CandidateFactory {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl CandidateFactory {
+    /// Creates a new factory with sensible defaults.
+    pub fn new() -> Self {
+        Self {
+            kind: KnowledgeKind::Fact,
+            content: "test candidate content".to_owned(),
+            suggested_tags: vec!["test-tag".to_owned()],
+            suggested_references: vec![],
+        }
+    }
+
+    /// Overrides the knowledge kind.
+    #[must_use]
+    pub fn kind(mut self, value: KnowledgeKind) -> Self {
+        self.kind = value;
+        self
+    }
+
+    /// Overrides the content.
+    #[must_use]
+    pub fn content(mut self, value: String) -> Self {
+        self.content = value;
+        self
+    }
+
+    /// Overrides the suggested tags.
+    #[must_use]
+    pub fn suggested_tags(mut self, value: Vec<String>) -> Self {
+        self.suggested_tags = value;
+        self
+    }
+
+    /// Overrides the suggested references.
+    #[must_use]
+    pub fn suggested_references(mut self, value: Vec<serde_json::Value>) -> Self {
+        self.suggested_references = value;
+        self
+    }
+
+    /// Builds a [`Candidate`] from the current factory state.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the assembled JSON cannot be deserialised into a
+    /// `Candidate`.
+    pub fn build(self) -> Candidate {
+        serde_json::from_value(serde_json::json!({
+            "kind": self.kind,
+            "content": self.content,
+            "suggested_tags": self.suggested_tags,
+            "suggested_references": self.suggested_references,
+        }))
+        .expect("CandidateFactory produces valid JSON")
+    }
+}
+
+/// Returns a [`CandidateFactory`] with sensible defaults.
+pub fn a_candidate() -> CandidateFactory {
+    CandidateFactory::new()
+}
+
+// ---------------------------------------------------------------------------
+// RelationHintFactory
+// ---------------------------------------------------------------------------
+
+/// Factory for [`RelationHint`] instances.
+#[derive(Debug, Clone)]
+pub struct RelationHintFactory {
+    source_index: u32,
+    target_index: u32,
+    hint_type: RelationHintType,
+}
+
+impl Default for RelationHintFactory {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl RelationHintFactory {
+    /// Creates a new factory with sensible defaults.
+    pub fn new() -> Self {
+        Self {
+            source_index: 0,
+            target_index: 1,
+            hint_type: RelationHintType::DerivedFrom,
+        }
+    }
+
+    /// Overrides the source index.
+    #[must_use]
+    pub fn source_index(mut self, value: u32) -> Self {
+        self.source_index = value;
+        self
+    }
+
+    /// Overrides the target index.
+    #[must_use]
+    pub fn target_index(mut self, value: u32) -> Self {
+        self.target_index = value;
+        self
+    }
+
+    /// Overrides the hint type.
+    #[must_use]
+    pub fn hint_type(mut self, value: RelationHintType) -> Self {
+        self.hint_type = value;
+        self
+    }
+
+    /// Builds a [`RelationHint`] from the current factory state.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the assembled JSON cannot be deserialised into a
+    /// `RelationHint`.
+    pub fn build(self) -> RelationHint {
+        serde_json::from_value(serde_json::json!({
+            "source_index": self.source_index,
+            "target_index": self.target_index,
+            "hint_type": self.hint_type,
+        }))
+        .expect("RelationHintFactory produces valid JSON")
+    }
+}
+
+/// Returns a [`RelationHintFactory`] with sensible defaults.
+pub fn a_relation_hint() -> RelationHintFactory {
+    RelationHintFactory::new()
+}
+
+// ---------------------------------------------------------------------------
+// Serialisation helpers
+// ---------------------------------------------------------------------------
+
+/// Serialises a slice of candidates to a JSON value.
+///
+/// # Panics
+///
+/// Panics if serialisation fails.
+pub fn candidates_json(candidates: &[Candidate]) -> serde_json::Value {
+    serde_json::to_value(candidates).expect("candidates serialise to JSON")
+}
+
+/// Serialises a slice of relation hints to a JSON value.
+///
+/// # Panics
+///
+/// Panics if serialisation fails.
+pub fn relation_hints_json(hints: &[RelationHint]) -> serde_json::Value {
+    serde_json::to_value(hints).expect("relation hints serialise to JSON")
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_candidate_builds_with_defaults() {
+        let candidate = a_candidate().build();
+        assert_eq!(candidate.kind(), KnowledgeKind::Fact);
+        assert_eq!(candidate.content(), "test candidate content");
+        assert_eq!(candidate.suggested_tags(), &["test-tag".to_owned()]);
+        assert!(candidate.suggested_references().is_empty());
+    }
+
+    #[test]
+    fn test_relation_hint_builds_with_defaults() {
+        let hint = a_relation_hint().build();
+        assert_eq!(hint.source_index(), 0);
+        assert_eq!(hint.target_index(), 1);
+        assert_eq!(hint.hint_type(), RelationHintType::DerivedFrom);
+    }
+
+    #[test]
+    fn test_candidates_json_serialises_slice() {
+        let candidates = vec![a_candidate().build()];
+        let json = candidates_json(&candidates);
+        assert!(json.is_array());
+        assert_eq!(json.as_array().unwrap().len(), 1);
+    }
+
+    #[test]
+    fn test_relation_hints_json_serialises_slice() {
+        let hints = vec![a_relation_hint().build()];
+        let json = relation_hints_json(&hints);
+        assert!(json.is_array());
+        assert_eq!(json.as_array().unwrap().len(), 1);
+    }
+}

--- a/crates/tribal-test-utils/src/lib.rs
+++ b/crates/tribal-test-utils/src/lib.rs
@@ -8,10 +8,10 @@
 mod db;
 pub mod duration;
 mod error;
-pub mod polling;
 mod factories;
 mod lifecycle;
 mod mock_inference;
+pub mod polling;
 mod seeding;
 mod setup;
 mod text;

--- a/crates/tribal-test-utils/src/lib.rs
+++ b/crates/tribal-test-utils/src/lib.rs
@@ -6,6 +6,7 @@
 //! and assertion helpers.
 
 mod db;
+pub mod duration;
 mod error;
 mod factories;
 mod lifecycle;

--- a/crates/tribal-test-utils/src/lib.rs
+++ b/crates/tribal-test-utils/src/lib.rs
@@ -8,6 +8,7 @@
 mod db;
 pub mod duration;
 mod error;
+pub mod polling;
 mod factories;
 mod lifecycle;
 mod mock_inference;

--- a/crates/tribal-test-utils/src/polling.rs
+++ b/crates/tribal-test-utils/src/polling.rs
@@ -1,0 +1,116 @@
+//! Poll-until helpers for integration tests.
+//!
+//! These helpers replace wall-clock sleeps with condition-based polling,
+//! eliminating timing assumptions and making tests both faster and more
+//! deterministic.
+
+use std::{future::Future, time::Duration};
+
+use sqlx::PgPool;
+use tribal_db::{JobRepository, PgJobRepository, PgTaskRepository, TaskRepository};
+use tribal_domain::{Job, JobId, JobStatus, Task, TaskId, TaskStatus};
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+const ENTITY_POLL_INTERVAL: Duration = Duration::from_millis(50);
+
+// ---------------------------------------------------------------------------
+// Generic poll
+// ---------------------------------------------------------------------------
+
+/// Polls `f` every `interval` until it returns `Some(T)`, panicking if
+/// `timeout` elapses first.
+///
+/// # Panics
+///
+/// Panics with `description` if the timeout is reached before `f`
+/// returns `Some`.
+pub async fn poll_until<T, F, Fut>(
+    description: &str,
+    interval: Duration,
+    timeout: Duration,
+    f: F,
+) -> T
+where
+    F: Fn() -> Fut,
+    Fut: Future<Output = Option<T>>,
+{
+    let deadline = tokio::time::Instant::now() + timeout;
+    loop {
+        if let Some(value) = f().await {
+            return value;
+        }
+        if tokio::time::Instant::now() >= deadline {
+            panic!("poll_until timed out: {description}");
+        }
+        tokio::time::sleep(interval).await;
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Task polling
+// ---------------------------------------------------------------------------
+
+/// Polls until the task reaches the expected status, returning the task.
+///
+/// Uses a 50 ms internal poll interval.
+///
+/// # Panics
+///
+/// Panics if the timeout is reached before the task reaches `target`.
+pub async fn poll_task_status(
+    pool: &PgPool,
+    task_id: TaskId,
+    target: TaskStatus,
+    timeout: Duration,
+) -> Task {
+    let description = format!("task {task_id} to reach {target:?}");
+    poll_until(&description, ENTITY_POLL_INTERVAL, timeout, || {
+        let pool = pool.clone();
+        async move {
+            let mut conn = pool.acquire().await.ok()?;
+            let task = PgTaskRepository.find_by_id(&mut conn, task_id).await.ok()?;
+            if task.status() == target {
+                Some(task)
+            } else {
+                None
+            }
+        }
+    })
+    .await
+}
+
+// ---------------------------------------------------------------------------
+// Job polling
+// ---------------------------------------------------------------------------
+
+/// Polls until the job reaches the expected status, returning the job.
+///
+/// Uses a 50 ms internal poll interval.
+///
+/// # Panics
+///
+/// Panics if the timeout is reached before the job reaches `target`.
+pub async fn poll_job_status(
+    pool: &PgPool,
+    job_id: JobId,
+    target: JobStatus,
+    timeout: Duration,
+) -> Job {
+    let description = format!("job {job_id} to reach {target:?}");
+    poll_until(&description, ENTITY_POLL_INTERVAL, timeout, || {
+        let pool = pool.clone();
+        async move {
+            let mut conn = pool.acquire().await.ok()?;
+            let job = PgJobRepository.find_by_id(&mut conn, job_id).await.ok()?;
+            if job.status() == target {
+                Some(job)
+            } else {
+                None
+            }
+        }
+    })
+    .await
+}

--- a/crates/tribal-test-utils/src/polling.rs
+++ b/crates/tribal-test-utils/src/polling.rs
@@ -61,6 +61,7 @@ where
 /// # Panics
 ///
 /// Panics if the timeout is reached before the task reaches `target`.
+/// Also panics immediately if a database error occurs during polling.
 pub async fn poll_task_status(
     pool: &PgPool,
     task_id: TaskId,
@@ -71,8 +72,11 @@ pub async fn poll_task_status(
     poll_until(&description, ENTITY_POLL_INTERVAL, timeout, || {
         let pool = pool.clone();
         async move {
-            let mut conn = pool.acquire().await.ok()?;
-            let task = PgTaskRepository.find_by_id(&mut conn, task_id).await.ok()?;
+            let mut conn = pool.acquire().await.expect("pool acquire failed");
+            let task = PgTaskRepository
+                .find_by_id(&mut conn, task_id)
+                .await
+                .expect("task query failed");
             if task.status() == target {
                 Some(task)
             } else {
@@ -94,6 +98,7 @@ pub async fn poll_task_status(
 /// # Panics
 ///
 /// Panics if the timeout is reached before the job reaches `target`.
+/// Also panics immediately if a database error occurs during polling.
 pub async fn poll_job_status(
     pool: &PgPool,
     job_id: JobId,
@@ -104,8 +109,11 @@ pub async fn poll_job_status(
     poll_until(&description, ENTITY_POLL_INTERVAL, timeout, || {
         let pool = pool.clone();
         async move {
-            let mut conn = pool.acquire().await.ok()?;
-            let job = PgJobRepository.find_by_id(&mut conn, job_id).await.ok()?;
+            let mut conn = pool.acquire().await.expect("pool acquire failed");
+            let job = PgJobRepository
+                .find_by_id(&mut conn, job_id)
+                .await
+                .expect("job query failed");
             if job.status() == target {
                 Some(job)
             } else {

--- a/crates/tribal-test-utils/src/polling.rs
+++ b/crates/tribal-test-utils/src/polling.rs
@@ -42,9 +42,10 @@ where
         if let Some(value) = f().await {
             return value;
         }
-        if tokio::time::Instant::now() >= deadline {
-            panic!("poll_until timed out: {description}");
-        }
+        assert!(
+            tokio::time::Instant::now() < deadline,
+            "poll_until timed out: {description}",
+        );
         tokio::time::sleep(interval).await;
     }
 }

--- a/crates/tribal-test-utils/src/setup.rs
+++ b/crates/tribal-test-utils/src/setup.rs
@@ -6,8 +6,16 @@
 //! insertion path (embeddings, committed relations).
 
 use sqlx::PgConnection;
-use tribal_db::{NewPromptVersion, PgPromptVersionRepository, PromptVersionRepository};
-use tribal_domain::{KnowledgeItemId, PrincipalId, PromptVersionId, RelationBatchId, RelationKind};
+use tribal_db::{
+    JobRepository, NewPromptVersion, PgJobRepository, PgPromptVersionRepository, PgTaskRepository,
+    PromptVersionRepository, TaskRepository,
+};
+use tribal_domain::{
+    JobId, KnowledgeItemId, PrincipalId, ProjectId, PromptVersionId, RelationBatchId, RelationKind,
+    TaskId, TaskType,
+};
+
+use crate::{a_new_job, a_new_task};
 
 // ---------------------------------------------------------------------------
 // Constants
@@ -106,4 +114,48 @@ pub async fn insert_committed_relation(
     .execute(&mut *conn)
     .await
     .expect("setup: insert committed relation");
+}
+
+// ---------------------------------------------------------------------------
+// seed_extraction_job
+// ---------------------------------------------------------------------------
+
+/// Inserts a job and its extraction task, returning both IDs.
+///
+/// The job uses the same prompt version for all three stages, which
+/// is the common case in integration tests.
+///
+/// # Panics
+///
+/// Panics if either insert fails.
+pub async fn seed_extraction_job(
+    conn: &mut PgConnection,
+    principal_id: PrincipalId,
+    project_id: ProjectId,
+    pv_id: PromptVersionId,
+) -> (JobId, TaskId) {
+    let job = PgJobRepository
+        .insert(
+            conn,
+            &a_new_job()
+                .project_id(project_id)
+                .principal_id(principal_id)
+                .extraction_prompt_version_id(pv_id)
+                .triage_prompt_version_id(pv_id)
+                .relation_prompt_version_id(pv_id)
+                .build(),
+        )
+        .await
+        .expect("setup: insert job");
+    let task = PgTaskRepository
+        .insert(
+            conn,
+            &a_new_task()
+                .job_id(job.id())
+                .task_type(TaskType::Extraction)
+                .build(),
+        )
+        .await
+        .expect("setup: insert task");
+    (job.id(), task.id())
 }

--- a/crates/tribal-worker/Cargo.toml
+++ b/crates/tribal-worker/Cargo.toml
@@ -7,7 +7,7 @@ rust-version.workspace = true
 publish.workspace = true
 
 [dependencies]
-tribal-domain.workspace = true
+tribal-domain = { workspace = true, features = ["schema"] }
 tribal-db.workspace = true
 tribal-inference.workspace = true
 
@@ -21,6 +21,8 @@ sqlx.workspace = true
 uuid.workspace = true
 chrono.workspace = true
 dashmap.workspace = true
+tera.workspace = true
+schemars.workspace = true
 
 [dev-dependencies]
 tribal-test-utils.workspace = true

--- a/crates/tribal-worker/src/common.rs
+++ b/crates/tribal-worker/src/common.rs
@@ -1,0 +1,26 @@
+//! Shared utilities used across the worker crate.
+
+/// Clamps a `usize` to `u32`, saturating at [`u32::MAX`].
+pub(crate) fn clamp_to_u32(value: usize) -> u32 {
+    u32::try_from(value).unwrap_or(u32::MAX)
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_clamp_to_u32_within_range() {
+        assert_eq!(clamp_to_u32(42), 42);
+        assert_eq!(clamp_to_u32(0), 0);
+    }
+
+    #[test]
+    fn test_clamp_to_u32_saturates() {
+        assert_eq!(clamp_to_u32(usize::MAX), u32::MAX);
+    }
+}

--- a/crates/tribal-worker/src/config.rs
+++ b/crates/tribal-worker/src/config.rs
@@ -27,8 +27,8 @@ pub enum ConfigError {
 
 /// Configuration for the worker loop.
 ///
-/// All duration fields are expressed as integer seconds and converted to
-/// [`Duration`] via convenience methods.  Defaults are applied via
+/// All duration fields are expressed as integer milliseconds and converted
+/// to [`Duration`] via convenience methods.  Defaults are applied via
 /// `serde(default)` so that an empty JSON object deserialises to a valid
 /// configuration.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
@@ -37,25 +37,25 @@ pub struct WorkerConfig {
     #[serde(default = "default_max_concurrent_tasks")]
     pub max_concurrent_tasks: usize,
 
-    /// Seconds between poll cycles.
-    #[serde(default = "default_poll_interval_seconds")]
-    pub poll_interval_seconds: u64,
+    /// Milliseconds between poll cycles.
+    #[serde(default = "default_poll_interval_millis")]
+    pub poll_interval_millis: u64,
 
-    /// Per-task timeout in seconds.
-    #[serde(default = "default_task_timeout_seconds")]
-    pub task_timeout_seconds: u64,
+    /// Per-task timeout in milliseconds.
+    #[serde(default = "default_task_timeout_millis")]
+    pub task_timeout_millis: u64,
 
     /// Maximum retries before a task is dead-lettered.
     #[serde(default = "default_task_max_retries")]
     pub task_max_retries: u32,
 
-    /// Seconds between heartbeat updates for claimed tasks.
-    #[serde(default = "default_heartbeat_interval_seconds")]
-    pub heartbeat_interval_seconds: u64,
+    /// Milliseconds between heartbeat updates for claimed tasks.
+    #[serde(default = "default_heartbeat_interval_millis")]
+    pub heartbeat_interval_millis: u64,
 
-    /// Seconds between stale-task reclaim sweeps.
-    #[serde(default = "default_reclaim_interval_seconds")]
-    pub reclaim_interval_seconds: u64,
+    /// Milliseconds between stale-task reclaim sweeps.
+    #[serde(default = "default_reclaim_interval_millis")]
+    pub reclaim_interval_millis: u64,
 
     /// Maximum candidate count per job (cap applied during extraction).
     #[serde(default = "default_max_candidates_per_job")]
@@ -74,25 +74,25 @@ impl WorkerConfig {
     /// Returns the poll interval as a [`Duration`].
     #[must_use]
     pub fn poll_interval(&self) -> Duration {
-        Duration::from_secs(self.poll_interval_seconds)
+        Duration::from_millis(self.poll_interval_millis)
     }
 
     /// Returns the task timeout as a [`Duration`].
     #[must_use]
     pub fn task_timeout(&self) -> Duration {
-        Duration::from_secs(self.task_timeout_seconds)
+        Duration::from_millis(self.task_timeout_millis)
     }
 
     /// Returns the heartbeat interval as a [`Duration`].
     #[must_use]
     pub fn heartbeat_interval(&self) -> Duration {
-        Duration::from_secs(self.heartbeat_interval_seconds)
+        Duration::from_millis(self.heartbeat_interval_millis)
     }
 
     /// Returns the reclaim interval as a [`Duration`].
     #[must_use]
     pub fn reclaim_interval(&self) -> Duration {
-        Duration::from_secs(self.reclaim_interval_seconds)
+        Duration::from_millis(self.reclaim_interval_millis)
     }
 
     /// Validates the configuration, returning an error on the first
@@ -109,34 +109,34 @@ impl WorkerConfig {
                 reason: "must be greater than zero",
             });
         }
-        if self.poll_interval_seconds == 0 {
+        if self.poll_interval_millis == 0 {
             return Err(ConfigError::InvalidField {
-                field: "poll_interval_seconds",
+                field: "poll_interval_millis",
                 reason: "must be greater than zero",
             });
         }
-        if self.task_timeout_seconds == 0 {
+        if self.task_timeout_millis == 0 {
             return Err(ConfigError::InvalidField {
-                field: "task_timeout_seconds",
+                field: "task_timeout_millis",
                 reason: "must be greater than zero",
             });
         }
-        if self.heartbeat_interval_seconds == 0 {
+        if self.heartbeat_interval_millis == 0 {
             return Err(ConfigError::InvalidField {
-                field: "heartbeat_interval_seconds",
+                field: "heartbeat_interval_millis",
                 reason: "must be greater than zero",
             });
         }
-        if self.heartbeat_interval_seconds >= self.task_timeout_seconds {
+        if self.heartbeat_interval_millis >= self.task_timeout_millis {
             return Err(ConfigError::InvalidField {
-                field: "heartbeat_interval_seconds",
-                reason: "must be less than task_timeout_seconds",
+                field: "heartbeat_interval_millis",
+                reason: "must be less than task_timeout_millis",
             });
         }
-        if self.reclaim_interval_seconds < self.poll_interval_seconds {
+        if self.reclaim_interval_millis < self.poll_interval_millis {
             return Err(ConfigError::InvalidField {
-                field: "reclaim_interval_seconds",
-                reason: "must be greater than or equal to poll_interval_seconds",
+                field: "reclaim_interval_millis",
+                reason: "must be greater than or equal to poll_interval_millis",
             });
         }
         if self.triage_search_limit == 0 {
@@ -159,11 +159,11 @@ impl Default for WorkerConfig {
     fn default() -> Self {
         Self {
             max_concurrent_tasks: default_max_concurrent_tasks(),
-            poll_interval_seconds: default_poll_interval_seconds(),
-            task_timeout_seconds: default_task_timeout_seconds(),
+            poll_interval_millis: default_poll_interval_millis(),
+            task_timeout_millis: default_task_timeout_millis(),
             task_max_retries: default_task_max_retries(),
-            heartbeat_interval_seconds: default_heartbeat_interval_seconds(),
-            reclaim_interval_seconds: default_reclaim_interval_seconds(),
+            heartbeat_interval_millis: default_heartbeat_interval_millis(),
+            reclaim_interval_millis: default_reclaim_interval_millis(),
             max_candidates_per_job: default_max_candidates_per_job(),
             triage_search_limit: default_triage_search_limit(),
             include_llm_content: false,
@@ -178,20 +178,20 @@ impl Default for WorkerConfig {
 const fn default_max_concurrent_tasks() -> usize {
     4
 }
-const fn default_poll_interval_seconds() -> u64 {
-    2
+const fn default_poll_interval_millis() -> u64 {
+    2_000
 }
-const fn default_task_timeout_seconds() -> u64 {
-    300
+const fn default_task_timeout_millis() -> u64 {
+    300_000
 }
 const fn default_task_max_retries() -> u32 {
     3
 }
-const fn default_heartbeat_interval_seconds() -> u64 {
-    100
+const fn default_heartbeat_interval_millis() -> u64 {
+    100_000
 }
-const fn default_reclaim_interval_seconds() -> u64 {
-    10
+const fn default_reclaim_interval_millis() -> u64 {
+    10_000
 }
 const fn default_max_candidates_per_job() -> u32 {
     20
@@ -212,11 +212,11 @@ mod tests {
     fn test_default_values() {
         let config: WorkerConfig = serde_json::from_str("{}").unwrap();
         assert_eq!(config.max_concurrent_tasks, 4);
-        assert_eq!(config.poll_interval_seconds, 2);
-        assert_eq!(config.task_timeout_seconds, 300);
+        assert_eq!(config.poll_interval_millis, 2_000);
+        assert_eq!(config.task_timeout_millis, 300_000);
         assert_eq!(config.task_max_retries, 3);
-        assert_eq!(config.heartbeat_interval_seconds, 100);
-        assert_eq!(config.reclaim_interval_seconds, 10);
+        assert_eq!(config.heartbeat_interval_millis, 100_000);
+        assert_eq!(config.reclaim_interval_millis, 10_000);
         assert_eq!(config.max_candidates_per_job, 20);
         assert_eq!(config.triage_search_limit, 10);
         assert!(!config.include_llm_content);
@@ -225,21 +225,21 @@ mod tests {
     #[test]
     fn test_duration_conversions() {
         let config = WorkerConfig::default();
-        assert_eq!(config.poll_interval(), Duration::from_secs(2));
-        assert_eq!(config.task_timeout(), Duration::from_secs(300));
-        assert_eq!(config.heartbeat_interval(), Duration::from_secs(100));
-        assert_eq!(config.reclaim_interval(), Duration::from_secs(10));
+        assert_eq!(config.poll_interval(), Duration::from_millis(2_000));
+        assert_eq!(config.task_timeout(), Duration::from_millis(300_000));
+        assert_eq!(config.heartbeat_interval(), Duration::from_millis(100_000));
+        assert_eq!(config.reclaim_interval(), Duration::from_millis(10_000));
     }
 
     #[test]
     fn test_serde_roundtrip() {
         let config = WorkerConfig {
             max_concurrent_tasks: 8,
-            poll_interval_seconds: 5,
-            task_timeout_seconds: 600,
+            poll_interval_millis: 5_000,
+            task_timeout_millis: 600_000,
             task_max_retries: 5,
-            heartbeat_interval_seconds: 200,
-            reclaim_interval_seconds: 20,
+            heartbeat_interval_millis: 200_000,
+            reclaim_interval_millis: 20_000,
             max_candidates_per_job: 50,
             triage_search_limit: 25,
             include_llm_content: true,
@@ -262,53 +262,53 @@ mod tests {
     #[test]
     fn test_validate_rejects_zero_poll_interval() {
         let config = WorkerConfig {
-            poll_interval_seconds: 0,
+            poll_interval_millis: 0,
             ..WorkerConfig::default()
         };
         let err = config.validate().unwrap_err();
-        assert!(err.to_string().contains("poll_interval_seconds"));
+        assert!(err.to_string().contains("poll_interval_millis"));
     }
 
     #[test]
     fn test_validate_rejects_zero_task_timeout() {
         let config = WorkerConfig {
-            task_timeout_seconds: 0,
+            task_timeout_millis: 0,
             ..WorkerConfig::default()
         };
         let err = config.validate().unwrap_err();
-        assert!(err.to_string().contains("task_timeout_seconds"));
+        assert!(err.to_string().contains("task_timeout_millis"));
     }
 
     #[test]
     fn test_validate_rejects_zero_heartbeat_interval() {
         let config = WorkerConfig {
-            heartbeat_interval_seconds: 0,
+            heartbeat_interval_millis: 0,
             ..WorkerConfig::default()
         };
         let err = config.validate().unwrap_err();
-        assert!(err.to_string().contains("heartbeat_interval_seconds"));
+        assert!(err.to_string().contains("heartbeat_interval_millis"));
     }
 
     #[test]
     fn test_validate_rejects_heartbeat_ge_timeout() {
         let config = WorkerConfig {
-            heartbeat_interval_seconds: 300,
-            task_timeout_seconds: 300,
+            heartbeat_interval_millis: 300_000,
+            task_timeout_millis: 300_000,
             ..WorkerConfig::default()
         };
         let err = config.validate().unwrap_err();
-        assert!(err.to_string().contains("heartbeat_interval_seconds"));
+        assert!(err.to_string().contains("heartbeat_interval_millis"));
     }
 
     #[test]
     fn test_validate_rejects_reclaim_lt_poll() {
         let config = WorkerConfig {
-            reclaim_interval_seconds: 1,
-            poll_interval_seconds: 2,
+            reclaim_interval_millis: 1_000,
+            poll_interval_millis: 2_000,
             ..WorkerConfig::default()
         };
         let err = config.validate().unwrap_err();
-        assert!(err.to_string().contains("reclaim_interval_seconds"));
+        assert!(err.to_string().contains("reclaim_interval_millis"));
     }
 
     #[test]

--- a/crates/tribal-worker/src/error.rs
+++ b/crates/tribal-worker/src/error.rs
@@ -92,10 +92,10 @@ pub(crate) enum StageError {
     OwnershipLost,
 
     /// The task exceeded its timeout.
-    #[error("task timed out after {timeout_seconds}s")]
+    #[error("task timed out after {timeout_millis}ms")]
     Timeout {
-        /// The timeout that was exceeded, in seconds.
-        timeout_seconds: u64,
+        /// The timeout that was exceeded, in milliseconds.
+        timeout_millis: u64,
     },
 
     /// A prompt template could not be rendered.
@@ -174,7 +174,7 @@ mod tests {
             (StageError::OwnershipLost, TaskErrorKind::OwnershipLost),
             (
                 StageError::Timeout {
-                    timeout_seconds: 300,
+                    timeout_millis: 300_000,
                 },
                 TaskErrorKind::Timeout,
             ),

--- a/crates/tribal-worker/src/error.rs
+++ b/crates/tribal-worker/src/error.rs
@@ -90,6 +90,16 @@ pub(crate) enum StageError {
         timeout_seconds: u64,
     },
 
+    /// A prompt template could not be rendered.
+    #[error("template render failed: {context}")]
+    TemplateRender {
+        /// Human-readable description of what was being rendered.
+        context: String,
+        /// The underlying Tera error.
+        #[source]
+        source: tera::Error,
+    },
+
     /// A database operation failed during stage execution.
     #[error("database error in {stage}: {context}")]
     Database {
@@ -113,6 +123,7 @@ impl StageError {
             Self::Parse { .. } => TaskErrorKind::ParseError,
             Self::OwnershipLost => TaskErrorKind::OwnershipLost,
             Self::Timeout { .. } => TaskErrorKind::Timeout,
+            Self::TemplateRender { .. } => TaskErrorKind::InternalError,
             Self::Database { .. } => TaskErrorKind::DatabaseError,
         }
     }
@@ -158,6 +169,13 @@ mod tests {
                     timeout_seconds: 300,
                 },
                 TaskErrorKind::Timeout,
+            ),
+            (
+                StageError::TemplateRender {
+                    context: "rendering extraction prompt".into(),
+                    source: tera::Error::msg("unknown variable"),
+                },
+                TaskErrorKind::InternalError,
             ),
             (
                 StageError::Database {

--- a/crates/tribal-worker/src/error.rs
+++ b/crates/tribal-worker/src/error.rs
@@ -3,6 +3,14 @@
 use tribal_domain::TaskErrorKind;
 
 // ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+pub(crate) const SEMAPHORE_CLOSED: &str = "semaphore closed unexpectedly";
+pub(crate) const STAGE_PRE_DISPATCH: &str = "pre-dispatch";
+pub(crate) const STAGE_EXTRACTION: &str = "extraction";
+
+// ---------------------------------------------------------------------------
 // WorkerError
 // ---------------------------------------------------------------------------
 

--- a/crates/tribal-worker/src/lib.rs
+++ b/crates/tribal-worker/src/lib.rs
@@ -3,6 +3,7 @@
 //! Write-path pipeline for Tribal: task claiming, extraction, triage,
 //! and relation execution, heartbeat management, and dead-lettering.
 
+mod common;
 mod config;
 mod error;
 mod parsing;

--- a/crates/tribal-worker/src/lib.rs
+++ b/crates/tribal-worker/src/lib.rs
@@ -5,6 +5,8 @@
 
 mod config;
 mod error;
+mod parsing;
+mod prompt;
 mod stages;
 mod worker;
 

--- a/crates/tribal-worker/src/parsing.rs
+++ b/crates/tribal-worker/src/parsing.rs
@@ -2,4 +2,4 @@
 
 mod extraction;
 
-pub(crate) use extraction::parse_extraction_response;
+pub(crate) use extraction::{ExtractionOutput, parse_extraction_response};

--- a/crates/tribal-worker/src/parsing.rs
+++ b/crates/tribal-worker/src/parsing.rs
@@ -1,0 +1,5 @@
+//! Response parsing for pipeline stages.
+
+mod extraction;
+
+pub(crate) use extraction::parse_extraction_response;

--- a/crates/tribal-worker/src/parsing/extraction.rs
+++ b/crates/tribal-worker/src/parsing/extraction.rs
@@ -1,9 +1,27 @@
-//! Extraction response parsing.
+//! Extraction response parsing and output type.
 
+use serde::Deserialize;
+use tribal_domain::{Candidate, RelationHint};
 use tribal_inference::CompletionResponse;
 
 use crate::error::StageError;
-use crate::stages::extraction::ExtractionOutput;
+
+// ---------------------------------------------------------------------------
+// ExtractionOutput
+// ---------------------------------------------------------------------------
+
+/// The deserialised output from the extraction LLM call.
+///
+/// Lenient serde — unknown fields are silently ignored so the LLM
+/// can return extra keys without breaking parsing.
+#[derive(Debug, Clone, PartialEq, Eq, Deserialize, schemars::JsonSchema)]
+pub(crate) struct ExtractionOutput {
+    /// Extracted knowledge item candidates.
+    pub candidates: Vec<Candidate>,
+    /// Intra-batch relation hints between candidates.
+    #[serde(default)]
+    pub relation_hints: Vec<RelationHint>,
+}
 
 // ---------------------------------------------------------------------------
 // Public API

--- a/crates/tribal-worker/src/parsing/extraction.rs
+++ b/crates/tribal-worker/src/parsing/extraction.rs
@@ -1,0 +1,97 @@
+//! Extraction response parsing.
+
+use tribal_inference::CompletionResponse;
+
+use crate::error::StageError;
+use crate::stages::extraction::ExtractionOutput;
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+
+/// Parses a completion response into an [`ExtractionOutput`].
+///
+/// # Errors
+///
+/// Returns [`StageError::Parse`] if the response text cannot be
+/// deserialised into [`ExtractionOutput`], with an operator-safe
+/// `context` and the full `raw_response` for debugging.
+pub(crate) fn parse_extraction_response(
+    response: &CompletionResponse,
+) -> Result<ExtractionOutput, StageError> {
+    serde_json::from_str::<ExtractionOutput>(&response.text).map_err(|e| StageError::Parse {
+        context: format!("deserialising extraction output: {e}"),
+        raw_response: Some(response.text.clone()),
+    })
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use std::time::Duration;
+
+    use tribal_inference::CompletionUsage;
+
+    use super::*;
+
+    fn mock_response(text: &str) -> CompletionResponse {
+        CompletionResponse {
+            text: text.to_owned(),
+            usage: CompletionUsage {
+                provider: "test".into(),
+                model: "test-model".into(),
+                input_tokens: 0,
+                output_tokens: 0,
+                cache_read_tokens: 0,
+                cache_write_tokens: 0,
+                total_tokens: 0,
+                latency: Duration::ZERO,
+            },
+        }
+    }
+
+    #[test]
+    fn test_parse_valid_json() {
+        let json = r#"{"candidates": [], "relation_hints": []}"#;
+        let response = mock_response(json);
+        let result = parse_extraction_response(&response);
+        assert!(result.is_ok());
+        let output = result.unwrap();
+        assert!(output.candidates.is_empty());
+        assert!(output.relation_hints.is_empty());
+    }
+
+    #[test]
+    fn test_parse_invalid_json_returns_parse_error() {
+        let response = mock_response("not json at all");
+        let result = parse_extraction_response(&response);
+        assert!(result.is_err());
+        let err = result.unwrap_err();
+        match err {
+            StageError::Parse { raw_response, .. } => {
+                assert_eq!(raw_response.as_deref(), Some("not json at all"));
+            }
+            other => panic!("expected StageError::Parse, got {other}"),
+        }
+    }
+
+    #[test]
+    fn test_parse_missing_relation_hints_defaults_to_empty() {
+        let json = r#"{"candidates": []}"#;
+        let response = mock_response(json);
+        let result = parse_extraction_response(&response);
+        assert!(result.is_ok());
+        assert!(result.unwrap().relation_hints.is_empty());
+    }
+
+    #[test]
+    fn test_parse_unknown_fields_are_ignored() {
+        let json = r#"{"candidates": [], "relation_hints": [], "extra_field": true}"#;
+        let response = mock_response(json);
+        let result = parse_extraction_response(&response);
+        assert!(result.is_ok());
+    }
+}

--- a/crates/tribal-worker/src/prompt.rs
+++ b/crates/tribal-worker/src/prompt.rs
@@ -1,0 +1,5 @@
+//! Prompt assembly for pipeline stages.
+
+mod extraction;
+
+pub(crate) use extraction::assemble_extraction_prompt;

--- a/crates/tribal-worker/src/prompt/extraction.rs
+++ b/crates/tribal-worker/src/prompt/extraction.rs
@@ -4,8 +4,7 @@ use schemars::schema_for;
 use tribal_domain::TagRegistryEntry;
 use tribal_inference::{CompletionRequest, Message, ResponseFormat, Role};
 
-use crate::error::StageError;
-use crate::parsing::ExtractionOutput;
+use crate::{error::StageError, parsing::ExtractionOutput};
 
 // ---------------------------------------------------------------------------
 // Constants
@@ -46,7 +45,7 @@ pub(crate) fn assemble_extraction_prompt(
     let schema_pretty =
         serde_json::to_string_pretty(&schema).expect("schema_for! produces serialisable output");
 
-    let tags: Vec<&str> = tag_registry.iter().map(|e| e.tag()).collect();
+    let tags: Vec<&str> = tag_registry.iter().map(TagRegistryEntry::tag).collect();
 
     let mut context = tera::Context::new();
     context.insert(VAR_RAW_INPUT, raw_input);
@@ -87,11 +86,8 @@ mod tests {
 
     #[test]
     fn test_invalid_template_returns_template_render_error() {
-        let result = assemble_extraction_prompt(
-            "{{ invalid | nonexistent_filter }}",
-            "some input",
-            &[],
-        );
+        let result =
+            assemble_extraction_prompt("{{ invalid | nonexistent_filter }}", "some input", &[]);
         assert!(result.is_err());
         let err = result.unwrap_err();
         assert_eq!(err.to_error_kind(), TaskErrorKind::InternalError);
@@ -121,7 +117,10 @@ mod tests {
         assert!(result.is_ok());
         let request = result.unwrap();
         assert!(
-            matches!(request.response_format, Some(ResponseFormat::JsonSchema { .. })),
+            matches!(
+                request.response_format,
+                Some(ResponseFormat::JsonSchema { .. })
+            ),
             "expected JsonSchema response format",
         );
     }

--- a/crates/tribal-worker/src/prompt/extraction.rs
+++ b/crates/tribal-worker/src/prompt/extraction.rs
@@ -5,7 +5,7 @@ use tribal_domain::TagRegistryEntry;
 use tribal_inference::{CompletionRequest, Message, ResponseFormat, Role};
 
 use crate::error::StageError;
-use crate::stages::extraction::ExtractionOutput;
+use crate::parsing::ExtractionOutput;
 
 // ---------------------------------------------------------------------------
 // Constants

--- a/crates/tribal-worker/src/prompt/extraction.rs
+++ b/crates/tribal-worker/src/prompt/extraction.rs
@@ -10,9 +10,6 @@ use crate::{error::StageError, parsing::ExtractionOutput};
 // Constants
 // ---------------------------------------------------------------------------
 
-/// Tera context variable: the raw input text.
-const VAR_RAW_INPUT: &str = "raw_input";
-
 /// Tera context variable: the tag registry as a list of strings.
 const VAR_TAGS: &str = "tags";
 
@@ -25,10 +22,10 @@ const VAR_SCHEMA: &str = "schema";
 
 /// Assembles a [`CompletionRequest`] for the extraction stage.
 ///
-/// Renders the Tera template with the [`VAR_RAW_INPUT`], [`VAR_TAGS`]
-/// (from the tag registry), and [`VAR_SCHEMA`] (JSON Schema for
-/// [`ExtractionOutput`]) context variables. The rendered text becomes
-/// the system prompt; the raw input is sent as a user message.
+/// Renders the Tera template with the [`VAR_TAGS`] (from the tag
+/// registry) and [`VAR_SCHEMA`] (JSON Schema for [`ExtractionOutput`])
+/// context variables. The rendered text becomes the system prompt; the
+/// raw input is sent as a user message.
 ///
 /// # Errors
 ///
@@ -48,7 +45,6 @@ pub(crate) fn assemble_extraction_prompt(
     let tags: Vec<&str> = tag_registry.iter().map(TagRegistryEntry::tag).collect();
 
     let mut context = tera::Context::new();
-    context.insert(VAR_RAW_INPUT, raw_input);
     context.insert(VAR_TAGS, &tags);
     context.insert(VAR_SCHEMA, &schema_pretty);
 

--- a/crates/tribal-worker/src/prompt/extraction.rs
+++ b/crates/tribal-worker/src/prompt/extraction.rs
@@ -1,0 +1,138 @@
+//! Extraction prompt assembly: template rendering and request construction.
+
+use schemars::schema_for;
+use tribal_domain::TagRegistryEntry;
+use tribal_inference::{CompletionRequest, Message, ResponseFormat, Role};
+
+use crate::error::StageError;
+use crate::stages::extraction::ExtractionOutput;
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+/// Tera context variable: the raw input text.
+const VAR_RAW_INPUT: &str = "raw_input";
+
+/// Tera context variable: the tag registry as a list of strings.
+const VAR_TAGS: &str = "tags";
+
+/// Tera context variable: the JSON Schema for the expected output.
+const VAR_SCHEMA: &str = "schema";
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+
+/// Assembles a [`CompletionRequest`] for the extraction stage.
+///
+/// Renders the Tera template with the [`VAR_RAW_INPUT`], [`VAR_TAGS`]
+/// (from the tag registry), and [`VAR_SCHEMA`] (JSON Schema for
+/// [`ExtractionOutput`]) context variables. The rendered text becomes
+/// the system prompt; the raw input is sent as a user message.
+///
+/// # Errors
+///
+/// Returns [`StageError::TemplateRender`] if the template cannot be
+/// rendered.
+pub(crate) fn assemble_extraction_prompt(
+    template_content: &str,
+    raw_input: &str,
+    tag_registry: &[TagRegistryEntry],
+) -> Result<CompletionRequest, StageError> {
+    let schema = schema_for!(ExtractionOutput);
+    let schema_value =
+        serde_json::to_value(&schema).expect("schema_for! produces serialisable output");
+    let schema_pretty =
+        serde_json::to_string_pretty(&schema).expect("schema_for! produces serialisable output");
+
+    let tags: Vec<&str> = tag_registry.iter().map(|e| e.tag()).collect();
+
+    let mut context = tera::Context::new();
+    context.insert(VAR_RAW_INPUT, raw_input);
+    context.insert(VAR_TAGS, &tags);
+    context.insert(VAR_SCHEMA, &schema_pretty);
+
+    let rendered = tera::Tera::one_off(template_content, &context, false).map_err(|e| {
+        StageError::TemplateRender {
+            context: "rendering extraction prompt".into(),
+            source: e,
+        }
+    })?;
+
+    Ok(CompletionRequest {
+        system: Some(rendered),
+        messages: vec![Message {
+            role: Role::User,
+            content: raw_input.to_owned(),
+        }],
+        temperature: None,
+        max_tokens: None,
+        response_format: Some(ResponseFormat::JsonSchema {
+            schema: schema_value,
+        }),
+    })
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use tribal_domain::TaskErrorKind;
+    use tribal_test_utils::a_tag_registry_entry;
+
+    use super::*;
+
+    #[test]
+    fn test_invalid_template_returns_template_render_error() {
+        let result = assemble_extraction_prompt(
+            "{{ invalid | nonexistent_filter }}",
+            "some input",
+            &[],
+        );
+        assert!(result.is_err());
+        let err = result.unwrap_err();
+        assert_eq!(err.to_error_kind(), TaskErrorKind::InternalError);
+    }
+
+    #[test]
+    fn test_renders_tags_into_prompt() {
+        let tags = vec![
+            a_tag_registry_entry().tag("rust".to_owned()).build(),
+            a_tag_registry_entry().tag("testing".to_owned()).build(),
+        ];
+        let result = assemble_extraction_prompt(
+            "Tags: {% for tag in tags %}{{ tag }} {% endfor %}",
+            "input text",
+            &tags,
+        );
+        assert!(result.is_ok());
+        let request = result.unwrap();
+        let system = request.system.unwrap();
+        assert!(system.contains("rust"), "system prompt: {system}");
+        assert!(system.contains("testing"), "system prompt: {system}");
+    }
+
+    #[test]
+    fn test_response_format_is_json_schema() {
+        let result = assemble_extraction_prompt("minimal template", "input", &[]);
+        assert!(result.is_ok());
+        let request = result.unwrap();
+        assert!(
+            matches!(request.response_format, Some(ResponseFormat::JsonSchema { .. })),
+            "expected JsonSchema response format",
+        );
+    }
+
+    #[test]
+    fn test_raw_input_sent_as_user_message() {
+        let result = assemble_extraction_prompt("template", "the raw input", &[]);
+        assert!(result.is_ok());
+        let request = result.unwrap();
+        assert_eq!(request.messages.len(), 1);
+        assert_eq!(request.messages[0].role, Role::User);
+        assert_eq!(request.messages[0].content, "the raw input");
+    }
+}

--- a/crates/tribal-worker/src/stages.rs
+++ b/crates/tribal-worker/src/stages.rs
@@ -1,5 +1,6 @@
 //! Pipeline stage implementations (extraction, triage, relation).
 
+mod common;
 mod extraction;
 mod relation;
 mod triage;

--- a/crates/tribal-worker/src/stages/common.rs
+++ b/crates/tribal-worker/src/stages/common.rs
@@ -34,7 +34,7 @@ impl Worker {
         &self,
         stage: &str,
     ) -> Result<Vec<TagRegistryEntry>, StageError> {
-        let mut conn = self.pool.acquire().await.map_err(|e| StageError::Database {
+        let mut conn = self.pool().acquire().await.map_err(|e| StageError::Database {
             stage: stage.into(),
             context: "acquiring connection for tag registry".into(),
             source: tribal_db::DbError::QueryFailed {
@@ -62,7 +62,7 @@ impl Worker {
         stage: &str,
         id: PromptVersionId,
     ) -> Result<PromptVersion, StageError> {
-        let mut conn = self.pool.acquire().await.map_err(|e| StageError::Database {
+        let mut conn = self.pool().acquire().await.map_err(|e| StageError::Database {
             stage: stage.into(),
             context: "acquiring connection for prompt version".into(),
             source: tribal_db::DbError::QueryFailed {

--- a/crates/tribal-worker/src/stages/common.rs
+++ b/crates/tribal-worker/src/stages/common.rs
@@ -17,8 +17,6 @@ use crate::{error::StageError, worker::Worker};
 
 const EXPECT_EXTRACTION_KEY: &str = "extraction key registered at startup";
 
-pub(crate) const SEMAPHORE_CLOSED: &str = "semaphore closed unexpectedly";
-
 // ---------------------------------------------------------------------------
 // Shared loaders
 // ---------------------------------------------------------------------------

--- a/crates/tribal-worker/src/stages/common.rs
+++ b/crates/tribal-worker/src/stages/common.rs
@@ -2,15 +2,14 @@
 
 use std::sync::Arc;
 
+use tokio::sync::Semaphore;
 use tribal_db::{
     PgPromptVersionRepository, PgTagRegistryRepository, PromptVersionRepository,
     TagRegistryRepository,
 };
 use tribal_domain::{PromptVersion, PromptVersionId, TagRegistryEntry};
-use tokio::sync::Semaphore;
 
-use crate::error::StageError;
-use crate::worker::Worker;
+use crate::{error::StageError, worker::Worker};
 
 // ---------------------------------------------------------------------------
 // Constants
@@ -34,14 +33,18 @@ impl Worker {
         &self,
         stage: &str,
     ) -> Result<Vec<TagRegistryEntry>, StageError> {
-        let mut conn = self.pool().acquire().await.map_err(|e| StageError::Database {
-            stage: stage.into(),
-            context: "acquiring connection for tag registry".into(),
-            source: tribal_db::DbError::QueryFailed {
-                context: "pool acquire".into(),
-                source: e,
-            },
-        })?;
+        let mut conn = self
+            .pool()
+            .acquire()
+            .await
+            .map_err(|e| StageError::Database {
+                stage: stage.into(),
+                context: "acquiring connection for tag registry".into(),
+                source: tribal_db::DbError::QueryFailed {
+                    context: "pool acquire".into(),
+                    source: e,
+                },
+            })?;
         PgTagRegistryRepository
             .find_all(&mut conn)
             .await
@@ -62,14 +65,18 @@ impl Worker {
         stage: &str,
         id: PromptVersionId,
     ) -> Result<PromptVersion, StageError> {
-        let mut conn = self.pool().acquire().await.map_err(|e| StageError::Database {
-            stage: stage.into(),
-            context: "acquiring connection for prompt version".into(),
-            source: tribal_db::DbError::QueryFailed {
-                context: "pool acquire".into(),
-                source: e,
-            },
-        })?;
+        let mut conn = self
+            .pool()
+            .acquire()
+            .await
+            .map_err(|e| StageError::Database {
+                stage: stage.into(),
+                context: "acquiring connection for prompt version".into(),
+                source: tribal_db::DbError::QueryFailed {
+                    context: "pool acquire".into(),
+                    source: e,
+                },
+            })?;
         PgPromptVersionRepository
             .find_by_id(&mut conn, id)
             .await

--- a/crates/tribal-worker/src/stages/common.rs
+++ b/crates/tribal-worker/src/stages/common.rs
@@ -1,10 +1,13 @@
 //! Shared utilities for pipeline stage implementations.
 
+use std::sync::Arc;
+
 use tribal_db::{
     PgPromptVersionRepository, PgTagRegistryRepository, PromptVersionRepository,
     TagRegistryRepository,
 };
 use tribal_domain::{PromptVersion, PromptVersionId, TagRegistryEntry};
+use tokio::sync::Semaphore;
 
 use crate::error::StageError;
 use crate::worker::Worker;
@@ -18,7 +21,7 @@ const EXPECT_EXTRACTION_KEY: &str = "extraction key registered at startup";
 pub(crate) const SEMAPHORE_CLOSED: &str = "semaphore closed unexpectedly";
 
 // ---------------------------------------------------------------------------
-// Tag registry
+// Shared loaders
 // ---------------------------------------------------------------------------
 
 impl Worker {
@@ -82,10 +85,10 @@ impl Worker {
     /// # Panics
     ///
     /// Panics if the extraction key is not registered in the provider
-    /// registry (startup configuration error).
-    pub(crate) fn extraction_semaphore(&self) -> &std::sync::Arc<tokio::sync::Semaphore> {
-        self.provider_registry
-            .semaphore(&self.extraction_key)
+    /// registry.
+    pub(crate) fn extraction_semaphore(&self) -> &Arc<Semaphore> {
+        self.provider_registry()
+            .semaphore(self.extraction_key())
             .expect(EXPECT_EXTRACTION_KEY)
     }
 }

--- a/crates/tribal-worker/src/stages/common.rs
+++ b/crates/tribal-worker/src/stages/common.rs
@@ -1,0 +1,91 @@
+//! Shared utilities for pipeline stage implementations.
+
+use tribal_db::{
+    PgPromptVersionRepository, PgTagRegistryRepository, PromptVersionRepository,
+    TagRegistryRepository,
+};
+use tribal_domain::{PromptVersion, PromptVersionId, TagRegistryEntry};
+
+use crate::error::StageError;
+use crate::worker::Worker;
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+const EXPECT_EXTRACTION_KEY: &str = "extraction key registered at startup";
+
+pub(crate) const SEMAPHORE_CLOSED: &str = "semaphore closed unexpectedly";
+
+// ---------------------------------------------------------------------------
+// Tag registry
+// ---------------------------------------------------------------------------
+
+impl Worker {
+    /// Loads the full tag registry from the database.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`StageError::Database`] on pool or query failure.
+    pub(crate) async fn load_tag_registry(
+        &self,
+        stage: &str,
+    ) -> Result<Vec<TagRegistryEntry>, StageError> {
+        let mut conn = self.pool.acquire().await.map_err(|e| StageError::Database {
+            stage: stage.into(),
+            context: "acquiring connection for tag registry".into(),
+            source: tribal_db::DbError::QueryFailed {
+                context: "pool acquire".into(),
+                source: e,
+            },
+        })?;
+        PgTagRegistryRepository
+            .find_all(&mut conn)
+            .await
+            .map_err(|e| StageError::Database {
+                stage: stage.into(),
+                context: "loading tag registry".into(),
+                source: e,
+            })
+    }
+
+    /// Loads a prompt version by ID from the database.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`StageError::Database`] on pool or query failure.
+    pub(crate) async fn load_prompt_version(
+        &self,
+        stage: &str,
+        id: PromptVersionId,
+    ) -> Result<PromptVersion, StageError> {
+        let mut conn = self.pool.acquire().await.map_err(|e| StageError::Database {
+            stage: stage.into(),
+            context: "acquiring connection for prompt version".into(),
+            source: tribal_db::DbError::QueryFailed {
+                context: "pool acquire".into(),
+                source: e,
+            },
+        })?;
+        PgPromptVersionRepository
+            .find_by_id(&mut conn, id)
+            .await
+            .map_err(|e| StageError::Database {
+                stage: stage.into(),
+                context: "loading prompt version".into(),
+                source: e,
+            })
+    }
+
+    /// Returns the extraction semaphore from the provider registry.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the extraction key is not registered in the provider
+    /// registry (startup configuration error).
+    pub(crate) fn extraction_semaphore(&self) -> &std::sync::Arc<tokio::sync::Semaphore> {
+        self.provider_registry
+            .semaphore(&self.extraction_key)
+            .expect(EXPECT_EXTRACTION_KEY)
+    }
+}

--- a/crates/tribal-worker/src/stages/extraction.rs
+++ b/crates/tribal-worker/src/stages/extraction.rs
@@ -3,13 +3,11 @@
 use std::sync::Arc;
 
 use serde::Deserialize;
-use tribal_db::{
-    NewExtractionResult, NewTask, PgPromptVersionRepository, PgTagRegistryRepository,
-    PromptVersionRepository, TagRegistryRepository,
-};
+use tribal_db::{NewExtractionResult, NewTask};
 use tribal_domain::{Candidate, Job, RelationHint, TagRegistryEntry, Task, TaskType};
 use tribal_inference::Usage;
 
+use super::common::SEMAPHORE_CLOSED;
 use crate::{
     error::StageError,
     parsing::parse_extraction_response,
@@ -22,7 +20,8 @@ use crate::{
 // ---------------------------------------------------------------------------
 
 const STAGE_EXTRACTION: &str = "extraction";
-const SEMAPHORE_CLOSED: &str = "semaphore closed unexpectedly";
+const CANDIDATES_SERIALISE: &str = "candidates serialise to JSON";
+const HINTS_SERIALISE: &str = "relation hints serialise to JSON";
 
 // ---------------------------------------------------------------------------
 // StageOutput
@@ -61,9 +60,6 @@ pub(crate) enum StageCommit {
 // ---------------------------------------------------------------------------
 
 /// Context assembled before running the extraction stage.
-///
-/// Groups the job, task, and tag registry into a single struct,
-/// establishing the pattern for `TriageContext` and `RelationContext`.
 #[allow(dead_code)]
 pub(crate) struct ExtractionContext {
     /// The parent job.
@@ -116,58 +112,19 @@ impl Worker {
     /// # Panics
     ///
     /// Panics if the extraction provider key is not registered in the
-    /// provider registry (startup configuration error) or if the
-    /// semaphore is unexpectedly closed.
+    /// provider registry or if the semaphore is unexpectedly closed.
     pub(crate) async fn run_extraction(
         &self,
         job: &Job,
         task: &Task,
     ) -> Result<StageOutput, StageError> {
-        // 1. Load tag registry.
-        let tag_registry = {
-            let mut conn = self.pool.acquire().await.map_err(|e| StageError::Database {
-                stage: STAGE_EXTRACTION.into(),
-                context: "acquiring connection for tag registry".into(),
-                source: tribal_db::DbError::QueryFailed {
-                    context: "pool acquire".into(),
-                    source: e,
-                },
-            })?;
-            PgTagRegistryRepository
-                .find_all(&mut conn)
-                .await
-                .map_err(|e| StageError::Database {
-                    stage: STAGE_EXTRACTION.into(),
-                    context: "loading tag registry".into(),
-                    source: e,
-                })?
-        };
+        let tag_registry = self.load_tag_registry(STAGE_EXTRACTION).await?;
 
-        // 2. Load prompt template.
-        let prompt_version = {
-            let mut conn = self.pool.acquire().await.map_err(|e| StageError::Database {
-                stage: STAGE_EXTRACTION.into(),
-                context: "acquiring connection for prompt version".into(),
-                source: tribal_db::DbError::QueryFailed {
-                    context: "pool acquire".into(),
-                    source: e,
-                },
-            })?;
-            PgPromptVersionRepository
-                .find_by_id(&mut conn, job.extraction_prompt_version_id())
-                .await
-                .map_err(|e| StageError::Database {
-                    stage: STAGE_EXTRACTION.into(),
-                    context: "loading prompt version".into(),
-                    source: e,
-                })?
-        };
+        let prompt_version = self
+            .load_prompt_version(STAGE_EXTRACTION, job.extraction_prompt_version_id())
+            .await?;
 
-        // 3. Acquire semaphore permit.
-        let semaphore = self
-            .provider_registry
-            .semaphore(&self.extraction_key)
-            .expect("extraction key registered at startup");
+        let semaphore = self.extraction_semaphore();
         let _permit = tokio::time::timeout(
             self.config.task_timeout(),
             Arc::clone(semaphore).acquire_owned(),
@@ -178,14 +135,12 @@ impl Worker {
         })?
         .expect(SEMAPHORE_CLOSED);
 
-        // 4. Assemble prompt.
         let request = assemble_extraction_prompt(
             prompt_version.content(),
             job.raw_input(),
             &tag_registry,
         )?;
 
-        // 5. Call the LLM.
         let response = self
             .extraction_provider()
             .complete(request)
@@ -195,10 +150,8 @@ impl Worker {
                 source: e,
             })?;
 
-        // 6. Parse response.
         let output = parse_extraction_response(&response)?;
 
-        // 7. Cap candidates.
         #[allow(clippy::cast_possible_truncation)]
         let original_count = output.candidates.len() as u32;
         let max = self.config.max_candidates_per_job as usize;
@@ -207,14 +160,12 @@ impl Worker {
         #[allow(clippy::cast_possible_truncation)]
         let batch_size = capped_candidates.len() as u32;
 
-        // 8. Filter relation hints to only reference retained candidates.
         let capped_hints: Vec<RelationHint> = output
             .relation_hints
             .into_iter()
             .filter(|h| h.source_index() < batch_size && h.target_index() < batch_size)
             .collect();
 
-        // 9. Build triage tasks.
         let triage_tasks: Vec<NewTask> = (0..batch_size)
             .map(|i| {
                 NewTask::builder()
@@ -225,18 +176,12 @@ impl Worker {
             })
             .collect();
 
-        // 10. Build extraction result.
         let extraction_result = NewExtractionResult::builder()
             .job_id(task.job_id())
-            .candidates(
-                serde_json::to_value(&capped_candidates).expect("candidates serialise to JSON"),
-            )
-            .relation_hints(
-                serde_json::to_value(&capped_hints).expect("relation hints serialise to JSON"),
-            )
+            .candidates(serde_json::to_value(&capped_candidates).expect(CANDIDATES_SERIALISE))
+            .relation_hints(serde_json::to_value(&capped_hints).expect(HINTS_SERIALISE))
             .build();
 
-        // 11. Return stage output.
         Ok(StageOutput {
             commit: StageCommit::Extraction {
                 extraction_result,

--- a/crates/tribal-worker/src/stages/extraction.rs
+++ b/crates/tribal-worker/src/stages/extraction.rs
@@ -108,7 +108,7 @@ impl Worker {
 
         let semaphore = self.extraction_semaphore();
         let _permit = tokio::time::timeout(
-            self.config.task_timeout(),
+            self.config().task_timeout(),
             Arc::clone(semaphore).acquire_owned(),
         )
         .await

--- a/crates/tribal-worker/src/stages/extraction.rs
+++ b/crates/tribal-worker/src/stages/extraction.rs
@@ -1,9 +1,28 @@
 //! Extraction stage: LLM-based candidate extraction from raw input.
 
-use tribal_db::{NewExtractionResult, NewTask};
-use tribal_inference::{CompletionRequest, InferenceError, Usage};
+use std::sync::Arc;
 
-use crate::{error::StageError, worker::Worker};
+use serde::Deserialize;
+use tribal_db::{
+    NewExtractionResult, NewTask, PgPromptVersionRepository, PgTagRegistryRepository,
+    PromptVersionRepository, TagRegistryRepository,
+};
+use tribal_domain::{Candidate, Job, RelationHint, TagRegistryEntry, Task, TaskType};
+use tribal_inference::Usage;
+
+use crate::{
+    error::StageError,
+    parsing::parse_extraction_response,
+    prompt::assemble_extraction_prompt,
+    worker::Worker,
+};
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+const STAGE_EXTRACTION: &str = "extraction";
+const SEMAPHORE_CLOSED: &str = "semaphore closed unexpectedly";
 
 // ---------------------------------------------------------------------------
 // StageOutput
@@ -23,7 +42,6 @@ pub(crate) struct StageOutput {
 
 /// Domain effects produced by a stage, committed transactionally after
 /// the stage completes.
-#[allow(dead_code)]
 pub(crate) enum StageCommit {
     /// Extraction stage effects.
     Extraction {
@@ -39,38 +57,194 @@ pub(crate) enum StageCommit {
 }
 
 // ---------------------------------------------------------------------------
+// ExtractionContext
+// ---------------------------------------------------------------------------
+
+/// Context assembled before running the extraction stage.
+///
+/// Groups the job, task, and tag registry into a single struct,
+/// establishing the pattern for `TriageContext` and `RelationContext`.
+#[allow(dead_code)]
+pub(crate) struct ExtractionContext {
+    /// The parent job.
+    pub job: Job,
+    /// The claimed task.
+    pub task: Task,
+    /// The current global tag registry.
+    pub tag_registry: Vec<TagRegistryEntry>,
+}
+
+// ---------------------------------------------------------------------------
+// ExtractionOutput
+// ---------------------------------------------------------------------------
+
+/// The deserialised output from the extraction LLM call.
+///
+/// Lenient serde — unknown fields are silently ignored so the LLM
+/// can return extra keys without breaking parsing.
+#[derive(Debug, Clone, PartialEq, Eq, Deserialize, schemars::JsonSchema)]
+pub(crate) struct ExtractionOutput {
+    /// Extracted knowledge item candidates.
+    pub candidates: Vec<Candidate>,
+    /// Intra-batch relation hints between candidates.
+    #[serde(default)]
+    pub relation_hints: Vec<RelationHint>,
+}
+
+// ---------------------------------------------------------------------------
 // Stage implementation
 // ---------------------------------------------------------------------------
 
 impl Worker {
     /// Runs the extraction stage for a task.
     ///
+    /// Loads the prompt template and tag registry from the database,
+    /// acquires a semaphore permit, assembles the prompt via Tera,
+    /// calls the LLM, parses the response, caps candidates, and
+    /// builds the [`StageOutput`] for commit.
+    ///
     /// # Errors
     ///
-    /// Returns [`StageError::Provider`] — stub always fails.
+    /// Returns a [`StageError`] variant matching the failure mode:
+    /// - [`StageError::Database`] for pool/repository failures.
+    /// - [`StageError::SemaphoreTimeout`] if the provider semaphore
+    ///   cannot be acquired within the task timeout.
+    /// - [`StageError::TemplateRender`] if the prompt template is invalid.
+    /// - [`StageError::Provider`] if the LLM call fails.
+    /// - [`StageError::Parse`] if the LLM response cannot be parsed.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the extraction provider key is not registered in the
+    /// provider registry (startup configuration error) or if the
+    /// semaphore is unexpectedly closed.
     pub(crate) async fn run_extraction(
         &self,
-        _job: &tribal_domain::Job,
-        _task: &tribal_domain::Task,
+        job: &Job,
+        task: &Task,
     ) -> Result<StageOutput, StageError> {
-        // Calls provider to honour mock delays; replaced by ticket 4.3.
-        let _ = self
-            .extraction_provider()
-            .complete(CompletionRequest {
-                system: Some("extraction stub".into()),
-                messages: vec![],
-                temperature: None,
-                max_tokens: None,
-                response_format: None,
-            })
-            .await;
+        // 1. Load tag registry.
+        let tag_registry = {
+            let mut conn = self.pool.acquire().await.map_err(|e| StageError::Database {
+                stage: STAGE_EXTRACTION.into(),
+                context: "acquiring connection for tag registry".into(),
+                source: tribal_db::DbError::QueryFailed {
+                    context: "pool acquire".into(),
+                    source: e,
+                },
+            })?;
+            PgTagRegistryRepository
+                .find_all(&mut conn)
+                .await
+                .map_err(|e| StageError::Database {
+                    stage: STAGE_EXTRACTION.into(),
+                    context: "loading tag registry".into(),
+                    source: e,
+                })?
+        };
 
-        Err(StageError::Provider {
-            context: "extraction stage not yet implemented".into(),
-            source: InferenceError::ProviderUnavailable {
-                provider: "stub".into(),
-                reason: "extraction stage not yet implemented".into(),
+        // 2. Load prompt template.
+        let prompt_version = {
+            let mut conn = self.pool.acquire().await.map_err(|e| StageError::Database {
+                stage: STAGE_EXTRACTION.into(),
+                context: "acquiring connection for prompt version".into(),
+                source: tribal_db::DbError::QueryFailed {
+                    context: "pool acquire".into(),
+                    source: e,
+                },
+            })?;
+            PgPromptVersionRepository
+                .find_by_id(&mut conn, job.extraction_prompt_version_id())
+                .await
+                .map_err(|e| StageError::Database {
+                    stage: STAGE_EXTRACTION.into(),
+                    context: "loading prompt version".into(),
+                    source: e,
+                })?
+        };
+
+        // 3. Acquire semaphore permit.
+        let semaphore = self
+            .provider_registry
+            .semaphore(&self.extraction_key)
+            .expect("extraction key registered at startup");
+        let _permit = tokio::time::timeout(
+            self.config.task_timeout(),
+            Arc::clone(semaphore).acquire_owned(),
+        )
+        .await
+        .map_err(|_| StageError::SemaphoreTimeout {
+            provider_key: self.extraction_key.to_string(),
+        })?
+        .expect(SEMAPHORE_CLOSED);
+
+        // 4. Assemble prompt.
+        let request = assemble_extraction_prompt(
+            prompt_version.content(),
+            job.raw_input(),
+            &tag_registry,
+        )?;
+
+        // 5. Call the LLM.
+        let response = self
+            .extraction_provider()
+            .complete(request)
+            .await
+            .map_err(|e| StageError::Provider {
+                context: "extraction LLM call".into(),
+                source: e,
+            })?;
+
+        // 6. Parse response.
+        let output = parse_extraction_response(&response)?;
+
+        // 7. Cap candidates.
+        #[allow(clippy::cast_possible_truncation)]
+        let original_count = output.candidates.len() as u32;
+        let max = self.config.max_candidates_per_job as usize;
+        let capped_candidates: Vec<Candidate> =
+            output.candidates.into_iter().take(max).collect();
+        #[allow(clippy::cast_possible_truncation)]
+        let batch_size = capped_candidates.len() as u32;
+
+        // 8. Filter relation hints to only reference retained candidates.
+        let capped_hints: Vec<RelationHint> = output
+            .relation_hints
+            .into_iter()
+            .filter(|h| h.source_index() < batch_size && h.target_index() < batch_size)
+            .collect();
+
+        // 9. Build triage tasks.
+        let triage_tasks: Vec<NewTask> = (0..batch_size)
+            .map(|i| {
+                NewTask::builder()
+                    .job_id(task.job_id())
+                    .task_type(TaskType::Triage)
+                    .batch_index(Some(i))
+                    .build()
+            })
+            .collect();
+
+        // 10. Build extraction result.
+        let extraction_result = NewExtractionResult::builder()
+            .job_id(task.job_id())
+            .candidates(
+                serde_json::to_value(&capped_candidates).expect("candidates serialise to JSON"),
+            )
+            .relation_hints(
+                serde_json::to_value(&capped_hints).expect("relation hints serialise to JSON"),
+            )
+            .build();
+
+        // 11. Return stage output.
+        Ok(StageOutput {
+            commit: StageCommit::Extraction {
+                extraction_result,
+                triage_tasks,
+                batch_size,
+                original_count,
             },
+            usages: vec![Usage::Completion(response.usage)],
         })
     }
 }

--- a/crates/tribal-worker/src/stages/extraction.rs
+++ b/crates/tribal-worker/src/stages/extraction.rs
@@ -2,7 +2,6 @@
 
 use std::sync::Arc;
 
-use serde::Deserialize;
 use tribal_db::{NewExtractionResult, NewTask};
 use tribal_domain::{Candidate, Job, RelationHint, TagRegistryEntry, Task, TaskType};
 use tribal_inference::Usage;
@@ -71,23 +70,6 @@ pub(crate) struct ExtractionContext {
 }
 
 // ---------------------------------------------------------------------------
-// ExtractionOutput
-// ---------------------------------------------------------------------------
-
-/// The deserialised output from the extraction LLM call.
-///
-/// Lenient serde — unknown fields are silently ignored so the LLM
-/// can return extra keys without breaking parsing.
-#[derive(Debug, Clone, PartialEq, Eq, Deserialize, schemars::JsonSchema)]
-pub(crate) struct ExtractionOutput {
-    /// Extracted knowledge item candidates.
-    pub candidates: Vec<Candidate>,
-    /// Intra-batch relation hints between candidates.
-    #[serde(default)]
-    pub relation_hints: Vec<RelationHint>,
-}
-
-// ---------------------------------------------------------------------------
 // Stage implementation
 // ---------------------------------------------------------------------------
 
@@ -131,7 +113,7 @@ impl Worker {
         )
         .await
         .map_err(|_| StageError::SemaphoreTimeout {
-            provider_key: self.extraction_key().to_string(),
+            provider_key: format!("{:?}", self.extraction_key()),
         })?
         .expect(SEMAPHORE_CLOSED);
 
@@ -154,7 +136,7 @@ impl Worker {
 
         #[allow(clippy::cast_possible_truncation)]
         let original_count = output.candidates.len() as u32;
-        let max = self.config.max_candidates_per_job as usize;
+        let max = self.config().max_candidates_per_job as usize;
         let capped_candidates: Vec<Candidate> =
             output.candidates.into_iter().take(max).collect();
         #[allow(clippy::cast_possible_truncation)]
@@ -163,7 +145,9 @@ impl Worker {
         let capped_hints: Vec<RelationHint> = output
             .relation_hints
             .into_iter()
-            .filter(|h| h.source_index() < batch_size && h.target_index() < batch_size)
+            .filter(|h: &RelationHint| {
+                h.source_index() < batch_size && h.target_index() < batch_size
+            })
             .collect();
 
         let triage_tasks: Vec<NewTask> = (0..batch_size)

--- a/crates/tribal-worker/src/stages/extraction.rs
+++ b/crates/tribal-worker/src/stages/extraction.rs
@@ -8,9 +8,7 @@ use tribal_inference::Usage;
 
 use super::common::SEMAPHORE_CLOSED;
 use crate::{
-    error::StageError,
-    parsing::parse_extraction_response,
-    prompt::assemble_extraction_prompt,
+    error::StageError, parsing::parse_extraction_response, prompt::assemble_extraction_prompt,
     worker::Worker,
 };
 
@@ -117,11 +115,8 @@ impl Worker {
         })?
         .expect(SEMAPHORE_CLOSED);
 
-        let request = assemble_extraction_prompt(
-            prompt_version.content(),
-            job.raw_input(),
-            &tag_registry,
-        )?;
+        let request =
+            assemble_extraction_prompt(prompt_version.content(), job.raw_input(), &tag_registry)?;
 
         let response = self
             .extraction_provider()
@@ -137,8 +132,7 @@ impl Worker {
         #[allow(clippy::cast_possible_truncation)]
         let original_count = output.candidates.len() as u32;
         let max = self.config().max_candidates_per_job as usize;
-        let capped_candidates: Vec<Candidate> =
-            output.candidates.into_iter().take(max).collect();
+        let capped_candidates: Vec<Candidate> = output.candidates.into_iter().take(max).collect();
         #[allow(clippy::cast_possible_truncation)]
         let batch_size = capped_candidates.len() as u32;
 

--- a/crates/tribal-worker/src/stages/extraction.rs
+++ b/crates/tribal-worker/src/stages/extraction.rs
@@ -186,9 +186,7 @@ impl Worker {
 
             let extraction_result = NewExtractionResult::builder()
                 .job_id(task.job_id())
-                .candidates(
-                    serde_json::to_value(&capped_candidates).expect(CANDIDATES_SERIALISE),
-                )
+                .candidates(serde_json::to_value(&capped_candidates).expect(CANDIDATES_SERIALISE))
                 .relation_hints(serde_json::to_value(&capped_hints).expect(HINTS_SERIALISE))
                 .build();
 

--- a/crates/tribal-worker/src/stages/extraction.rs
+++ b/crates/tribal-worker/src/stages/extraction.rs
@@ -2,8 +2,9 @@
 
 use std::sync::Arc;
 
+use tracing::Instrument;
 use tribal_db::{NewExtractionResult, NewTask};
-use tribal_domain::{Candidate, Job, RelationHint, TagRegistryEntry, Task, TaskType};
+use tribal_domain::{Candidate, Job, RelationHint, TagRegistryEntry, Task, TaskType, span_attrs};
 use tribal_inference::Usage;
 
 use crate::{
@@ -98,76 +99,110 @@ impl Worker {
         job: &Job,
         task: &Task,
     ) -> Result<StageOutput, StageError> {
-        let tag_registry = self.load_tag_registry(STAGE_EXTRACTION).await?;
+        let span = tracing::info_span!(
+            "tribal.task.extraction",
+            { span_attrs::TASK_ID } = %task.id(),
+            { span_attrs::LLM_STAGE } = "extraction",
+            { span_attrs::RETRY_COUNT } = task.retry_count(),
+        );
 
-        let prompt_version = self
-            .load_prompt_version(STAGE_EXTRACTION, job.extraction_prompt_version_id())
-            .await?;
+        async {
+            let tag_registry = self.load_tag_registry(STAGE_EXTRACTION).await?;
 
-        let semaphore = self.extraction_semaphore();
-        let _permit = tokio::time::timeout(
-            self.config().task_timeout(),
-            Arc::clone(semaphore).acquire_owned(),
-        )
-        .await
-        .map_err(|_| StageError::SemaphoreTimeout {
-            provider_key: format!("{:?}", self.extraction_key()),
-        })?
-        .expect(SEMAPHORE_CLOSED);
+            let prompt_version = self
+                .load_prompt_version(STAGE_EXTRACTION, job.extraction_prompt_version_id())
+                .await?;
 
-        let request =
-            assemble_extraction_prompt(prompt_version.content(), job.raw_input(), &tag_registry)?;
-
-        let response = self
-            .extraction_provider()
-            .complete(request)
+            let semaphore = self.extraction_semaphore();
+            let _permit = tokio::time::timeout(
+                self.config().task_timeout(),
+                Arc::clone(semaphore).acquire_owned(),
+            )
             .await
-            .map_err(|e| StageError::Provider {
-                context: "extraction LLM call".into(),
-                source: e,
-            })?;
+            .map_err(|_| StageError::SemaphoreTimeout {
+                provider_key: format!("{:?}", self.extraction_key()),
+            })?
+            .expect(SEMAPHORE_CLOSED);
 
-        let output = parse_extraction_response(&response)?;
+            let request = assemble_extraction_prompt(
+                prompt_version.content(),
+                job.raw_input(),
+                &tag_registry,
+            )?;
 
-        #[allow(clippy::cast_possible_truncation)]
-        let original_count = output.candidates.len() as u32;
-        let max = self.config().max_candidates_per_job as usize;
-        let capped_candidates: Vec<Candidate> = output.candidates.into_iter().take(max).collect();
-        #[allow(clippy::cast_possible_truncation)]
-        let batch_size = capped_candidates.len() as u32;
+            if self.config().include_llm_content {
+                tracing::debug!(
+                    prompt = %request.system.as_deref().unwrap_or(""),
+                    "extraction prompt assembled",
+                );
+            }
 
-        let capped_hints: Vec<RelationHint> = output
-            .relation_hints
-            .into_iter()
-            .filter(|h: &RelationHint| {
-                h.source_index() < batch_size && h.target_index() < batch_size
+            let response = self
+                .extraction_provider()
+                .complete(request)
+                .await
+                .map_err(|e| StageError::Provider {
+                    context: "extraction LLM call".into(),
+                    source: e,
+                })?;
+
+            if self.config().include_llm_content {
+                tracing::debug!(
+                    response = %response.text,
+                    "extraction response received",
+                );
+            }
+
+            let output = {
+                let _parse_span = tracing::info_span!("tribal.extraction.parse").entered();
+                parse_extraction_response(&response)?
+            };
+
+            #[allow(clippy::cast_possible_truncation)]
+            let original_count = output.candidates.len() as u32;
+            let max = self.config().max_candidates_per_job as usize;
+            let capped_candidates: Vec<Candidate> =
+                output.candidates.into_iter().take(max).collect();
+            #[allow(clippy::cast_possible_truncation)]
+            let batch_size = capped_candidates.len() as u32;
+
+            let capped_hints: Vec<RelationHint> = output
+                .relation_hints
+                .into_iter()
+                .filter(|h: &RelationHint| {
+                    h.source_index() < batch_size && h.target_index() < batch_size
+                })
+                .collect();
+
+            let triage_tasks: Vec<NewTask> = (0..batch_size)
+                .map(|i| {
+                    NewTask::builder()
+                        .job_id(task.job_id())
+                        .task_type(TaskType::Triage)
+                        .batch_index(Some(i))
+                        .build()
+                })
+                .collect();
+
+            let extraction_result = NewExtractionResult::builder()
+                .job_id(task.job_id())
+                .candidates(
+                    serde_json::to_value(&capped_candidates).expect(CANDIDATES_SERIALISE),
+                )
+                .relation_hints(serde_json::to_value(&capped_hints).expect(HINTS_SERIALISE))
+                .build();
+
+            Ok(StageOutput {
+                commit: StageCommit::Extraction {
+                    extraction_result,
+                    triage_tasks,
+                    batch_size,
+                    original_count,
+                },
+                usages: vec![Usage::Completion(response.usage)],
             })
-            .collect();
-
-        let triage_tasks: Vec<NewTask> = (0..batch_size)
-            .map(|i| {
-                NewTask::builder()
-                    .job_id(task.job_id())
-                    .task_type(TaskType::Triage)
-                    .batch_index(Some(i))
-                    .build()
-            })
-            .collect();
-
-        let extraction_result = NewExtractionResult::builder()
-            .job_id(task.job_id())
-            .candidates(serde_json::to_value(&capped_candidates).expect(CANDIDATES_SERIALISE))
-            .relation_hints(serde_json::to_value(&capped_hints).expect(HINTS_SERIALISE))
-            .build();
-
-        Ok(StageOutput {
-            commit: StageCommit::Extraction {
-                extraction_result,
-                triage_tasks,
-                batch_size,
-                original_count,
-            },
-            usages: vec![Usage::Completion(response.usage)],
-        })
+        }
+        .instrument(span)
+        .await
     }
 }

--- a/crates/tribal-worker/src/stages/extraction.rs
+++ b/crates/tribal-worker/src/stages/extraction.rs
@@ -131,7 +131,7 @@ impl Worker {
         )
         .await
         .map_err(|_| StageError::SemaphoreTimeout {
-            provider_key: self.extraction_key.to_string(),
+            provider_key: self.extraction_key().to_string(),
         })?
         .expect(SEMAPHORE_CLOSED);
 

--- a/crates/tribal-worker/src/stages/extraction.rs
+++ b/crates/tribal-worker/src/stages/extraction.rs
@@ -8,6 +8,7 @@ use tribal_domain::{Candidate, Job, RelationHint, TagRegistryEntry, Task, TaskTy
 use tribal_inference::Usage;
 
 use crate::{
+    common::clamp_to_u32,
     error::{SEMAPHORE_CLOSED, STAGE_EXTRACTION, StageError},
     parsing::parse_extraction_response,
     prompt::assemble_extraction_prompt,
@@ -80,12 +81,17 @@ impl Worker {
     /// calls the LLM, parses the response, caps candidates, and
     /// builds the [`StageOutput`] for commit.
     ///
+    /// The `deadline` is the absolute instant by which the outer task
+    /// timeout will fire.  Semaphore acquisition uses the remaining
+    /// time budget so that `SemaphoreTimeout` is reported instead of
+    /// a generic `Timeout` when permits are exhausted.
+    ///
     /// # Errors
     ///
     /// Returns a [`StageError`] variant matching the failure mode:
     /// - [`StageError::Database`] for pool/repository failures.
     /// - [`StageError::SemaphoreTimeout`] if the provider semaphore
-    ///   cannot be acquired within the task timeout.
+    ///   cannot be acquired within the remaining time budget.
     /// - [`StageError::TemplateRender`] if the prompt template is invalid.
     /// - [`StageError::Provider`] if the LLM call fails.
     /// - [`StageError::Parse`] if the LLM response cannot be parsed.
@@ -98,6 +104,7 @@ impl Worker {
         &self,
         job: &Job,
         task: &Task,
+        deadline: tokio::time::Instant,
     ) -> Result<StageOutput, StageError> {
         let span = tracing::info_span!(
             "tribal.task.extraction",
@@ -114,15 +121,13 @@ impl Worker {
                 .await?;
 
             let semaphore = self.extraction_semaphore();
-            let _permit = tokio::time::timeout(
-                self.config().task_timeout(),
-                Arc::clone(semaphore).acquire_owned(),
-            )
-            .await
-            .map_err(|_| StageError::SemaphoreTimeout {
-                provider_key: format!("{:?}", self.extraction_key()),
-            })?
-            .expect(SEMAPHORE_CLOSED);
+            let remaining = deadline.saturating_duration_since(tokio::time::Instant::now());
+            let _permit = tokio::time::timeout(remaining, Arc::clone(semaphore).acquire_owned())
+                .await
+                .map_err(|_| StageError::SemaphoreTimeout {
+                    provider_key: format!("{:?}", self.extraction_key()),
+                })?
+                .expect(SEMAPHORE_CLOSED);
 
             let request = assemble_extraction_prompt(
                 prompt_version.content(),
@@ -158,13 +163,11 @@ impl Worker {
                 parse_extraction_response(&response)?
             };
 
-            #[allow(clippy::cast_possible_truncation)]
-            let original_count = output.candidates.len() as u32;
+            let original_count = clamp_to_u32(output.candidates.len());
             let max = self.config().max_candidates_per_job as usize;
             let capped_candidates: Vec<Candidate> =
                 output.candidates.into_iter().take(max).collect();
-            #[allow(clippy::cast_possible_truncation)]
-            let batch_size = capped_candidates.len() as u32;
+            let batch_size = clamp_to_u32(capped_candidates.len());
 
             let capped_hints: Vec<RelationHint> = output
                 .relation_hints

--- a/crates/tribal-worker/src/stages/extraction.rs
+++ b/crates/tribal-worker/src/stages/extraction.rs
@@ -6,9 +6,10 @@ use tribal_db::{NewExtractionResult, NewTask};
 use tribal_domain::{Candidate, Job, RelationHint, TagRegistryEntry, Task, TaskType};
 use tribal_inference::Usage;
 
-use super::common::SEMAPHORE_CLOSED;
 use crate::{
-    error::StageError, parsing::parse_extraction_response, prompt::assemble_extraction_prompt,
+    error::{SEMAPHORE_CLOSED, STAGE_EXTRACTION, StageError},
+    parsing::parse_extraction_response,
+    prompt::assemble_extraction_prompt,
     worker::Worker,
 };
 
@@ -16,7 +17,6 @@ use crate::{
 // Constants
 // ---------------------------------------------------------------------------
 
-const STAGE_EXTRACTION: &str = "extraction";
 const CANDIDATES_SERIALISE: &str = "candidates serialise to JSON";
 const HINTS_SERIALISE: &str = "relation hints serialise to JSON";
 

--- a/crates/tribal-worker/src/stages/relation.rs
+++ b/crates/tribal-worker/src/stages/relation.rs
@@ -19,6 +19,7 @@ impl Worker {
         &self,
         _job: &tribal_domain::Job,
         _task: &tribal_domain::Task,
+        _deadline: tokio::time::Instant,
     ) -> Result<StageOutput, StageError> {
         // Replaced by ticket 4.5
         Err(StageError::Provider {

--- a/crates/tribal-worker/src/stages/triage.rs
+++ b/crates/tribal-worker/src/stages/triage.rs
@@ -19,6 +19,7 @@ impl Worker {
         &self,
         _job: &tribal_domain::Job,
         _task: &tribal_domain::Task,
+        _deadline: tokio::time::Instant,
     ) -> Result<StageOutput, StageError> {
         // Replaced by ticket 4.4
         Err(StageError::Provider {

--- a/crates/tribal-worker/src/worker/dispatch.rs
+++ b/crates/tribal-worker/src/worker/dispatch.rs
@@ -359,7 +359,7 @@ impl Worker {
             }
             () = tokio::time::sleep(self.config.task_timeout()) => {
                 Err(StageError::Timeout {
-                    timeout_seconds: self.config.task_timeout_seconds,
+                    timeout_millis: self.config.task_timeout_millis,
                 })
             }
             Ok(()) = &mut heartbeat.ownership_lost_rx => {

--- a/crates/tribal-worker/src/worker/dispatch.rs
+++ b/crates/tribal-worker/src/worker/dispatch.rs
@@ -49,7 +49,6 @@ const STAGE_EXTRACTION: &str = "extraction";
 /// cancellation token is triggered.
 pub struct Worker {
     pool: PgPool,
-    #[allow(dead_code)]
     provider_registry: Arc<ProviderRegistry>,
     extraction_provider: Arc<dyn InferenceProvider>,
     #[allow(dead_code)]
@@ -58,7 +57,6 @@ pub struct Worker {
     relation_provider: Arc<dyn InferenceProvider>,
     #[allow(dead_code)]
     embedding_provider: Arc<dyn EmbeddingProvider>,
-    #[allow(dead_code)]
     extraction_key: ProviderKey,
     #[allow(dead_code)]
     triage_inference_key: ProviderKey,
@@ -124,9 +122,19 @@ impl Worker {
         &self.config
     }
 
+    /// Returns a reference to the provider registry.
+    pub(crate) fn provider_registry(&self) -> &Arc<ProviderRegistry> {
+        &self.provider_registry
+    }
+
     /// Returns a reference to the extraction inference provider.
     pub(crate) fn extraction_provider(&self) -> &Arc<dyn InferenceProvider> {
         &self.extraction_provider
+    }
+
+    /// Returns the extraction provider key.
+    pub(crate) fn extraction_key(&self) -> &ProviderKey {
+        &self.extraction_key
     }
 
     /// Returns the high-water mark of simultaneously in-flight tasks

--- a/crates/tribal-worker/src/worker/dispatch.rs
+++ b/crates/tribal-worker/src/worker/dispatch.rs
@@ -492,14 +492,26 @@ impl Worker {
         task: &Task,
         outcome: &FailureOutcome<'_>,
         error_message: &str,
-    ) -> Result<(), sqlx::Error> {
+    ) -> Result<(), tribal_db::DbError> {
         let Some(claim_token) = task.claim_token() else {
             tracing::error!(task_id = %task.id(), "task has no claim token");
             return Ok(());
         };
 
-        let mut conn = self.pool.acquire().await?;
-        let mut txn = sqlx::Connection::begin(&mut *conn).await?;
+        let mut conn =
+            self.pool
+                .acquire()
+                .await
+                .map_err(|source| tribal_db::DbError::QueryFailed {
+                    context: "acquiring connection for failure persistence".to_owned(),
+                    source,
+                })?;
+        let mut txn = sqlx::Connection::begin(&mut *conn)
+            .await
+            .map_err(|source| tribal_db::DbError::QueryFailed {
+                context: "beginning failure transaction".to_owned(),
+                source,
+            })?;
 
         let rows_affected = PgTaskRepository
             .fail(
@@ -511,11 +523,7 @@ impl Worker {
                 outcome.error_kind,
                 error_message,
             )
-            .await
-            .map_err(|e| match e {
-                tribal_db::DbError::QueryFailed { source, .. } => source,
-                other => sqlx::Error::Protocol(other.to_string()),
-            })?;
+            .await?;
 
         if rows_affected == 0 {
             tracing::warn!(task_id = %task.id(), "ownership lost during failure handling");
@@ -537,14 +545,15 @@ impl Worker {
                 .build();
             PgJobRepository
                 .update_status(&mut txn, task.job_id(), &transition)
-                .await
-                .map_err(|e| match e {
-                    tribal_db::DbError::QueryFailed { source, .. } => source,
-                    other => sqlx::Error::Protocol(other.to_string()),
-                })?;
+                .await?;
         }
 
-        txn.commit().await?;
+        txn.commit()
+            .await
+            .map_err(|source| tribal_db::DbError::QueryFailed {
+                context: "committing failure transaction".to_owned(),
+                source,
+            })?;
         self.log_failure_outcome(task, outcome);
         Ok(())
     }

--- a/crates/tribal-worker/src/worker/dispatch.rs
+++ b/crates/tribal-worker/src/worker/dispatch.rs
@@ -25,18 +25,9 @@ use super::{
 };
 use crate::{
     config::WorkerConfig,
-    error::{StageError, WorkerError},
+    error::{SEMAPHORE_CLOSED, STAGE_EXTRACTION, STAGE_PRE_DISPATCH, StageError, WorkerError},
     stages::{StageCommit, StageOutput},
 };
-
-// ---------------------------------------------------------------------------
-// Constants
-// ---------------------------------------------------------------------------
-
-const SEMAPHORE_CLOSED: &str = "semaphore closed unexpectedly";
-
-const STAGE_PRE_DISPATCH: &str = "pre-dispatch";
-const STAGE_EXTRACTION: &str = "extraction";
 
 // ---------------------------------------------------------------------------
 // Worker

--- a/crates/tribal-worker/src/worker/dispatch.rs
+++ b/crates/tribal-worker/src/worker/dispatch.rs
@@ -122,6 +122,11 @@ impl Worker {
         &self.config
     }
 
+    /// Returns a reference to the database pool.
+    pub(crate) fn pool(&self) -> &PgPool {
+        &self.pool
+    }
+
     /// Returns a reference to the provider registry.
     pub(crate) fn provider_registry(&self) -> &Arc<ProviderRegistry> {
         &self.provider_registry

--- a/crates/tribal-worker/src/worker/dispatch.rs
+++ b/crates/tribal-worker/src/worker/dispatch.rs
@@ -25,6 +25,7 @@ use super::{
     heartbeat::{run_reclaim_sweep, run_startup_reclaim, spawn_heartbeat},
 };
 use crate::{
+    common::clamp_to_u32,
     config::WorkerConfig,
     error::{SEMAPHORE_CLOSED, STAGE_EXTRACTION, STAGE_PRE_DISPATCH, StageError, WorkerError},
     stages::{StageCommit, StageOutput},
@@ -253,6 +254,13 @@ impl Worker {
                 Ok(tasks) => {
                     poll_interval = self.config.poll_interval();
                     for task in tasks {
+                        tracing::info!(
+                            task_id = %task.id(),
+                            task_type = %task.task_type(),
+                            job_id = %task.job_id(),
+                            retry_count = task.retry_count(),
+                            "task.claimed",
+                        );
                         let permit = semaphore
                             .clone()
                             .acquire_owned()
@@ -367,6 +375,8 @@ impl Worker {
             self.cancellation_token.clone(),
         );
 
+        let deadline = tokio::time::Instant::now() + self.config.task_timeout();
+
         let stage_result = tokio::select! {
             () = self.cancellation_token.cancelled() => {
                 heartbeat.abort();
@@ -381,7 +391,7 @@ impl Worker {
             Ok(()) = &mut heartbeat.ownership_lost_rx => {
                 Err(StageError::OwnershipLost)
             }
-            result = self.dispatch_stage(&job, &task) => {
+            result = self.dispatch_stage(&job, &task, deadline) => {
                 result
             }
         };
@@ -412,11 +422,16 @@ impl Worker {
     }
 
     /// Routes to the correct stage based on task type.
-    async fn dispatch_stage(&self, job: &Job, task: &Task) -> Result<StageOutput, StageError> {
+    async fn dispatch_stage(
+        &self,
+        job: &Job,
+        task: &Task,
+        deadline: tokio::time::Instant,
+    ) -> Result<StageOutput, StageError> {
         match task.task_type() {
-            TaskType::Extraction => self.run_extraction(job, task).await,
-            TaskType::Triage => self.run_triage(job, task).await,
-            TaskType::Relation => self.run_relation(job, task).await,
+            TaskType::Extraction => self.run_extraction(job, task, deadline).await,
+            TaskType::Triage => self.run_triage(job, task, deadline).await,
+            TaskType::Relation => self.run_relation(job, task, deadline).await,
         }
     }
 
@@ -428,6 +443,9 @@ impl Worker {
     /// in a single transaction so they commit or roll back atomically.
     async fn handle_stage_failure(&self, task: &Task, error: &StageError) {
         tracing::error!(
+            task_id = %task.id(),
+            task_type = %task.task_type(),
+            job_id = %task.job_id(),
             error_kind = %error.to_error_kind(),
             error_message = %error,
             "stage execution failed",
@@ -446,53 +464,62 @@ impl Worker {
         let job_failed = is_dead_lettered
             && matches!(task.task_type(), TaskType::Extraction | TaskType::Relation);
 
-        let mut conn = match self.pool.acquire().await {
-            Ok(c) => c,
-            Err(e) => {
-                tracing::error!(
-                    error = %e,
-                    task_id = %task.id(),
-                    "failed to acquire connection for failure handling",
-                );
-                return;
-            }
+        let outcome = FailureOutcome {
+            error,
+            error_kind,
+            retry_count: post_increment_retry,
+            available_at,
+            is_dead_lettered,
+            job_failed,
         };
 
+        if let Err(e) = self.persist_failure(task, &outcome, &error_message).await {
+            tracing::error!(
+                error = %e,
+                task_id = %task.id(),
+                task_type = %task.task_type(),
+                job_id = %task.job_id(),
+                "failed to persist failure",
+            );
+        }
+    }
+
+    /// Persists the failure state for a task within a single
+    /// transaction: fails the task, optionally transitions the parent
+    /// job to `Failed`, commits, and emits lifecycle events.
+    async fn persist_failure(
+        &self,
+        task: &Task,
+        outcome: &FailureOutcome<'_>,
+        error_message: &str,
+    ) -> Result<(), sqlx::Error> {
         let Some(claim_token) = task.claim_token() else {
             tracing::error!(task_id = %task.id(), "task has no claim token");
-            return;
+            return Ok(());
         };
 
-        let mut txn = match sqlx::Connection::begin(&mut *conn).await {
-            Ok(t) => t,
-            Err(e) => {
-                tracing::error!(error = %e, "failed to begin failure transaction");
-                return;
-            }
-        };
+        let mut conn = self.pool.acquire().await?;
+        let mut txn = sqlx::Connection::begin(&mut *conn).await?;
 
-        let rows_affected = match PgTaskRepository
+        let rows_affected = PgTaskRepository
             .fail(
                 &mut txn,
                 task.id(),
                 claim_token,
                 self.config.task_max_retries,
-                available_at,
-                error_kind,
-                &error_message,
+                outcome.available_at,
+                outcome.error_kind,
+                error_message,
             )
             .await
-        {
-            Ok(rows) => rows,
-            Err(e) => {
-                tracing::error!(error = %e, task_id = %task.id(), "failed to fail task");
-                return;
-            }
-        };
+            .map_err(|e| match e {
+                tribal_db::DbError::QueryFailed { source, .. } => source,
+                other => sqlx::Error::Protocol(other.to_string()),
+            })?;
 
         if rows_affected == 0 {
             tracing::warn!(task_id = %task.id(), "ownership lost during failure handling");
-            return;
+            return Ok(());
         }
 
         // When a task exhausts its retry budget, dead-lettering is
@@ -501,42 +528,25 @@ impl Worker {
         // Triage failures are non-fatal: remaining triage tasks can
         // still succeed, and the relation stage runs on whatever
         // triage results are available.
-        if job_failed {
+        if outcome.job_failed {
             let transition = JobStatusTransition::builder()
                 .status(JobStatus::Failed)
                 .outcome(Some(JobOutcome::Failure))
-                .error_message(Some(error_message))
+                .error_message(Some(error_message.to_owned()))
                 .completed_at(Some(Utc::now()))
                 .build();
-            if let Err(e) = PgJobRepository
+            PgJobRepository
                 .update_status(&mut txn, task.job_id(), &transition)
                 .await
-            {
-                tracing::error!(
-                    error = %e,
-                    job_id = %task.job_id(),
-                    "failed to transition job to Failed on dead-letter",
-                );
-                return;
-            }
+                .map_err(|e| match e {
+                    tribal_db::DbError::QueryFailed { source, .. } => source,
+                    other => sqlx::Error::Protocol(other.to_string()),
+                })?;
         }
 
-        match txn.commit().await {
-            Ok(()) => self.log_failure_outcome(
-                task,
-                &FailureOutcome {
-                    error,
-                    error_kind,
-                    retry_count: post_increment_retry,
-                    available_at,
-                    is_dead_lettered,
-                    job_failed,
-                },
-            ),
-            Err(e) => {
-                tracing::error!(error = %e, "failed to commit failure transaction");
-            }
-        }
+        txn.commit().await?;
+        self.log_failure_outcome(task, outcome);
+        Ok(())
     }
 
     /// Emits lifecycle events after a failure transaction commits and
@@ -834,11 +844,6 @@ fn extraction_sqlx_error(context: &str, source: sqlx::Error) -> StageError {
     )
 }
 
-/// Clamps a `usize` to `u32`, saturating at [`u32::MAX`].
-fn clamp_to_u32(value: usize) -> u32 {
-    u32::try_from(value).unwrap_or(u32::MAX)
-}
-
 /// Computes the next claim-cycle backoff by doubling the current poll
 /// interval, capping at [`BACKOFF_CAP_SECS`], and flooring at 1 s.
 fn next_claim_backoff(current: std::time::Duration) -> std::time::Duration {
@@ -863,17 +868,6 @@ fn job_status_for_task_type(task_type: TaskType) -> JobStatus {
 #[cfg(test)]
 mod tests {
     use super::*;
-
-    #[test]
-    fn test_clamp_to_u32_within_range() {
-        assert_eq!(clamp_to_u32(42), 42);
-        assert_eq!(clamp_to_u32(0), 0);
-    }
-
-    #[test]
-    fn test_clamp_to_u32_saturates() {
-        assert_eq!(clamp_to_u32(usize::MAX), u32::MAX);
-    }
 
     #[test]
     fn test_claim_backoff_doubles_and_caps() {

--- a/crates/tribal-worker/src/worker/dispatch.rs
+++ b/crates/tribal-worker/src/worker/dispatch.rs
@@ -10,11 +10,11 @@ use dashmap::DashMap;
 use sqlx::PgPool;
 use tokio::sync::{Semaphore, watch};
 use tokio_util::sync::CancellationToken;
+use tracing::Instrument;
 use tribal_db::{
     ExtractionResultRepository, JobRepository, JobStatusTransition, NewExtractionResult, NewTask,
     PgExtractionResultRepository, PgJobRepository, PgTaskRepository, TaskRepository,
 };
-use tracing::Instrument;
 use tribal_domain::{Job, JobId, JobOutcome, JobStatus, Task, TaskErrorKind, TaskType, span_attrs};
 use tribal_inference::{
     EmbeddingProvider, InferenceProvider, ProviderKey, ProviderRegistry, Usage,
@@ -620,8 +620,7 @@ impl Worker {
 
         async {
             tracing::Span::current().record(span_attrs::BATCH_SIZE, batch_size);
-            tracing::Span::current()
-                .record(span_attrs::EXTRACTION_ORIGINAL_COUNT, original_count);
+            tracing::Span::current().record(span_attrs::EXTRACTION_ORIGINAL_COUNT, original_count);
 
             let Some(claim_token) = task.claim_token() else {
                 return Err(StageError::OwnershipLost);

--- a/crates/tribal-worker/src/worker/dispatch.rs
+++ b/crates/tribal-worker/src/worker/dispatch.rs
@@ -14,7 +14,8 @@ use tribal_db::{
     ExtractionResultRepository, JobRepository, JobStatusTransition, NewExtractionResult, NewTask,
     PgExtractionResultRepository, PgJobRepository, PgTaskRepository, TaskRepository,
 };
-use tribal_domain::{Job, JobId, JobOutcome, JobStatus, Task, TaskType};
+use tracing::Instrument;
+use tribal_domain::{Job, JobId, JobOutcome, JobStatus, Task, TaskErrorKind, TaskType, span_attrs};
 use tribal_inference::{
     EmbeddingProvider, InferenceProvider, ProviderKey, ProviderRegistry, Usage,
 };
@@ -28,6 +29,21 @@ use crate::{
     error::{SEMAPHORE_CLOSED, STAGE_EXTRACTION, STAGE_PRE_DISPATCH, StageError, WorkerError},
     stages::{StageCommit, StageOutput},
 };
+
+// ---------------------------------------------------------------------------
+// FailureOutcome
+// ---------------------------------------------------------------------------
+
+/// Data needed to emit lifecycle events after a failure transaction
+/// commits.  Bundled into a struct to avoid passing many parameters.
+struct FailureOutcome<'a> {
+    error: &'a StageError,
+    error_kind: TaskErrorKind,
+    retry_count: u32,
+    available_at: chrono::DateTime<Utc>,
+    is_dead_lettered: bool,
+    job_failed: bool,
+}
 
 // ---------------------------------------------------------------------------
 // Worker
@@ -411,10 +427,10 @@ impl Worker {
     /// All mutations (task fail + optional job transition) are composed
     /// in a single transaction so they commit or roll back atomically.
     async fn handle_stage_failure(&self, task: &Task, error: &StageError) {
-        tracing::warn!(
-            task_id = %task.id(),
-            error = %error,
-            "stage failed",
+        tracing::error!(
+            error_kind = %error.to_error_kind(),
+            error_message = %error,
+            "stage execution failed",
         );
 
         let error_kind = error.to_error_kind();
@@ -506,15 +522,52 @@ impl Worker {
         }
 
         match txn.commit().await {
-            Ok(()) => {
-                if job_failed {
-                    self.notify_job_state(task.job_id());
-                    self.job_state_txs.remove(&task.job_id());
-                }
-            }
+            Ok(()) => self.log_failure_outcome(
+                task,
+                &FailureOutcome {
+                    error,
+                    error_kind,
+                    retry_count: post_increment_retry,
+                    available_at,
+                    is_dead_lettered,
+                    job_failed,
+                },
+            ),
             Err(e) => {
                 tracing::error!(error = %e, "failed to commit failure transaction");
             }
+        }
+    }
+
+    /// Emits lifecycle events after a failure transaction commits and
+    /// notifies job-state subscribers when the job is dead-lettered.
+    fn log_failure_outcome(&self, task: &Task, outcome: &FailureOutcome<'_>) {
+        if outcome.is_dead_lettered {
+            tracing::error!(
+                task_id = %task.id(),
+                task_type = %task.task_type(),
+                job_id = %task.job_id(),
+                error_kind = %outcome.error_kind,
+                error_message = %outcome.error,
+                retry_count = outcome.retry_count,
+                "task.dead_lettered",
+            );
+        } else {
+            tracing::warn!(
+                task_id = %task.id(),
+                task_type = %task.task_type(),
+                job_id = %task.job_id(),
+                error_kind = %outcome.error_kind,
+                error_message = %outcome.error,
+                retry_count = outcome.retry_count,
+                available_at = %outcome.available_at,
+                "task.failed",
+            );
+        }
+
+        if outcome.job_failed {
+            self.notify_job_state(task.job_id());
+            self.job_state_txs.remove(&task.job_id());
         }
     }
 
@@ -559,123 +612,104 @@ impl Worker {
         batch_size: u32,
         original_count: u32,
     ) -> Result<(), StageError> {
-        let Some(claim_token) = task.claim_token() else {
-            return Err(StageError::OwnershipLost);
-        };
+        let span = tracing::info_span!(
+            "tribal.extraction.commit",
+            { span_attrs::BATCH_SIZE } = tracing::field::Empty,
+            { span_attrs::EXTRACTION_ORIGINAL_COUNT } = tracing::field::Empty,
+        );
 
-        let mut conn = self
-            .pool
-            .acquire()
-            .await
-            .map_err(|e| StageError::Database {
-                stage: STAGE_EXTRACTION.into(),
-                context: "acquiring connection".into(),
-                source: tribal_db::DbError::QueryFailed {
-                    context: "pool acquire".into(),
-                    source: e,
-                },
-            })?;
+        async {
+            tracing::Span::current().record(span_attrs::BATCH_SIZE, batch_size);
+            tracing::Span::current()
+                .record(span_attrs::EXTRACTION_ORIGINAL_COUNT, original_count);
 
-        let mut txn =
-            sqlx::Connection::begin(&mut *conn)
+            let Some(claim_token) = task.claim_token() else {
+                return Err(StageError::OwnershipLost);
+            };
+
+            let mut conn = self
+                .pool
+                .acquire()
                 .await
-                .map_err(|e| StageError::Database {
-                    stage: STAGE_EXTRACTION.into(),
-                    context: "beginning transaction".into(),
-                    source: tribal_db::DbError::QueryFailed {
-                        context: "begin".into(),
-                        source: e,
-                    },
-                })?;
+                .map_err(|e| extraction_sqlx_error("acquiring connection", e))?;
 
-        PgExtractionResultRepository
-            .insert(&mut txn, &extraction_result)
-            .await
-            .map_err(|e| StageError::Database {
-                stage: STAGE_EXTRACTION.into(),
-                context: "inserting extraction result".into(),
-                source: e,
-            })?;
+            let mut txn = sqlx::Connection::begin(&mut *conn)
+                .await
+                .map_err(|e| extraction_sqlx_error("beginning transaction", e))?;
 
-        let is_empty = batch_size == 0;
+            PgExtractionResultRepository
+                .insert(&mut txn, &extraction_result)
+                .await
+                .map_err(|e| extraction_db_error("inserting extraction result", e))?;
 
-        if !is_empty {
-            for new_task in &triage_tasks {
-                PgTaskRepository
-                    .insert(&mut txn, new_task)
-                    .await
-                    .map_err(|e| StageError::Database {
-                        stage: STAGE_EXTRACTION.into(),
-                        context: "creating triage task".into(),
-                        source: e,
-                    })?;
+            let is_empty = batch_size == 0;
+
+            if !is_empty {
+                for new_task in &triage_tasks {
+                    PgTaskRepository
+                        .insert(&mut txn, new_task)
+                        .await
+                        .map_err(|e| extraction_db_error("creating triage task", e))?;
+                }
             }
+
+            PgJobRepository
+                .update_batch_size(&mut txn, task.job_id(), batch_size, original_count)
+                .await
+                .map_err(|e| extraction_db_error("updating batch size", e))?;
+
+            // Zero-candidate path: when extraction produces no candidates,
+            // the job completes immediately with an Empty outcome — no
+            // triage or relation stages are needed.
+            let job_transition = if is_empty {
+                JobStatusTransition::builder()
+                    .status(JobStatus::Completed)
+                    .outcome(Some(JobOutcome::Empty))
+                    .completed_at(Some(Utc::now()))
+                    .build()
+            } else {
+                JobStatusTransition::builder()
+                    .status(JobStatus::Triaging)
+                    .build()
+            };
+
+            PgJobRepository
+                .update_status(&mut txn, task.job_id(), &job_transition)
+                .await
+                .map_err(|e| extraction_db_error("transitioning job status", e))?;
+
+            let rows = PgTaskRepository
+                .complete(&mut txn, task.id(), claim_token)
+                .await
+                .map_err(|e| extraction_db_error("completing task", e))?;
+
+            if rows == 0 {
+                return Err(StageError::OwnershipLost);
+            }
+
+            txn.commit()
+                .await
+                .map_err(|e| extraction_sqlx_error("committing transaction", e))?;
+
+            // Notify watch subscribers of the job state change.
+            self.notify_job_state(task.job_id());
+
+            // Clean up watch channel entry for terminal job transitions.
+            if is_empty {
+                self.job_state_txs.remove(&task.job_id());
+            }
+
+            tracing::info!(
+                task_id = %task.id(),
+                task_type = "extraction",
+                job_id = %task.job_id(),
+                "task.completed",
+            );
+
+            Ok(())
         }
-
-        PgJobRepository
-            .update_batch_size(&mut txn, task.job_id(), batch_size, original_count)
-            .await
-            .map_err(|e| StageError::Database {
-                stage: STAGE_EXTRACTION.into(),
-                context: "updating batch size".into(),
-                source: e,
-            })?;
-
-        // Zero-candidate path: when extraction produces no candidates,
-        // the job completes immediately with an Empty outcome — no
-        // triage or relation stages are needed.
-        let job_transition = if is_empty {
-            JobStatusTransition::builder()
-                .status(JobStatus::Completed)
-                .outcome(Some(JobOutcome::Empty))
-                .completed_at(Some(Utc::now()))
-                .build()
-        } else {
-            JobStatusTransition::builder()
-                .status(JobStatus::Triaging)
-                .build()
-        };
-
-        PgJobRepository
-            .update_status(&mut txn, task.job_id(), &job_transition)
-            .await
-            .map_err(|e| StageError::Database {
-                stage: STAGE_EXTRACTION.into(),
-                context: "transitioning job status".into(),
-                source: e,
-            })?;
-
-        let rows = PgTaskRepository
-            .complete(&mut txn, task.id(), claim_token)
-            .await
-            .map_err(|e| StageError::Database {
-                stage: STAGE_EXTRACTION.into(),
-                context: "completing task".into(),
-                source: e,
-            })?;
-
-        if rows == 0 {
-            return Err(StageError::OwnershipLost);
-        }
-
-        txn.commit().await.map_err(|e| StageError::Database {
-            stage: STAGE_EXTRACTION.into(),
-            context: "committing transaction".into(),
-            source: tribal_db::DbError::QueryFailed {
-                context: "commit".into(),
-                source: e,
-            },
-        })?;
-
-        // Notify watch subscribers of the job state change.
-        self.notify_job_state(task.job_id());
-
-        // Clean up watch channel entry for terminal job transitions.
-        if is_empty {
-            self.job_state_txs.remove(&task.job_id());
-        }
-
-        Ok(())
+        .instrument(span)
+        .await
     }
 
     /// Records token usage for a completed stage.
@@ -779,6 +813,27 @@ impl Worker {
 // ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------
+
+/// Builds a [`StageError::Database`] for the extraction stage.
+fn extraction_db_error(context: &str, source: tribal_db::DbError) -> StageError {
+    StageError::Database {
+        stage: STAGE_EXTRACTION.into(),
+        context: context.into(),
+        source,
+    }
+}
+
+/// Wraps a raw [`sqlx::Error`] into a [`StageError::Database`] for the
+/// extraction stage.
+fn extraction_sqlx_error(context: &str, source: sqlx::Error) -> StageError {
+    extraction_db_error(
+        context,
+        tribal_db::DbError::QueryFailed {
+            context: context.into(),
+            source,
+        },
+    )
+}
 
 /// Clamps a `usize` to `u32`, saturating at [`u32::MAX`].
 fn clamp_to_u32(value: usize) -> u32 {

--- a/crates/tribal-worker/tests/worker.rs
+++ b/crates/tribal-worker/tests/worker.rs
@@ -38,8 +38,9 @@ use tribal_test_utils::{
         CLAIM_SETTLE, EARLY_ABORT_BOUND, HEARTBEAT_DETECT, LONG_PROVIDER_DELAY, MULTI_CYCLE_SETTLE,
         POLL_SETTLE, STALE_HEARTBEAT_BACKDATE,
     },
-    insert_prompt_version, seed_extraction_job, serial_lock, set_retry_count, test_context,
-    truncate_all_tables,
+    insert_prompt_version,
+    polling::{poll_job_status, poll_task_status, poll_until},
+    seed_extraction_job, serial_lock, set_retry_count, test_context, truncate_all_tables,
 };
 use tribal_worker::{Worker, WorkerConfig};
 
@@ -140,14 +141,14 @@ fn build_test_worker(
                 key(RequestClass::Inference),
                 ProviderLimits {
                     max_in_flight: 10,
-                    request_timeout: std::time::Duration::from_secs(30),
+                    request_timeout: Duration::from_secs(30),
                 },
             ),
             (
                 key(RequestClass::Embedding),
                 ProviderLimits {
                     max_in_flight: 10,
-                    request_timeout: std::time::Duration::from_secs(30),
+                    request_timeout: Duration::from_secs(30),
                 },
             ),
         ])
@@ -174,27 +175,44 @@ fn build_test_worker(
     ))
 }
 
-/// Spawns a worker, lets it run for the given settle duration, then
-/// cancels and awaits shutdown.
-async fn run_worker_briefly(worker: Arc<Worker>, token: CancellationToken, settle: Duration) {
-    let handle = {
-        let w = Arc::clone(&worker);
-        tokio::spawn(async move { w.run().await })
-    };
-    tokio::time::sleep(settle).await;
-    token.cancel();
-    let _ = handle.await;
+/// Polls until a task is requeued with at least one retry.
+///
+/// Used by reclaim and heartbeat tests where the exact retry count
+/// depends on timing.
+async fn poll_task_requeued_with_retry(
+    pool: &sqlx::PgPool,
+    task_id: tribal_domain::TaskId,
+    timeout: Duration,
+) -> tribal_domain::Task {
+    poll_until(
+        "task requeued with retry",
+        Duration::from_millis(50),
+        timeout,
+        || {
+            let pool = pool.clone();
+            async move {
+                let mut conn = pool.acquire().await.ok()?;
+                let task = PgTaskRepository.find_by_id(&mut conn, task_id).await.ok()?;
+                if task.status() == TaskStatus::Queued && task.retry_count() >= 1 {
+                    Some(task)
+                } else {
+                    None
+                }
+            }
+        },
+    )
+    .await
 }
 
-/// Returns a [`WorkerConfig`] with aggressive timeouts for fast tests.
+/// Returns a [`WorkerConfig`] with sub-second intervals for fast tests.
 fn test_config() -> WorkerConfig {
     WorkerConfig {
         max_concurrent_tasks: 4,
-        poll_interval_seconds: 1,
-        task_timeout_seconds: 10,
+        poll_interval_millis: 100,
+        task_timeout_millis: 5_000,
         task_max_retries: 3,
-        heartbeat_interval_seconds: 5,
-        reclaim_interval_seconds: 1,
+        heartbeat_interval_millis: 200,
+        reclaim_interval_millis: 100,
         max_candidates_per_job: 20,
         triage_search_limit: 10,
         include_llm_content: false,
@@ -222,20 +240,16 @@ async fn test_retry_path_increments_retry_count() {
     };
 
     let token = CancellationToken::new();
-    let worker = build_test_worker(pool, token.clone(), test_config(), None, None);
-    run_worker_briefly(worker, token, POLL_SETTLE).await;
+    let worker = build_test_worker(pool.clone(), token.clone(), test_config(), None, None);
+    let handle = {
+        let w = Arc::clone(&worker);
+        tokio::spawn(async move { w.run().await })
+    };
 
-    let mut conn = raw_conn(ctx).await;
-    let task = PgTaskRepository
-        .find_by_id(&mut conn, task_id)
-        .await
-        .expect("find task");
+    let task = poll_task_status(&pool, task_id, TaskStatus::Queued, POLL_SETTLE).await;
+    token.cancel();
+    let _ = handle.await;
 
-    assert_eq!(
-        task.status(),
-        TaskStatus::Queued,
-        "task should be re-queued"
-    );
     assert_eq!(task.retry_count(), 1, "retry count should be incremented");
     assert_eq!(
         task.error_kind(),
@@ -251,6 +265,7 @@ async fn test_retry_path_increments_retry_count() {
         "available_at should be in the future (backoff)",
     );
 
+    let mut conn = raw_conn(ctx).await;
     let job = PgJobRepository
         .find_by_id(&mut conn, job_id)
         .await
@@ -288,33 +303,24 @@ async fn test_dead_letter_path_transitions_task_and_job() {
     };
 
     let token = CancellationToken::new();
-    let worker = build_test_worker(pool, token.clone(), config, None, None);
-    run_worker_briefly(worker, token, POLL_SETTLE).await;
+    let worker = build_test_worker(pool.clone(), token.clone(), config, None, None);
+    let handle = {
+        let w = Arc::clone(&worker);
+        tokio::spawn(async move { w.run().await })
+    };
 
-    let mut conn = raw_conn(ctx).await;
+    let task = poll_task_status(&pool, task_id, TaskStatus::DeadLetter, POLL_SETTLE).await;
+    token.cancel();
+    let _ = handle.await;
 
-    let task = PgTaskRepository
-        .find_by_id(&mut conn, task_id)
-        .await
-        .expect("find task");
-
-    assert_eq!(
-        task.status(),
-        TaskStatus::DeadLetter,
-        "task should be dead-lettered",
-    );
     assert_eq!(
         task.error_kind(),
         Some(TaskErrorKind::ProviderError),
         "error kind should be provider_error",
     );
 
-    let job = PgJobRepository
-        .find_by_id(&mut conn, job_id)
-        .await
-        .expect("find job");
+    let job = poll_job_status(&pool, job_id, JobStatus::Failed, POLL_SETTLE).await;
 
-    assert_eq!(job.status(), JobStatus::Failed, "job should be failed");
     assert_eq!(
         job.outcome(),
         Some(JobOutcome::Failure),
@@ -344,14 +350,7 @@ async fn test_concurrency_limit_respected() {
 
     let config = WorkerConfig {
         max_concurrent_tasks: max_concurrent,
-        poll_interval_seconds: 1,
-        task_timeout_seconds: 10,
-        task_max_retries: 3,
-        heartbeat_interval_seconds: 5,
-        reclaim_interval_seconds: 1,
-        max_candidates_per_job: 20,
-        triage_search_limit: 10,
-        include_llm_content: false,
+        ..test_config()
     };
 
     let (principal_id, project_id, pv_id) = setup_prerequisites(ctx, "concurrency").await;
@@ -446,29 +445,26 @@ async fn test_reclaim_sweep_requeues_stale_heartbeat_task() {
         task_id
     };
 
-    let config = test_config();
     let token = CancellationToken::new();
-    let worker = build_test_worker(pool, token.clone(), config, None, None);
-    run_worker_briefly(worker, token, POLL_SETTLE).await;
+    let worker = build_test_worker(pool.clone(), token.clone(), test_config(), None, None);
+    let handle = {
+        let w = Arc::clone(&worker);
+        tokio::spawn(async move { w.run().await })
+    };
 
-    let mut conn = raw_conn(ctx).await;
-    let task = PgTaskRepository
-        .find_by_id(&mut conn, task_id)
-        .await
-        .expect("find task");
+    // Reclaim requeues the task (retry_count=1). The worker's poll
+    // loop may re-dispatch it before we observe the intermediate
+    // state — the extraction stub fails, handle_stage_failure requeues
+    // again (retry_count=2). Both outcomes prove reclaim ran.
+    let task = poll_task_requeued_with_retry(&pool, task_id, POLL_SETTLE).await;
 
-    // Reclaim requeues the task (retry_count=1).  The worker's poll
-    // loop may subsequently re-dispatch it before we assert — the
-    // extraction stub fails, handle_stage_failure requeues again
-    // (retry_count=2).  Both outcomes prove reclaim ran.
+    token.cancel();
+    let _ = handle.await;
+
     assert_eq!(
         task.status(),
         TaskStatus::Queued,
         "task should be requeued after reclaim",
-    );
-    assert!(
-        task.retry_count() >= 1,
-        "retry count should be at least 1 (reclaim incremented it)",
     );
 
     teardown(ctx).await;
@@ -507,21 +503,16 @@ async fn test_reclaim_sweep_dead_letters_exhausted_task() {
     };
 
     let token = CancellationToken::new();
-    let worker = build_test_worker(pool, token.clone(), config, None, None);
-    run_worker_briefly(worker, token, POLL_SETTLE).await;
+    let worker = build_test_worker(pool.clone(), token.clone(), config, None, None);
+    let handle = {
+        let w = Arc::clone(&worker);
+        tokio::spawn(async move { w.run().await })
+    };
 
-    let mut conn = raw_conn(ctx).await;
+    let task = poll_task_status(&pool, task_id, TaskStatus::DeadLetter, POLL_SETTLE).await;
+    token.cancel();
+    let _ = handle.await;
 
-    let task = PgTaskRepository
-        .find_by_id(&mut conn, task_id)
-        .await
-        .expect("find task");
-
-    assert_eq!(
-        task.status(),
-        TaskStatus::DeadLetter,
-        "task should be dead-lettered",
-    );
     assert_eq!(
         task.error_kind(),
         Some(TaskErrorKind::HeartbeatExpired),
@@ -533,14 +524,8 @@ async fn test_reclaim_sweep_dead_letters_exhausted_task() {
         "error message should be heartbeat_expired",
     );
 
-    // The reclaim loop should have transitioned the parent job to
-    // Failed via fail_stale_dead_lettered_jobs.
-    let job = PgJobRepository
-        .find_by_id(&mut conn, job_id)
-        .await
-        .expect("find job");
+    let job = poll_job_status(&pool, job_id, JobStatus::Failed, POLL_SETTLE).await;
 
-    assert_eq!(job.status(), JobStatus::Failed, "job should be failed");
     assert_eq!(
         job.outcome(),
         Some(JobOutcome::Failure),
@@ -647,19 +632,16 @@ async fn test_heartbeat_detects_ownership_loss_mid_stage() {
 
     let config = WorkerConfig {
         max_concurrent_tasks: 1,
-        poll_interval_seconds: 1,
-        task_timeout_seconds: 60,
-        task_max_retries: 3,
-        heartbeat_interval_seconds: 1,
-        reclaim_interval_seconds: 120,
-        max_candidates_per_job: 20,
-        triage_search_limit: 10,
-        include_llm_content: false,
+        heartbeat_interval_millis: 100,
+        // Disable reclaim sweep so it does not interfere with the
+        // manual reclaim injection below.
+        reclaim_interval_millis: 120_000,
+        ..test_config()
     };
 
     let token = CancellationToken::new();
     let worker = build_test_worker(
-        pool,
+        pool.clone(),
         token.clone(),
         config,
         Some(inference as Arc<dyn InferenceProvider>),
@@ -673,14 +655,18 @@ async fn test_heartbeat_detects_ownership_loss_mid_stage() {
         tokio::spawn(async move { w.run().await })
     };
 
-    // Wait for the worker to claim and begin dispatching.  After the
-    // claim settle period the extraction stage should be blocked inside
-    // the long mock delay.
-    tokio::time::sleep(CLAIM_SETTLE).await;
-    assert!(
-        inference_ref.call_count() >= 1,
-        "extraction stage should have called the provider",
-    );
+    // Poll until the mock provider has been called, confirming the
+    // extraction stage is in-flight.
+    poll_until(
+        "provider called at least once",
+        Duration::from_millis(50),
+        CLAIM_SETTLE,
+        || {
+            let count = inference_ref.call_count();
+            async move { if count >= 1 { Some(()) } else { None } }
+        },
+    )
+    .await;
 
     // Simulate external reclaim: backdate the heartbeat far beyond the
     // timeout window, then call reclaim_stale to requeue the task.
@@ -707,8 +693,10 @@ async fn test_heartbeat_detects_ownership_loss_mid_stage() {
             .expect("reclaim stale");
     }
 
-    // Heartbeat interval is 1s — give it time to detect the loss.
-    tokio::time::sleep(HEARTBEAT_DETECT).await;
+    // Poll until the heartbeat detects ownership loss and the task
+    // is requeued.
+    poll_task_requeued_with_retry(&pool, task_id, HEARTBEAT_DETECT).await;
+
     token.cancel();
     let _ = worker_handle.await;
 
@@ -729,10 +717,6 @@ async fn test_heartbeat_detects_ownership_loss_mid_stage() {
         .await
         .expect("find task");
 
-    // The task retains the state set by reclaim_stale — Queued with
-    // retry_count incremented and error_kind=HeartbeatExpired.
-    // handle_stage_failure detected the claim_token mismatch (0 rows
-    // affected) and correctly declined to overwrite.
     assert!(
         task.retry_count() >= 1,
         "task should have been reclaimed at least once",
@@ -793,17 +777,22 @@ async fn test_extraction_happy_path() {
     );
 
     let token = CancellationToken::new();
-    let worker = build_test_worker(pool, token.clone(), test_config(), Some(inference), None);
-    run_worker_briefly(worker, token, POLL_SETTLE).await;
+    let worker = build_test_worker(
+        pool.clone(),
+        token.clone(),
+        test_config(),
+        Some(inference),
+        None,
+    );
+    let handle = {
+        let w = Arc::clone(&worker);
+        tokio::spawn(async move { w.run().await })
+    };
 
-    let mut conn = raw_conn(ctx).await;
+    let job = poll_job_status(&pool, job_id, JobStatus::Triaging, POLL_SETTLE).await;
+    token.cancel();
+    let _ = handle.await;
 
-    // Job should be Triaging with correct batch size.
-    let job = PgJobRepository
-        .find_by_id(&mut conn, job_id)
-        .await
-        .expect("find job");
-    assert_eq!(job.status(), JobStatus::Triaging, "job should be triaging");
     assert_eq!(job.batch_size(), Some(2), "batch_size should be 2");
     assert_eq!(
         job.extraction_original_count(),
@@ -812,6 +801,7 @@ async fn test_extraction_happy_path() {
     );
 
     // Extraction result should be persisted.
+    let mut conn = raw_conn(ctx).await;
     let extraction = PgExtractionResultRepository
         .find_by_job_id(&mut conn, job_id)
         .await
@@ -865,29 +855,32 @@ async fn test_extraction_zero_candidates() {
     );
 
     let token = CancellationToken::new();
-    let worker = build_test_worker(pool, token.clone(), test_config(), Some(inference), None);
-    run_worker_briefly(worker, token, POLL_SETTLE).await;
-
-    let mut conn = raw_conn(ctx).await;
-
-    let job = PgJobRepository
-        .find_by_id(&mut conn, job_id)
-        .await
-        .expect("find job");
-    assert_eq!(
-        job.status(),
-        JobStatus::Completed,
-        "job should be completed",
+    let worker = build_test_worker(
+        pool.clone(),
+        token.clone(),
+        test_config(),
+        Some(inference),
+        None,
     );
+    let handle = {
+        let w = Arc::clone(&worker);
+        tokio::spawn(async move { w.run().await })
+    };
+
+    let job = poll_job_status(&pool, job_id, JobStatus::Completed, POLL_SETTLE).await;
+    token.cancel();
+    let _ = handle.await;
+
     assert_eq!(
         job.outcome(),
         Some(JobOutcome::Empty),
         "outcome should be Empty",
     );
-    assert!(job.completed_at().is_some(), "completed_at should be set",);
+    assert!(job.completed_at().is_some(), "completed_at should be set");
     assert_eq!(job.batch_size(), Some(0), "batch_size should be 0");
 
     // No triage tasks should have been created.
+    let mut conn = raw_conn(ctx).await;
     let tasks = PgTaskRepository
         .find_by_job_id(&mut conn, job_id)
         .await
@@ -941,16 +934,16 @@ async fn test_extraction_capping() {
     };
 
     let token = CancellationToken::new();
-    let worker = build_test_worker(pool, token.clone(), config, Some(inference), None);
-    run_worker_briefly(worker, token, POLL_SETTLE).await;
+    let worker = build_test_worker(pool.clone(), token.clone(), config, Some(inference), None);
+    let handle = {
+        let w = Arc::clone(&worker);
+        tokio::spawn(async move { w.run().await })
+    };
 
-    let mut conn = raw_conn(ctx).await;
+    let job = poll_job_status(&pool, job_id, JobStatus::Triaging, POLL_SETTLE).await;
+    token.cancel();
+    let _ = handle.await;
 
-    let job = PgJobRepository
-        .find_by_id(&mut conn, job_id)
-        .await
-        .expect("find job");
-    assert_eq!(job.status(), JobStatus::Triaging, "job should be triaging");
     assert_eq!(
         job.batch_size(),
         Some(2),
@@ -963,6 +956,7 @@ async fn test_extraction_capping() {
     );
 
     // Only 2 triage tasks.
+    let mut conn = raw_conn(ctx).await;
     let tasks = PgTaskRepository
         .find_by_job_id(&mut conn, job_id)
         .await
@@ -1019,20 +1013,43 @@ async fn test_extraction_parse_failure() {
     );
 
     let token = CancellationToken::new();
-    let worker = build_test_worker(pool, token.clone(), test_config(), Some(inference), None);
-    run_worker_briefly(worker, token, POLL_SETTLE).await;
-
-    let mut conn = raw_conn(ctx).await;
-    let task = PgTaskRepository
-        .find_by_id(&mut conn, task_id)
-        .await
-        .expect("find task");
-
-    assert_eq!(
-        task.status(),
-        TaskStatus::Queued,
-        "task should be requeued after parse failure",
+    let worker = build_test_worker(
+        pool.clone(),
+        token.clone(),
+        test_config(),
+        Some(inference),
+        None,
     );
+    let handle = {
+        let w = Arc::clone(&worker);
+        tokio::spawn(async move { w.run().await })
+    };
+
+    // Poll for the task to be requeued with a ParseError.
+    let task = poll_until(
+        "task requeued with parse error",
+        Duration::from_millis(50),
+        POLL_SETTLE,
+        || {
+            let pool = pool.clone();
+            async move {
+                let mut conn = pool.acquire().await.ok()?;
+                let task = PgTaskRepository.find_by_id(&mut conn, task_id).await.ok()?;
+                if task.status() == TaskStatus::Queued
+                    && task.error_kind() == Some(TaskErrorKind::ParseError)
+                {
+                    Some(task)
+                } else {
+                    None
+                }
+            }
+        },
+    )
+    .await;
+
+    token.cancel();
+    let _ = handle.await;
+
     assert_eq!(
         task.error_kind(),
         Some(TaskErrorKind::ParseError),

--- a/crates/tribal-worker/tests/worker.rs
+++ b/crates/tribal-worker/tests/worker.rs
@@ -246,7 +246,7 @@ async fn test_retry_path_increments_retry_count() {
         tokio::spawn(async move { w.run().await })
     };
 
-    let task = poll_task_status(&pool, task_id, TaskStatus::Queued, POLL_SETTLE).await;
+    let task = poll_task_requeued_with_retry(&pool, task_id, POLL_SETTLE).await;
     token.cancel();
     let _ = handle.await;
 

--- a/crates/tribal-worker/tests/worker.rs
+++ b/crates/tribal-worker/tests/worker.rs
@@ -1,8 +1,8 @@
 //! Integration tests for the worker poll-claim-dispatch loop.
 //!
 //! Each test seeds data via committed raw connections (not pooled),
-//! constructs a [`Worker`] with mock providers (whose stubs always
-//! fail), runs the worker briefly, then asserts on task and job state.
+//! constructs a [`Worker`] with mock providers, runs the worker
+//! briefly, then asserts on task and job state.
 //!
 //! Tests are serialised via [`serial_lock`] because all workers claim
 //! from the same `tasks` table — parallel execution causes cross-test
@@ -18,8 +18,9 @@ use dashmap::DashMap;
 use tokio::sync::watch;
 use tokio_util::sync::CancellationToken;
 use tribal_db::{
-    JobRepository, PgJobRepository, PgPrincipalRepository, PgProjectRepository, PgTaskRepository,
-    PrincipalRepository, ProjectRepository, TaskRepository,
+    ExtractionResultRepository, JobRepository, PgExtractionResultRepository, PgJobRepository,
+    PgPrincipalRepository, PgProjectRepository, PgTaskRepository, PrincipalRepository,
+    ProjectRepository, TaskRepository,
 };
 use tribal_domain::{
     JobId, JobOutcome, JobStatus, PrincipalId, ProjectId, PromptVersionId, TaskErrorKind,
@@ -31,9 +32,9 @@ use tribal_inference::{
 };
 use tribal_test_utils::{
     ExhaustBehaviour, MockEmbeddingProvider, MockInferenceProvider, MockProviderOptions,
-    TestContext, a_completion_response, a_new_job, a_new_principal, a_new_project,
-    a_new_prompt_version, a_new_task, backdate_task_heartbeat, insert_prompt_version, serial_lock,
-    set_retry_count, test_context, truncate_all_tables,
+    TestContext, a_candidate, a_completion_response, a_new_job, a_new_principal, a_new_project,
+    a_new_prompt_version, a_new_task, a_relation_hint, backdate_task_heartbeat,
+    insert_prompt_version, serial_lock, set_retry_count, test_context, truncate_all_tables,
 };
 use tribal_worker::{Worker, WorkerConfig};
 
@@ -883,6 +884,436 @@ async fn test_heartbeat_detects_ownership_loss_mid_stage() {
         task.error_kind(),
         Some(TaskErrorKind::HeartbeatExpired),
         "error kind should reflect the reclaim",
+    );
+
+    teardown(ctx).await;
+}
+
+// ---------------------------------------------------------------------------
+// Extraction stage tests
+// ---------------------------------------------------------------------------
+
+/// Helper: builds an extraction-output JSON string from candidates and hints.
+fn extraction_response_json(
+    candidates: &[tribal_domain::Candidate],
+    hints: &[tribal_domain::RelationHint],
+) -> String {
+    serde_json::json!({
+        "candidates": serde_json::to_value(candidates).unwrap(),
+        "relation_hints": serde_json::to_value(hints).unwrap(),
+    })
+    .to_string()
+}
+
+/// Verifies the happy path: the extraction stage parses a multi-candidate
+/// response, creates triage tasks, persists an extraction result, and
+/// transitions the job to Triaging.
+#[tokio::test]
+async fn test_extraction_happy_path() {
+    let _guard = serial_lock().await;
+    let ctx = test_context().await;
+    let pool = ctx.create_pool().await.expect("create pool");
+
+    let (principal_id, project_id, pv_id) = setup_prerequisites(ctx, "extraction-happy").await;
+
+    let candidates = vec![
+        a_candidate().content("first".to_owned()).build(),
+        a_candidate().content("second".to_owned()).build(),
+    ];
+    let hints = vec![a_relation_hint().build()];
+    let response_json = extraction_response_json(&candidates, &hints);
+
+    let (job_id, _task_id) = {
+        let mut conn = raw_conn(ctx).await;
+        let job = PgJobRepository
+            .insert(
+                &mut conn,
+                &a_new_job()
+                    .project_id(project_id)
+                    .principal_id(principal_id)
+                    .extraction_prompt_version_id(pv_id)
+                    .triage_prompt_version_id(pv_id)
+                    .relation_prompt_version_id(pv_id)
+                    .build(),
+            )
+            .await
+            .expect("insert job");
+        let task = PgTaskRepository
+            .insert(
+                &mut conn,
+                &a_new_task()
+                    .job_id(job.id())
+                    .task_type(TaskType::Extraction)
+                    .build(),
+            )
+            .await
+            .expect("insert task");
+        (job.id(), task.id())
+    };
+
+    let inference: Arc<dyn InferenceProvider> = Arc::new(
+        MockInferenceProvider::builder()
+            .on_complete(a_completion_response(&response_json), None)
+            .on_exhaust(ExhaustBehaviour::RepeatLast)
+            .build(),
+    );
+
+    let token = CancellationToken::new();
+    let worker = build_test_worker(pool, token.clone(), test_config(), Some(inference), None);
+
+    let worker_handle = {
+        let w = Arc::clone(&worker);
+        tokio::spawn(async move { w.run().await })
+    };
+
+    tokio::time::sleep(std::time::Duration::from_secs(3)).await;
+    token.cancel();
+    let _ = worker_handle.await;
+
+    let mut conn = raw_conn(ctx).await;
+
+    // Job should be Triaging with correct batch size.
+    let job = PgJobRepository
+        .find_by_id(&mut conn, job_id)
+        .await
+        .expect("find job");
+    assert_eq!(job.status(), JobStatus::Triaging, "job should be triaging");
+    assert_eq!(job.batch_size(), Some(2), "batch_size should be 2");
+    assert_eq!(
+        job.extraction_original_count(),
+        Some(2),
+        "original count should be 2",
+    );
+
+    // Extraction result should be persisted.
+    let extraction = PgExtractionResultRepository
+        .find_by_job_id(&mut conn, job_id)
+        .await
+        .expect("find extraction result");
+    assert!(
+        extraction.is_some(),
+        "extraction result should be persisted",
+    );
+    let extraction = extraction.unwrap();
+    let persisted_candidates: Vec<serde_json::Value> =
+        serde_json::from_value(extraction.candidates().clone()).expect("parse candidates");
+    assert_eq!(persisted_candidates.len(), 2);
+
+    // Two triage tasks should exist.
+    let tasks = PgTaskRepository
+        .find_by_job_id(&mut conn, job_id)
+        .await
+        .expect("find tasks");
+    let triage_tasks: Vec<_> = tasks
+        .iter()
+        .filter(|t| t.task_type() == TaskType::Triage)
+        .collect();
+    assert_eq!(triage_tasks.len(), 2, "should create 2 triage tasks");
+
+    teardown(ctx).await;
+}
+
+/// Verifies that zero candidates causes the job to complete immediately
+/// with an Empty outcome, and no triage tasks are created.
+#[tokio::test]
+async fn test_extraction_zero_candidates() {
+    let _guard = serial_lock().await;
+    let ctx = test_context().await;
+    let pool = ctx.create_pool().await.expect("create pool");
+
+    let (principal_id, project_id, pv_id) =
+        setup_prerequisites(ctx, "extraction-zero-candidates").await;
+
+    let response_json = extraction_response_json(&[], &[]);
+
+    let (job_id, _task_id) = {
+        let mut conn = raw_conn(ctx).await;
+        let job = PgJobRepository
+            .insert(
+                &mut conn,
+                &a_new_job()
+                    .project_id(project_id)
+                    .principal_id(principal_id)
+                    .extraction_prompt_version_id(pv_id)
+                    .triage_prompt_version_id(pv_id)
+                    .relation_prompt_version_id(pv_id)
+                    .build(),
+            )
+            .await
+            .expect("insert job");
+        let task = PgTaskRepository
+            .insert(
+                &mut conn,
+                &a_new_task()
+                    .job_id(job.id())
+                    .task_type(TaskType::Extraction)
+                    .build(),
+            )
+            .await
+            .expect("insert task");
+        (job.id(), task.id())
+    };
+
+    let inference: Arc<dyn InferenceProvider> = Arc::new(
+        MockInferenceProvider::builder()
+            .on_complete(a_completion_response(&response_json), None)
+            .on_exhaust(ExhaustBehaviour::RepeatLast)
+            .build(),
+    );
+
+    let token = CancellationToken::new();
+    let worker = build_test_worker(pool, token.clone(), test_config(), Some(inference), None);
+
+    let worker_handle = {
+        let w = Arc::clone(&worker);
+        tokio::spawn(async move { w.run().await })
+    };
+
+    tokio::time::sleep(std::time::Duration::from_secs(3)).await;
+    token.cancel();
+    let _ = worker_handle.await;
+
+    let mut conn = raw_conn(ctx).await;
+
+    let job = PgJobRepository
+        .find_by_id(&mut conn, job_id)
+        .await
+        .expect("find job");
+    assert_eq!(
+        job.status(),
+        JobStatus::Completed,
+        "job should be completed",
+    );
+    assert_eq!(
+        job.outcome(),
+        Some(JobOutcome::Empty),
+        "outcome should be Empty",
+    );
+    assert!(
+        job.completed_at().is_some(),
+        "completed_at should be set",
+    );
+    assert_eq!(job.batch_size(), Some(0), "batch_size should be 0");
+
+    // No triage tasks should have been created.
+    let tasks = PgTaskRepository
+        .find_by_job_id(&mut conn, job_id)
+        .await
+        .expect("find tasks");
+    let triage_tasks: Vec<_> = tasks
+        .iter()
+        .filter(|t| t.task_type() == TaskType::Triage)
+        .collect();
+    assert!(triage_tasks.is_empty(), "should create no triage tasks");
+
+    teardown(ctx).await;
+}
+
+/// Verifies that candidates exceeding `max_candidates_per_job` are
+/// capped, relation hints referencing out-of-range indices are
+/// filtered, and the original count reflects the pre-cap total.
+#[tokio::test]
+async fn test_extraction_capping() {
+    let _guard = serial_lock().await;
+    let ctx = test_context().await;
+    let pool = ctx.create_pool().await.expect("create pool");
+
+    let (principal_id, project_id, pv_id) =
+        setup_prerequisites(ctx, "extraction-capping").await;
+
+    // Build 5 candidates and hints that span all 5 indices.
+    let candidates: Vec<_> = (0..5)
+        .map(|i| a_candidate().content(format!("candidate {i}")).build())
+        .collect();
+    let hints = vec![
+        a_relation_hint()
+            .source_index(0)
+            .target_index(1)
+            .build(),
+        a_relation_hint()
+            .source_index(2)
+            .target_index(4)
+            .build(),
+    ];
+    let response_json = extraction_response_json(&candidates, &hints);
+
+    let (job_id, _task_id) = {
+        let mut conn = raw_conn(ctx).await;
+        let job = PgJobRepository
+            .insert(
+                &mut conn,
+                &a_new_job()
+                    .project_id(project_id)
+                    .principal_id(principal_id)
+                    .extraction_prompt_version_id(pv_id)
+                    .triage_prompt_version_id(pv_id)
+                    .relation_prompt_version_id(pv_id)
+                    .build(),
+            )
+            .await
+            .expect("insert job");
+        let task = PgTaskRepository
+            .insert(
+                &mut conn,
+                &a_new_task()
+                    .job_id(job.id())
+                    .task_type(TaskType::Extraction)
+                    .build(),
+            )
+            .await
+            .expect("insert task");
+        (job.id(), task.id())
+    };
+
+    let inference: Arc<dyn InferenceProvider> = Arc::new(
+        MockInferenceProvider::builder()
+            .on_complete(a_completion_response(&response_json), None)
+            .on_exhaust(ExhaustBehaviour::RepeatLast)
+            .build(),
+    );
+
+    // Cap at 2 candidates.
+    let config = WorkerConfig {
+        max_candidates_per_job: 2,
+        ..test_config()
+    };
+
+    let token = CancellationToken::new();
+    let worker = build_test_worker(pool, token.clone(), config, Some(inference), None);
+
+    let worker_handle = {
+        let w = Arc::clone(&worker);
+        tokio::spawn(async move { w.run().await })
+    };
+
+    tokio::time::sleep(std::time::Duration::from_secs(3)).await;
+    token.cancel();
+    let _ = worker_handle.await;
+
+    let mut conn = raw_conn(ctx).await;
+
+    let job = PgJobRepository
+        .find_by_id(&mut conn, job_id)
+        .await
+        .expect("find job");
+    assert_eq!(job.status(), JobStatus::Triaging, "job should be triaging");
+    assert_eq!(job.batch_size(), Some(2), "batch_size should be capped to 2");
+    assert_eq!(
+        job.extraction_original_count(),
+        Some(5),
+        "original count should reflect pre-cap total of 5",
+    );
+
+    // Only 2 triage tasks.
+    let tasks = PgTaskRepository
+        .find_by_job_id(&mut conn, job_id)
+        .await
+        .expect("find tasks");
+    let triage_tasks: Vec<_> = tasks
+        .iter()
+        .filter(|t| t.task_type() == TaskType::Triage)
+        .collect();
+    assert_eq!(triage_tasks.len(), 2, "should create 2 triage tasks");
+
+    // Relation hints should be filtered: hint (0,1) is within range,
+    // hint (2,4) is out of range for batch_size=2.
+    let extraction = PgExtractionResultRepository
+        .find_by_job_id(&mut conn, job_id)
+        .await
+        .expect("find extraction result")
+        .expect("extraction result should exist");
+    let persisted_hints: Vec<serde_json::Value> =
+        serde_json::from_value(extraction.relation_hints().clone()).expect("parse hints");
+    assert_eq!(
+        persisted_hints.len(),
+        1,
+        "only hint within capped range should be persisted",
+    );
+
+    teardown(ctx).await;
+}
+
+/// Verifies that an unparseable LLM response causes the extraction
+/// task to be requeued with a ParseError error kind.
+#[tokio::test]
+async fn test_extraction_parse_failure() {
+    let _guard = serial_lock().await;
+    let ctx = test_context().await;
+    let pool = ctx.create_pool().await.expect("create pool");
+
+    let (principal_id, project_id, pv_id) =
+        setup_prerequisites(ctx, "extraction-parse-failure").await;
+
+    let (_job_id, task_id) = {
+        let mut conn = raw_conn(ctx).await;
+        let job = PgJobRepository
+            .insert(
+                &mut conn,
+                &a_new_job()
+                    .project_id(project_id)
+                    .principal_id(principal_id)
+                    .extraction_prompt_version_id(pv_id)
+                    .triage_prompt_version_id(pv_id)
+                    .relation_prompt_version_id(pv_id)
+                    .build(),
+            )
+            .await
+            .expect("insert job");
+        let task = PgTaskRepository
+            .insert(
+                &mut conn,
+                &a_new_task()
+                    .job_id(job.id())
+                    .task_type(TaskType::Extraction)
+                    .build(),
+            )
+            .await
+            .expect("insert task");
+        (job.id(), task.id())
+    };
+
+    // Return text that is not valid ExtractionOutput JSON.
+    let inference: Arc<dyn InferenceProvider> = Arc::new(
+        MockInferenceProvider::builder()
+            .on_complete(
+                a_completion_response("this is not valid json for extraction"),
+                None,
+            )
+            .on_exhaust(ExhaustBehaviour::RepeatLast)
+            .build(),
+    );
+
+    let token = CancellationToken::new();
+    let worker = build_test_worker(pool, token.clone(), test_config(), Some(inference), None);
+
+    let worker_handle = {
+        let w = Arc::clone(&worker);
+        tokio::spawn(async move { w.run().await })
+    };
+
+    tokio::time::sleep(std::time::Duration::from_secs(3)).await;
+    token.cancel();
+    let _ = worker_handle.await;
+
+    let mut conn = raw_conn(ctx).await;
+    let task = PgTaskRepository
+        .find_by_id(&mut conn, task_id)
+        .await
+        .expect("find task");
+
+    assert_eq!(
+        task.status(),
+        TaskStatus::Queued,
+        "task should be requeued after parse failure",
+    );
+    assert_eq!(
+        task.error_kind(),
+        Some(TaskErrorKind::ParseError),
+        "error kind should be parse_error",
+    );
+    assert!(
+        task.error_message().is_some(),
+        "error message should be set",
     );
 
     teardown(ctx).await;

--- a/crates/tribal-worker/tests/worker.rs
+++ b/crates/tribal-worker/tests/worker.rs
@@ -12,7 +12,7 @@
 //! rather than pool connections to avoid the `PoolConnection::drop`
 //! spawn issue that leaks connections across serialised tests.
 
-use std::sync::Arc;
+use std::{sync::Arc, time::Duration};
 
 use dashmap::DashMap;
 use tokio::sync::watch;
@@ -34,7 +34,12 @@ use tribal_test_utils::{
     ExhaustBehaviour, MockEmbeddingProvider, MockInferenceProvider, MockProviderOptions,
     TestContext, a_candidate, a_completion_response, a_new_job, a_new_principal, a_new_project,
     a_new_prompt_version, a_new_task, a_relation_hint, backdate_task_heartbeat,
-    insert_prompt_version, serial_lock, set_retry_count, test_context, truncate_all_tables,
+    duration::{
+        CLAIM_SETTLE, EARLY_ABORT_BOUND, HEARTBEAT_DETECT, LONG_PROVIDER_DELAY, MULTI_CYCLE_SETTLE,
+        POLL_SETTLE, STALE_HEARTBEAT_BACKDATE,
+    },
+    insert_prompt_version, seed_extraction_job, serial_lock, set_retry_count, test_context,
+    truncate_all_tables,
 };
 use tribal_worker::{Worker, WorkerConfig};
 
@@ -169,6 +174,18 @@ fn build_test_worker(
     ))
 }
 
+/// Spawns a worker, lets it run for the given settle duration, then
+/// cancels and awaits shutdown.
+async fn run_worker_briefly(worker: Arc<Worker>, token: CancellationToken, settle: Duration) {
+    let handle = {
+        let w = Arc::clone(&worker);
+        tokio::spawn(async move { w.run().await })
+    };
+    tokio::time::sleep(settle).await;
+    token.cancel();
+    let _ = handle.await;
+}
+
 /// Returns a [`WorkerConfig`] with aggressive timeouts for fast tests.
 fn test_config() -> WorkerConfig {
     WorkerConfig {
@@ -201,43 +218,12 @@ async fn test_retry_path_increments_retry_count() {
 
     let (job_id, task_id) = {
         let mut conn = raw_conn(ctx).await;
-        let job = PgJobRepository
-            .insert(
-                &mut conn,
-                &a_new_job()
-                    .project_id(project_id)
-                    .principal_id(principal_id)
-                    .extraction_prompt_version_id(pv_id)
-                    .triage_prompt_version_id(pv_id)
-                    .relation_prompt_version_id(pv_id)
-                    .build(),
-            )
-            .await
-            .expect("insert job");
-        let task = PgTaskRepository
-            .insert(
-                &mut conn,
-                &a_new_task()
-                    .job_id(job.id())
-                    .task_type(TaskType::Extraction)
-                    .build(),
-            )
-            .await
-            .expect("insert task");
-        (job.id(), task.id())
+        seed_extraction_job(&mut conn, principal_id, project_id, pv_id).await
     };
 
     let token = CancellationToken::new();
     let worker = build_test_worker(pool, token.clone(), test_config(), None, None);
-
-    let worker_handle = {
-        let w = Arc::clone(&worker);
-        tokio::spawn(async move { w.run().await })
-    };
-
-    tokio::time::sleep(std::time::Duration::from_secs(3)).await;
-    token.cancel();
-    let _ = worker_handle.await;
+    run_worker_briefly(worker, token, POLL_SETTLE).await;
 
     let mut conn = raw_conn(ctx).await;
     let task = PgTaskRepository
@@ -291,48 +277,19 @@ async fn test_dead_letter_path_transitions_task_and_job() {
 
     let (job_id, task_id) = {
         let mut conn = raw_conn(ctx).await;
-        let job = PgJobRepository
-            .insert(
-                &mut conn,
-                &a_new_job()
-                    .project_id(project_id)
-                    .principal_id(principal_id)
-                    .extraction_prompt_version_id(pv_id)
-                    .triage_prompt_version_id(pv_id)
-                    .relation_prompt_version_id(pv_id)
-                    .build(),
-            )
-            .await
-            .expect("insert job");
-        let task = PgTaskRepository
-            .insert(
-                &mut conn,
-                &a_new_task()
-                    .job_id(job.id())
-                    .task_type(TaskType::Extraction)
-                    .build(),
-            )
-            .await
-            .expect("insert task");
+        let (job_id, task_id) =
+            seed_extraction_job(&mut conn, principal_id, project_id, pv_id).await;
 
         // Pre-set retry_count to max_retries so the next failure
         // triggers dead-lettering.
-        set_retry_count(&mut conn, task.id(), config.task_max_retries).await;
+        set_retry_count(&mut conn, task_id, config.task_max_retries).await;
 
-        (job.id(), task.id())
+        (job_id, task_id)
     };
 
     let token = CancellationToken::new();
     let worker = build_test_worker(pool, token.clone(), config, None, None);
-
-    let worker_handle = {
-        let w = Arc::clone(&worker);
-        tokio::spawn(async move { w.run().await })
-    };
-
-    tokio::time::sleep(std::time::Duration::from_secs(3)).await;
-    token.cancel();
-    let _ = worker_handle.await;
+    run_worker_briefly(worker, token, POLL_SETTLE).await;
 
     let mut conn = raw_conn(ctx).await;
 
@@ -440,7 +397,7 @@ async fn test_concurrency_limit_respected() {
     };
 
     // Let the worker run through a couple of cycles.
-    tokio::time::sleep(std::time::Duration::from_secs(4)).await;
+    tokio::time::sleep(MULTI_CYCLE_SETTLE).await;
     token.cancel();
     let _ = worker_handle.await;
 
@@ -472,29 +429,8 @@ async fn test_reclaim_sweep_requeues_stale_heartbeat_task() {
 
     let task_id = {
         let mut conn = raw_conn(ctx).await;
-        let job = PgJobRepository
-            .insert(
-                &mut conn,
-                &a_new_job()
-                    .project_id(project_id)
-                    .principal_id(principal_id)
-                    .extraction_prompt_version_id(pv_id)
-                    .triage_prompt_version_id(pv_id)
-                    .relation_prompt_version_id(pv_id)
-                    .build(),
-            )
-            .await
-            .expect("insert job");
-        let task = PgTaskRepository
-            .insert(
-                &mut conn,
-                &a_new_task()
-                    .job_id(job.id())
-                    .task_type(TaskType::Extraction)
-                    .build(),
-            )
-            .await
-            .expect("insert task");
+        let (_job_id, task_id) =
+            seed_extraction_job(&mut conn, principal_id, project_id, pv_id).await;
 
         // Claim the task via the repository (simulating a previous
         // worker instance) and immediately backdate the heartbeat
@@ -505,24 +441,15 @@ async fn test_reclaim_sweep_requeues_stale_heartbeat_task() {
             .expect("claim");
         assert_eq!(claimed.len(), 1);
 
-        backdate_task_heartbeat(&mut conn, task.id(), std::time::Duration::from_secs(120)).await;
+        backdate_task_heartbeat(&mut conn, task_id, STALE_HEARTBEAT_BACKDATE).await;
 
-        task.id()
+        task_id
     };
 
     let config = test_config();
     let token = CancellationToken::new();
     let worker = build_test_worker(pool, token.clone(), config, None, None);
-
-    let worker_handle = {
-        let w = Arc::clone(&worker);
-        tokio::spawn(async move { w.run().await })
-    };
-
-    // Let the reclaim loop run (reclaim_interval = 1s in test config).
-    tokio::time::sleep(std::time::Duration::from_secs(3)).await;
-    token.cancel();
-    let _ = worker_handle.await;
+    run_worker_briefly(worker, token, POLL_SETTLE).await;
 
     let mut conn = raw_conn(ctx).await;
     let task = PgTaskRepository
@@ -560,33 +487,12 @@ async fn test_reclaim_sweep_dead_letters_exhausted_task() {
 
     let (job_id, task_id) = {
         let mut conn = raw_conn(ctx).await;
-        let job = PgJobRepository
-            .insert(
-                &mut conn,
-                &a_new_job()
-                    .project_id(project_id)
-                    .principal_id(principal_id)
-                    .extraction_prompt_version_id(pv_id)
-                    .triage_prompt_version_id(pv_id)
-                    .relation_prompt_version_id(pv_id)
-                    .build(),
-            )
-            .await
-            .expect("insert job");
-        let task = PgTaskRepository
-            .insert(
-                &mut conn,
-                &a_new_task()
-                    .job_id(job.id())
-                    .task_type(TaskType::Extraction)
-                    .build(),
-            )
-            .await
-            .expect("insert task");
+        let (job_id, task_id) =
+            seed_extraction_job(&mut conn, principal_id, project_id, pv_id).await;
 
         // Pre-set retry_count to max_retries so reclaim triggers
         // dead-lettering.
-        set_retry_count(&mut conn, task.id(), config.task_max_retries).await;
+        set_retry_count(&mut conn, task_id, config.task_max_retries).await;
 
         // Claim and backdate heartbeat.
         let claimed = PgTaskRepository
@@ -595,22 +501,14 @@ async fn test_reclaim_sweep_dead_letters_exhausted_task() {
             .expect("claim");
         assert_eq!(claimed.len(), 1);
 
-        backdate_task_heartbeat(&mut conn, task.id(), std::time::Duration::from_secs(120)).await;
+        backdate_task_heartbeat(&mut conn, task_id, STALE_HEARTBEAT_BACKDATE).await;
 
-        (job.id(), task.id())
+        (job_id, task_id)
     };
 
     let token = CancellationToken::new();
     let worker = build_test_worker(pool, token.clone(), config, None, None);
-
-    let worker_handle = {
-        let w = Arc::clone(&worker);
-        tokio::spawn(async move { w.run().await })
-    };
-
-    tokio::time::sleep(std::time::Duration::from_secs(3)).await;
-    token.cancel();
-    let _ = worker_handle.await;
+    run_worker_briefly(worker, token, POLL_SETTLE).await;
 
     let mut conn = raw_conn(ctx).await;
 
@@ -664,29 +562,8 @@ async fn test_startup_reclaim_recovers_orphaned_task() {
 
     let task_id = {
         let mut conn = raw_conn(ctx).await;
-        let job = PgJobRepository
-            .insert(
-                &mut conn,
-                &a_new_job()
-                    .project_id(project_id)
-                    .principal_id(principal_id)
-                    .extraction_prompt_version_id(pv_id)
-                    .triage_prompt_version_id(pv_id)
-                    .relation_prompt_version_id(pv_id)
-                    .build(),
-            )
-            .await
-            .expect("insert job");
-        let task = PgTaskRepository
-            .insert(
-                &mut conn,
-                &a_new_task()
-                    .job_id(job.id())
-                    .task_type(TaskType::Extraction)
-                    .build(),
-            )
-            .await
-            .expect("insert task");
+        let (_job_id, task_id) =
+            seed_extraction_job(&mut conn, principal_id, project_id, pv_id).await;
 
         // Claim and backdate heartbeat (simulating crash).
         let claimed = PgTaskRepository
@@ -695,9 +572,9 @@ async fn test_startup_reclaim_recovers_orphaned_task() {
             .expect("claim");
         assert_eq!(claimed.len(), 1);
 
-        backdate_task_heartbeat(&mut conn, task.id(), std::time::Duration::from_secs(120)).await;
+        backdate_task_heartbeat(&mut conn, task_id, STALE_HEARTBEAT_BACKDATE).await;
 
-        task.id()
+        task_id
     };
 
     let config = test_config();
@@ -748,30 +625,9 @@ async fn test_heartbeat_detects_ownership_loss_mid_stage() {
 
     let task_id = {
         let mut conn = raw_conn(ctx).await;
-        let job = PgJobRepository
-            .insert(
-                &mut conn,
-                &a_new_job()
-                    .project_id(project_id)
-                    .principal_id(principal_id)
-                    .extraction_prompt_version_id(pv_id)
-                    .triage_prompt_version_id(pv_id)
-                    .relation_prompt_version_id(pv_id)
-                    .build(),
-            )
-            .await
-            .expect("insert job");
-        let task = PgTaskRepository
-            .insert(
-                &mut conn,
-                &a_new_task()
-                    .job_id(job.id())
-                    .task_type(TaskType::Extraction)
-                    .build(),
-            )
-            .await
-            .expect("insert task");
-        task.id()
+        let (_job_id, task_id) =
+            seed_extraction_job(&mut conn, principal_id, project_id, pv_id).await;
+        task_id
     };
 
     // Mock with a long delay keeps the extraction stage in-flight long
@@ -781,7 +637,7 @@ async fn test_heartbeat_detects_ownership_loss_mid_stage() {
             .on_complete(
                 a_completion_response("delayed"),
                 Some(MockProviderOptions {
-                    delay: Some(std::time::Duration::from_secs(30)),
+                    delay: Some(LONG_PROVIDER_DELAY),
                 }),
             )
             .on_exhaust(ExhaustBehaviour::RepeatLast)
@@ -817,9 +673,10 @@ async fn test_heartbeat_detects_ownership_loss_mid_stage() {
         tokio::spawn(async move { w.run().await })
     };
 
-    // Wait for the worker to claim and begin dispatching.  After 2s
-    // the extraction stage should be blocked inside the 30s mock delay.
-    tokio::time::sleep(std::time::Duration::from_secs(2)).await;
+    // Wait for the worker to claim and begin dispatching.  After the
+    // claim settle period the extraction stage should be blocked inside
+    // the long mock delay.
+    tokio::time::sleep(CLAIM_SETTLE).await;
     assert!(
         inference_ref.call_count() >= 1,
         "extraction stage should have called the provider",
@@ -831,7 +688,7 @@ async fn test_heartbeat_detects_ownership_loss_mid_stage() {
     // return 0 rows and fire the ownership_lost signal.
     {
         let mut conn = raw_conn(ctx).await;
-        backdate_task_heartbeat(&mut conn, task_id, std::time::Duration::from_secs(120)).await;
+        backdate_task_heartbeat(&mut conn, task_id, STALE_HEARTBEAT_BACKDATE).await;
 
         // Use a large flat backoff so the requeued task's available_at
         // is far in the future, preventing the worker's poll loop from
@@ -851,18 +708,18 @@ async fn test_heartbeat_detects_ownership_loss_mid_stage() {
     }
 
     // Heartbeat interval is 1s — give it time to detect the loss.
-    tokio::time::sleep(std::time::Duration::from_secs(3)).await;
+    tokio::time::sleep(HEARTBEAT_DETECT).await;
     token.cancel();
     let _ = worker_handle.await;
 
     let elapsed = start.elapsed();
 
-    // If ownership loss was NOT detected, the 30s mock delay would
+    // If ownership loss was NOT detected, the long mock delay would
     // have to complete before the worker moved on.  The total test
-    // time being well under 30s proves the heartbeat interrupted the
-    // stage early.
+    // time being well under the delay proves the heartbeat interrupted
+    // the stage early.
     assert!(
-        elapsed < std::time::Duration::from_secs(15),
+        elapsed < EARLY_ABORT_BOUND,
         "expected ownership loss to abort the stage early, but test took {elapsed:?}",
     );
 
@@ -925,30 +782,7 @@ async fn test_extraction_happy_path() {
 
     let (job_id, _task_id) = {
         let mut conn = raw_conn(ctx).await;
-        let job = PgJobRepository
-            .insert(
-                &mut conn,
-                &a_new_job()
-                    .project_id(project_id)
-                    .principal_id(principal_id)
-                    .extraction_prompt_version_id(pv_id)
-                    .triage_prompt_version_id(pv_id)
-                    .relation_prompt_version_id(pv_id)
-                    .build(),
-            )
-            .await
-            .expect("insert job");
-        let task = PgTaskRepository
-            .insert(
-                &mut conn,
-                &a_new_task()
-                    .job_id(job.id())
-                    .task_type(TaskType::Extraction)
-                    .build(),
-            )
-            .await
-            .expect("insert task");
-        (job.id(), task.id())
+        seed_extraction_job(&mut conn, principal_id, project_id, pv_id).await
     };
 
     let inference: Arc<dyn InferenceProvider> = Arc::new(
@@ -960,15 +794,7 @@ async fn test_extraction_happy_path() {
 
     let token = CancellationToken::new();
     let worker = build_test_worker(pool, token.clone(), test_config(), Some(inference), None);
-
-    let worker_handle = {
-        let w = Arc::clone(&worker);
-        tokio::spawn(async move { w.run().await })
-    };
-
-    tokio::time::sleep(std::time::Duration::from_secs(3)).await;
-    token.cancel();
-    let _ = worker_handle.await;
+    run_worker_briefly(worker, token, POLL_SETTLE).await;
 
     let mut conn = raw_conn(ctx).await;
 
@@ -1028,30 +854,7 @@ async fn test_extraction_zero_candidates() {
 
     let (job_id, _task_id) = {
         let mut conn = raw_conn(ctx).await;
-        let job = PgJobRepository
-            .insert(
-                &mut conn,
-                &a_new_job()
-                    .project_id(project_id)
-                    .principal_id(principal_id)
-                    .extraction_prompt_version_id(pv_id)
-                    .triage_prompt_version_id(pv_id)
-                    .relation_prompt_version_id(pv_id)
-                    .build(),
-            )
-            .await
-            .expect("insert job");
-        let task = PgTaskRepository
-            .insert(
-                &mut conn,
-                &a_new_task()
-                    .job_id(job.id())
-                    .task_type(TaskType::Extraction)
-                    .build(),
-            )
-            .await
-            .expect("insert task");
-        (job.id(), task.id())
+        seed_extraction_job(&mut conn, principal_id, project_id, pv_id).await
     };
 
     let inference: Arc<dyn InferenceProvider> = Arc::new(
@@ -1063,15 +866,7 @@ async fn test_extraction_zero_candidates() {
 
     let token = CancellationToken::new();
     let worker = build_test_worker(pool, token.clone(), test_config(), Some(inference), None);
-
-    let worker_handle = {
-        let w = Arc::clone(&worker);
-        tokio::spawn(async move { w.run().await })
-    };
-
-    tokio::time::sleep(std::time::Duration::from_secs(3)).await;
-    token.cancel();
-    let _ = worker_handle.await;
+    run_worker_briefly(worker, token, POLL_SETTLE).await;
 
     let mut conn = raw_conn(ctx).await;
 
@@ -1089,10 +884,7 @@ async fn test_extraction_zero_candidates() {
         Some(JobOutcome::Empty),
         "outcome should be Empty",
     );
-    assert!(
-        job.completed_at().is_some(),
-        "completed_at should be set",
-    );
+    assert!(job.completed_at().is_some(), "completed_at should be set",);
     assert_eq!(job.batch_size(), Some(0), "batch_size should be 0");
 
     // No triage tasks should have been created.
@@ -1118,51 +910,21 @@ async fn test_extraction_capping() {
     let ctx = test_context().await;
     let pool = ctx.create_pool().await.expect("create pool");
 
-    let (principal_id, project_id, pv_id) =
-        setup_prerequisites(ctx, "extraction-capping").await;
+    let (principal_id, project_id, pv_id) = setup_prerequisites(ctx, "extraction-capping").await;
 
     // Build 5 candidates and hints that span all 5 indices.
     let candidates: Vec<_> = (0..5)
         .map(|i| a_candidate().content(format!("candidate {i}")).build())
         .collect();
     let hints = vec![
-        a_relation_hint()
-            .source_index(0)
-            .target_index(1)
-            .build(),
-        a_relation_hint()
-            .source_index(2)
-            .target_index(4)
-            .build(),
+        a_relation_hint().source_index(0).target_index(1).build(),
+        a_relation_hint().source_index(2).target_index(4).build(),
     ];
     let response_json = extraction_response_json(&candidates, &hints);
 
     let (job_id, _task_id) = {
         let mut conn = raw_conn(ctx).await;
-        let job = PgJobRepository
-            .insert(
-                &mut conn,
-                &a_new_job()
-                    .project_id(project_id)
-                    .principal_id(principal_id)
-                    .extraction_prompt_version_id(pv_id)
-                    .triage_prompt_version_id(pv_id)
-                    .relation_prompt_version_id(pv_id)
-                    .build(),
-            )
-            .await
-            .expect("insert job");
-        let task = PgTaskRepository
-            .insert(
-                &mut conn,
-                &a_new_task()
-                    .job_id(job.id())
-                    .task_type(TaskType::Extraction)
-                    .build(),
-            )
-            .await
-            .expect("insert task");
-        (job.id(), task.id())
+        seed_extraction_job(&mut conn, principal_id, project_id, pv_id).await
     };
 
     let inference: Arc<dyn InferenceProvider> = Arc::new(
@@ -1180,15 +942,7 @@ async fn test_extraction_capping() {
 
     let token = CancellationToken::new();
     let worker = build_test_worker(pool, token.clone(), config, Some(inference), None);
-
-    let worker_handle = {
-        let w = Arc::clone(&worker);
-        tokio::spawn(async move { w.run().await })
-    };
-
-    tokio::time::sleep(std::time::Duration::from_secs(3)).await;
-    token.cancel();
-    let _ = worker_handle.await;
+    run_worker_briefly(worker, token, POLL_SETTLE).await;
 
     let mut conn = raw_conn(ctx).await;
 
@@ -1197,7 +951,11 @@ async fn test_extraction_capping() {
         .await
         .expect("find job");
     assert_eq!(job.status(), JobStatus::Triaging, "job should be triaging");
-    assert_eq!(job.batch_size(), Some(2), "batch_size should be capped to 2");
+    assert_eq!(
+        job.batch_size(),
+        Some(2),
+        "batch_size should be capped to 2"
+    );
     assert_eq!(
         job.extraction_original_count(),
         Some(5),
@@ -1246,30 +1004,7 @@ async fn test_extraction_parse_failure() {
 
     let (_job_id, task_id) = {
         let mut conn = raw_conn(ctx).await;
-        let job = PgJobRepository
-            .insert(
-                &mut conn,
-                &a_new_job()
-                    .project_id(project_id)
-                    .principal_id(principal_id)
-                    .extraction_prompt_version_id(pv_id)
-                    .triage_prompt_version_id(pv_id)
-                    .relation_prompt_version_id(pv_id)
-                    .build(),
-            )
-            .await
-            .expect("insert job");
-        let task = PgTaskRepository
-            .insert(
-                &mut conn,
-                &a_new_task()
-                    .job_id(job.id())
-                    .task_type(TaskType::Extraction)
-                    .build(),
-            )
-            .await
-            .expect("insert task");
-        (job.id(), task.id())
+        seed_extraction_job(&mut conn, principal_id, project_id, pv_id).await
     };
 
     // Return text that is not valid ExtractionOutput JSON.
@@ -1285,15 +1020,7 @@ async fn test_extraction_parse_failure() {
 
     let token = CancellationToken::new();
     let worker = build_test_worker(pool, token.clone(), test_config(), Some(inference), None);
-
-    let worker_handle = {
-        let w = Arc::clone(&worker);
-        tokio::spawn(async move { w.run().await })
-    };
-
-    tokio::time::sleep(std::time::Duration::from_secs(3)).await;
-    token.cancel();
-    let _ = worker_handle.await;
+    run_worker_briefly(worker, token, POLL_SETTLE).await;
 
     let mut conn = raw_conn(ctx).await;
     let task = PgTaskRepository

--- a/prompts/extraction.tera
+++ b/prompts/extraction.tera
@@ -17,6 +17,4 @@ The following tags already exist in the registry. Prefer reusing these where app
 
 Respond with valid JSON matching this schema:
 
-{% raw %}{{% endraw %}
 {{ schema }}
-{% raw %}}{% endraw %}

--- a/prompts/extraction.tera
+++ b/prompts/extraction.tera
@@ -1,0 +1,22 @@
+You are a knowledge extraction agent. Analyse the user's input and extract structured knowledge items as candidates.
+
+Each candidate must include:
+- kind: one of "fact", "heuristic", "procedure", "decision_record"
+- content: a clear, self-contained knowledge statement
+- suggested_tags: relevant categorisation tags for the knowledge item
+- suggested_references: optional external references (each with reference_type, value, and optional description)
+
+If two candidates have a derivation relationship (one is derived from the other), include a relation_hint with the source and target indices.
+
+{% if tags | length > 0 %}
+The following tags already exist in the registry. Prefer reusing these where appropriate rather than inventing new ones:
+{% for tag in tags %}
+- {{ tag }}
+{% endfor %}
+{% endif %}
+
+Respond with valid JSON matching this schema:
+
+{% raw %}{{% endraw %}
+{{ schema }}
+{% raw %}}{% endraw %}


### PR DESCRIPTION
Implements the extraction stage of the write path pipeline, as per designs.

Refactors worker integration tests to use a polling approach for status transitions to eliminate flakes and keep test times down (60% decrease!)

Adds `TaskErrorKind::InternalError`, refactors worker config to use millisecond precision, amongst some other good stuff.

Adds basic template for extraction LLM call—will iterate later on.

Closes tribal-memory/cortex#85.