### PR TITLE
[CHORE] Bump version to 0.1.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4844,7 +4844,7 @@ dependencies = [
 
 [[package]]
 name = "tribal"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "axum",
  "base64 0.22.1",
@@ -4886,7 +4886,7 @@ dependencies = [
 
 [[package]]
 name = "tribal-common"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "dashmap",
  "rand 0.10.1",
@@ -4897,7 +4897,7 @@ dependencies = [
 
 [[package]]
 name = "tribal-config"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "dirs",
  "figment",
@@ -4911,7 +4911,7 @@ dependencies = [
 
 [[package]]
 name = "tribal-db"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "async-trait",
  "chrono",
@@ -4930,7 +4930,7 @@ dependencies = [
 
 [[package]]
 name = "tribal-domain"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "chrono",
  "schemars 0.8.22",
@@ -4944,7 +4944,7 @@ dependencies = [
 
 [[package]]
 name = "tribal-e2e"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "chrono",
  "dashmap",
@@ -4970,7 +4970,7 @@ dependencies = [
 
 [[package]]
 name = "tribal-inference"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "async-trait",
  "reqwest 0.13.2",
@@ -4986,7 +4986,7 @@ dependencies = [
 
 [[package]]
 name = "tribal-mcp"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "axum",
  "chrono",
@@ -5019,7 +5019,7 @@ dependencies = [
 
 [[package]]
 name = "tribal-telemetry"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "opentelemetry",
  "opentelemetry-otlp",
@@ -5040,7 +5040,7 @@ dependencies = [
 
 [[package]]
 name = "tribal-test-utils"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "async-trait",
  "chrono",
@@ -5063,7 +5063,7 @@ dependencies = [
 
 [[package]]
 name = "tribal-worker"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "chrono",
  "dashmap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ members = [
 
 [workspace.package]
 edition = "2024"
-version = "0.1.0"
+version = "0.1.1"
 license = "Elastic-2.0"
 rust-version = "1.93"
 publish = false


### PR DESCRIPTION
- Made a few changes to the default prompts after driving Tribal a little.
- Changed the approach to surfacing knowledge items for the relation inference call to prevent weaker models having to echo back real UUIDs — no resource IDs ever get sent to the model.

The above changes were introduced in #146.