### PR TITLE
[TRIBAL 8.1] Implement standard env var fallback and config shape updates

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -103,9 +103,9 @@ dependencies = [
 
 [[package]]
 name = "astral-tokio-tar"
-version = "0.6.0"
+version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c23f3af104b40a3430ccb90ed5f7bd877a8dc5c26fc92fde51a22b40890dcf9"
+checksum = "4ce73b17c62717c4b6a9af10b43e87c578b0cac27e00666d48304d3b7d2c0693"
 dependencies = [
  "filetime",
  "futures-core",
@@ -3690,9 +3690,9 @@ checksum = "f87165f0995f63a9fbeea62b64d10b4d9d8e78ec6d7d51fb2125fda7bb36788f"
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.12"
+version = "0.103.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8279bb85272c9f10811ae6a6c547ff594d6a7f3c6c6b02ee9726d1d0dcfcdd06"
+checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
 dependencies = [
  "aws-lc-rs",
  "ring",
@@ -5507,7 +5507,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4907,6 +4907,7 @@ dependencies = [
  "shellexpand",
  "tempfile",
  "thiserror 2.0.18",
+ "tribal-domain",
 ]
 
 [[package]]

--- a/crates/tribal-config/Cargo.toml
+++ b/crates/tribal-config/Cargo.toml
@@ -15,6 +15,8 @@ serde_yaml.workspace = true
 shellexpand.workspace = true
 thiserror.workspace = true
 
+tribal-domain.workspace = true
+
 [dev-dependencies]
 figment = { workspace = true, features = ["test"] }
 tempfile.workspace = true

--- a/crates/tribal-config/src/divergence.rs
+++ b/crates/tribal-config/src/divergence.rs
@@ -82,8 +82,7 @@ mod tests {
     #[test]
     fn test_warns_on_url_mismatch() {
         let yaml = "database:\n  url: \"postgres://file-url/db\"\n";
-        let mut config = TribalConfig::default();
-        config.database.url = "postgres://resolved-url/db".to_owned();
+        let config = TribalConfig::minimum_valid("postgres://resolved-url/db");
 
         let warnings = check_config_divergence(yaml, &config);
         assert_eq!(warnings.len(), 1);
@@ -92,8 +91,7 @@ mod tests {
 
     #[test]
     fn test_no_warning_when_urls_match() {
-        let mut config = TribalConfig::default();
-        config.database.url = "postgres://same/db".to_owned();
+        let config = TribalConfig::minimum_valid("postgres://same/db");
 
         let yaml = "database:\n  url: \"postgres://same/db\"\n";
         let warnings = check_config_divergence(yaml, &config);

--- a/crates/tribal-config/src/env.rs
+++ b/crates/tribal-config/src/env.rs
@@ -16,3 +16,15 @@ pub const ENV_PROJECT_ID: &str = "TRIBAL_PROJECT_ID";
 
 /// Environment variable for the bearer token used in HTTP/SSE transport.
 pub const ENV_AUTH_TOKEN: &str = "TRIBAL_AUTH_TOKEN";
+
+/// Standard environment variable for the `OpenAI` API key.
+///
+/// Consulted as a final fallback when no `TRIBAL_*__API_KEY` or
+/// config-file `api_key` is supplied for an `OpenAi`-provider stage.
+pub const ENV_OPENAI_API_KEY: &str = "OPENAI_API_KEY";
+
+/// Standard environment variable for the `Anthropic` API key.
+///
+/// Consulted as a final fallback when no `TRIBAL_*__API_KEY` or
+/// config-file `api_key` is supplied for an `Anthropic`-provider stage.
+pub const ENV_ANTHROPIC_API_KEY: &str = "ANTHROPIC_API_KEY";

--- a/crates/tribal-config/src/lib.rs
+++ b/crates/tribal-config/src/lib.rs
@@ -25,7 +25,10 @@ pub use env::{
     ENV_PROJECT_ID,
 };
 pub use error::ConfigError;
-pub use loader::{CliOverrides, DatabaseCliOverrides, ServerCliOverrides, load_config};
+pub use loader::{
+    CliOverrides, DatabaseCliOverrides, EmbeddingCliOverrides, InferenceCliOverrides,
+    InferenceStageCliOverrides, ServerCliOverrides, TelemetryCliOverrides, load_config,
+};
 pub use redact::redact_secrets;
 pub use render::render_minimal_config;
 pub use sections::{

--- a/crates/tribal-config/src/lib.rs
+++ b/crates/tribal-config/src/lib.rs
@@ -35,9 +35,9 @@ pub use sections::{
     DEFAULT_EXPLORATION_MAX_LIMIT, DEFAULT_OLLAMA_BASE_URL, DEFAULT_OPENAI_BASE_URL,
     DEFAULT_OVERFETCH_MULTIPLIER, DEFAULT_SIMILARITY_THRESHOLD, DatabaseConfig, DiscoveryConfig,
     EmbeddingConfig, ExplorationConfig, FileRotation, InferenceConfig, LimitsConfig, LogFormat,
-    LogOutput, LoggingConfig, MAX_LIFECYCLE_DURATION_MS, MAX_OVERFETCH_MULTIPLIER, PromptsConfig,
-    ProviderKind, ProviderLimitsConfig, ServerConfig, SseConfig, StageInferenceConfig,
-    TelemetryConfig, TransportKind, TribalConfig, VERSION, WorkerConfig,
+    LogOutput, LoggingConfig, MAX_LIFECYCLE_DURATION_MS, MAX_OVERFETCH_MULTIPLIER, PromptSource,
+    PromptsConfig, ProviderKind, ProviderLimitsConfig, ServerConfig, SseConfig,
+    StageInferenceConfig, TelemetryConfig, TransportKind, TribalConfig, VERSION, WorkerConfig,
 };
 pub use validation::{ERR_TTL_ZERO, validate};
 

--- a/crates/tribal-config/src/lib.rs
+++ b/crates/tribal-config/src/lib.rs
@@ -20,7 +20,10 @@ mod validation;
 pub use divergence::{
     WARNING_CONFIG_UNPARSEABLE, WARNING_DATABASE_URL_DIVERGENCE, check_config_divergence,
 };
-pub use env::{ENV_AUTH_TOKEN, ENV_CONFIG_PATH, ENV_PREFIX, ENV_PROJECT_ID};
+pub use env::{
+    ENV_ANTHROPIC_API_KEY, ENV_AUTH_TOKEN, ENV_CONFIG_PATH, ENV_OPENAI_API_KEY, ENV_PREFIX,
+    ENV_PROJECT_ID,
+};
 pub use error::ConfigError;
 pub use loader::{CliOverrides, DatabaseCliOverrides, ServerCliOverrides, load_config};
 pub use redact::redact_secrets;

--- a/crates/tribal-config/src/loader.rs
+++ b/crates/tribal-config/src/loader.rs
@@ -447,6 +447,24 @@ prompts:
     }
 
     #[test]
+    fn test_embedded_hot_reload_yaml_rejected_at_load() {
+        Jail::expect_with(|jail| {
+            jail.create_file(
+                "tribal.yaml",
+                "prompts:\n  source:\n    kind: embedded\n    hot_reload: true\n",
+            )?;
+
+            let path = jail.directory().join("tribal.yaml");
+            let result = load_config(path.to_str().unwrap(), None, None);
+            assert!(
+                result.is_err(),
+                "`embedded` variant must reject `hot_reload`, got: {result:?}",
+            );
+            Ok(())
+        });
+    }
+
+    #[test]
     fn test_env_var_overrides_yaml() {
         Jail::expect_with(|jail| {
             jail.create_file("tribal.yaml", "database:\n  pool_mcp_max_connections: 4\n")?;

--- a/crates/tribal-config/src/loader.rs
+++ b/crates/tribal-config/src/loader.rs
@@ -317,6 +317,7 @@ fn apply_stage_fallback(api_key: &mut Option<String>, provider: ProviderKind) {
         && provider.requires_api_key()
         && let Some(name) = provider.standard_env_var_name()
         && let Ok(value) = std::env::var(name)
+        && !value.is_empty()
     {
         *api_key = Some(value);
     }
@@ -343,7 +344,16 @@ mod tests {
     use figment::Jail;
 
     use super::*;
-    use crate::ProviderKind;
+    use crate::{ENV_ANTHROPIC_API_KEY, ENV_OPENAI_API_KEY, ProviderKind, validate};
+
+    /// Serialises a [`TribalConfig`] and writes it as `tribal.yaml` in the
+    /// jail's working directory. Lets tests assemble fixtures by setting
+    /// fields on a `TribalConfig` instead of hand-rolling YAML strings.
+    fn write_config_yaml(jail: &mut Jail, config: &TribalConfig) {
+        let yaml = serde_yaml::to_string(config).expect("serialise TribalConfig to YAML");
+        jail.create_file("tribal.yaml", &yaml)
+            .expect("write tribal.yaml in jail");
+    }
 
     #[test]
     fn test_defaults_only() {
@@ -703,7 +713,7 @@ prompts:
                 "tribal.yaml",
                 "embedding:\n  provider: openai\n  api_key: \"from-file\"\n",
             )?;
-            jail.set_env("OPENAI_API_KEY", "from-standard-env");
+            jail.set_env(ENV_OPENAI_API_KEY, "from-standard-env");
 
             let path = jail.directory().join("tribal.yaml");
             let config = load_config(path.to_str().unwrap(), None, None).unwrap();
@@ -717,7 +727,7 @@ prompts:
         Jail::expect_with(|jail| {
             jail.create_file("tribal.yaml", "embedding:\n  provider: openai\n")?;
             jail.set_env("TRIBAL_EMBEDDING__API_KEY", "from-tribal-env");
-            jail.set_env("OPENAI_API_KEY", "from-standard-env");
+            jail.set_env(ENV_OPENAI_API_KEY, "from-standard-env");
 
             let path = jail.directory().join("tribal.yaml");
             let config = load_config(path.to_str().unwrap(), None, None).unwrap();
@@ -729,14 +739,45 @@ prompts:
     #[test]
     fn test_openai_api_key_satisfies_validation() {
         Jail::expect_with(|jail| {
-            jail.create_file("tribal.yaml", "embedding:\n  provider: openai\n")?;
-            jail.set_env("OPENAI_API_KEY", "from-standard-env");
+            let mut fixture = TribalConfig::minimum_valid("postgres://h/db");
+            fixture.embedding.provider = ProviderKind::OpenAi;
+            write_config_yaml(jail, &fixture);
+            jail.set_env(ENV_OPENAI_API_KEY, "from-standard-env");
 
             let path = jail.directory().join("tribal.yaml");
             let config = load_config(path.to_str().unwrap(), None, None).unwrap();
             assert_eq!(
                 config.embedding.api_key.as_deref(),
                 Some("from-standard-env"),
+            );
+            let result = validate(&config);
+            assert!(
+                result.is_ok(),
+                "validate must pass when the standard env var supplies the key, got {result:?}",
+            );
+            Ok(())
+        });
+    }
+
+    #[test]
+    fn test_empty_standard_env_var_does_not_satisfy_validation() {
+        Jail::expect_with(|jail| {
+            let mut fixture = TribalConfig::minimum_valid("postgres://h/db");
+            fixture.embedding.provider = ProviderKind::OpenAi;
+            write_config_yaml(jail, &fixture);
+            // Docker compose's `${OPENAI_API_KEY:-}` emits an empty value
+            // when the host env var is unset; the fallback must treat that
+            // as "no key reachable" so validation fires loudly with the
+            // existing "api_key is required" literal.
+            jail.set_env(ENV_OPENAI_API_KEY, "");
+
+            let path = jail.directory().join("tribal.yaml");
+            let config = load_config(path.to_str().unwrap(), None, None).unwrap();
+            assert!(config.embedding.api_key.is_none());
+            let result = validate(&config);
+            assert!(
+                result.is_err(),
+                "validate must fail when the standard env var is empty, got {result:?}",
             );
             Ok(())
         });
@@ -755,8 +796,8 @@ inference:
     provider: anthropic
 ",
             )?;
-            jail.set_env("OPENAI_API_KEY", "openai-key");
-            jail.set_env("ANTHROPIC_API_KEY", "anthropic-key");
+            jail.set_env(ENV_OPENAI_API_KEY, "openai-key");
+            jail.set_env(ENV_ANTHROPIC_API_KEY, "anthropic-key");
 
             let path = jail.directory().join("tribal.yaml");
             let config = load_config(path.to_str().unwrap(), None, None).unwrap();
@@ -781,23 +822,41 @@ inference:
             }
 
             // For every provider that does not require an API key, the
-            // fallback must leave `api_key` as `None`.
+            // fallback must leave `api_key` as `None` for every stage that
+            // consults it — not only the embedding stage.
             for provider in ProviderKind::ALL
                 .into_iter()
                 .filter(|k| !k.requires_api_key())
             {
-                jail.create_file(
-                    "tribal.yaml",
-                    &format!("embedding:\n  provider: {provider}\n"),
-                )?;
+                let yaml = format!(
+                    "\
+embedding:
+  provider: {provider}
+inference:
+  extraction:
+    provider: {provider}
+  triage:
+    provider: {provider}
+  relation:
+    provider: {provider}
+"
+                );
+                jail.create_file("tribal.yaml", &yaml)?;
                 let path = jail.directory().join("tribal.yaml");
                 let config = load_config(path.to_str().unwrap(), None, None).unwrap();
-                assert_eq!(config.embedding.provider, provider);
-                assert!(
-                    config.embedding.api_key.is_none(),
-                    "{provider} should not consume any standard env var, got {:?}",
-                    config.embedding.api_key,
-                );
+
+                let stages = [
+                    ("embedding", &config.embedding.api_key),
+                    ("inference.extraction", &config.inference.extraction.api_key),
+                    ("inference.triage", &config.inference.triage.api_key),
+                    ("inference.relation", &config.inference.relation.api_key),
+                ];
+                for (label, api_key) in stages {
+                    assert!(
+                        api_key.is_none(),
+                        "{provider} at {label} consumed a standard env var, got {api_key:?}",
+                    );
+                }
             }
             Ok(())
         });

--- a/crates/tribal-config/src/loader.rs
+++ b/crates/tribal-config/src/loader.rs
@@ -333,7 +333,7 @@ prompts:
         Jail::expect_with(|jail| {
             let path = jail.directory().join("tribal.yaml");
             let config = load_config(path.to_str().unwrap(), None, None).unwrap();
-            assert_eq!(config.prompts.source, PromptSource::Embedded);
+            assert_eq!(config.prompts.source, PromptSource::Embedded {});
             Ok(())
         });
     }

--- a/crates/tribal-config/src/loader.rs
+++ b/crates/tribal-config/src/loader.rs
@@ -9,6 +9,7 @@ use figment::{
 };
 use serde::Serialize;
 use serde_json::Value as JsonValue;
+use tribal_domain::ApiKey;
 
 use crate::{
     LoggingConfig, TelemetryConfig, TribalConfig,
@@ -288,27 +289,18 @@ fn restore_temp_dir_fallback_flags(config: &mut TribalConfig) {
     }
 }
 
-/// Normalises every `api_key` field to `None` when its trimmed form is
-/// empty, then populates any still-`None` field for cloud providers from
-/// the corresponding standard env var (`OPENAI_API_KEY`,
-/// `ANTHROPIC_API_KEY`).
+/// Populates `api_key` for any cloud-provider stage where prior cascade
+/// layers left it `None`, using the env var returned by
+/// [`ProviderKind::standard_env_var_name`].
 ///
-/// The normalisation pass runs before the fallback so that an empty or
-/// whitespace-only value supplied by any cascade layer (file,
-/// `TRIBAL_*__API_KEY`, or the standard env var) is treated uniformly:
-/// validation never sees a `Some("")` it would have to special-case, and
-/// `feedback_trim_at_resolution.md` is honoured at the single resolution
-/// boundary.
-///
-/// Silent best-effort: a missing or non-Unicode env var leaves `api_key`
-/// as `None`, which then triggers the existing `validate_api_key_presence`
-/// error if no usable key emerged from any layer.
+/// The OS env lookup is opportunistic: a missing, non-Unicode, or
+/// malformed value (empty, whitespace-bearing) leaves `api_key` as
+/// `None`, which then triggers the existing `validate_api_key_presence`
+/// error if no usable key emerged from any layer. Empty or
+/// whitespace-bearing values supplied through YAML or `TRIBAL_*__API_KEY`
+/// fail at deserialise time instead, courtesy of [`ApiKey`]'s strict
+/// `FromStr` impl.
 fn apply_standard_env_var_fallback(config: &mut TribalConfig) {
-    normalise_api_key(&mut config.embedding.api_key);
-    normalise_api_key(&mut config.inference.extraction.api_key);
-    normalise_api_key(&mut config.inference.triage.api_key);
-    normalise_api_key(&mut config.inference.relation.api_key);
-
     apply_stage_fallback(&mut config.embedding.api_key, config.embedding.provider);
     apply_stage_fallback(
         &mut config.inference.extraction.api_key,
@@ -324,31 +316,13 @@ fn apply_standard_env_var_fallback(config: &mut TribalConfig) {
     );
 }
 
-/// Resets `api_key` to `None` if its trimmed form is empty; otherwise
-/// stores the trimmed value, eliminating surrounding whitespace from
-/// every source.
-fn normalise_api_key(api_key: &mut Option<String>) {
-    *api_key = api_key.take().and_then(trimmed_some);
-}
-
-fn apply_stage_fallback(api_key: &mut Option<String>, provider: ProviderKind) {
+fn apply_stage_fallback(api_key: &mut Option<ApiKey>, provider: ProviderKind) {
     if api_key.is_none()
         && provider.requires_api_key()
         && let Some(name) = provider.standard_env_var_name()
-        && let Ok(value) = std::env::var(name)
-        && let Some(trimmed) = trimmed_some(value)
+        && let Some(parsed) = std::env::var(name).ok().and_then(|v| v.parse().ok())
     {
-        *api_key = Some(trimmed);
-    }
-}
-
-/// Returns `Some(trimmed)` when `value.trim()` is non-empty, else `None`.
-fn trimmed_some(value: String) -> Option<String> {
-    let trimmed = value.trim();
-    if trimmed.is_empty() {
-        None
-    } else {
-        Some(trimmed.to_owned())
+        *api_key = Some(parsed);
     }
 }
 
@@ -746,7 +720,10 @@ prompts:
 
             let path = jail.directory().join("tribal.yaml");
             let config = load_config(path.to_str().unwrap(), None, None).unwrap();
-            assert_eq!(config.embedding.api_key.as_deref(), Some("from-file"));
+            assert_eq!(
+                config.embedding.api_key.as_ref().map(ApiKey::as_str),
+                Some("from-file")
+            );
             Ok(())
         });
     }
@@ -760,7 +737,10 @@ prompts:
 
             let path = jail.directory().join("tribal.yaml");
             let config = load_config(path.to_str().unwrap(), None, None).unwrap();
-            assert_eq!(config.embedding.api_key.as_deref(), Some("from-tribal-env"),);
+            assert_eq!(
+                config.embedding.api_key.as_ref().map(ApiKey::as_str),
+                Some("from-tribal-env"),
+            );
             Ok(())
         });
     }
@@ -776,7 +756,7 @@ prompts:
             let path = jail.directory().join("tribal.yaml");
             let config = load_config(path.to_str().unwrap(), None, None).unwrap();
             assert_eq!(
-                config.embedding.api_key.as_deref(),
+                config.embedding.api_key.as_ref().map(ApiKey::as_str),
                 Some("from-standard-env"),
             );
             let result = validate(&config);
@@ -830,9 +810,12 @@ inference:
 
             let path = jail.directory().join("tribal.yaml");
             let config = load_config(path.to_str().unwrap(), None, None).unwrap();
-            assert_eq!(config.embedding.api_key.as_deref(), Some("openai-key"));
             assert_eq!(
-                config.inference.triage.api_key.as_deref(),
+                config.embedding.api_key.as_ref().map(ApiKey::as_str),
+                Some("openai-key")
+            );
+            assert_eq!(
+                config.inference.triage.api_key.as_ref().map(ApiKey::as_str),
                 Some("anthropic-key"),
             );
             Ok(())

--- a/crates/tribal-config/src/loader.rs
+++ b/crates/tribal-config/src/loader.rs
@@ -288,15 +288,27 @@ fn restore_temp_dir_fallback_flags(config: &mut TribalConfig) {
     }
 }
 
-/// Populates `api_key` for any embedding or inference stage where the
-/// config file and the `TRIBAL_*__API_KEY` env var both left it `None`,
-/// using the provider's standard env var (`OPENAI_API_KEY`,
-/// `ANTHROPIC_API_KEY`) as a final fallback.
+/// Normalises every `api_key` field to `None` when its trimmed form is
+/// empty, then populates any still-`None` field for cloud providers from
+/// the corresponding standard env var (`OPENAI_API_KEY`,
+/// `ANTHROPIC_API_KEY`).
+///
+/// The normalisation pass runs before the fallback so that an empty or
+/// whitespace-only value supplied by any cascade layer (file,
+/// `TRIBAL_*__API_KEY`, or the standard env var) is treated uniformly:
+/// validation never sees a `Some("")` it would have to special-case, and
+/// `feedback_trim_at_resolution.md` is honoured at the single resolution
+/// boundary.
 ///
 /// Silent best-effort: a missing or non-Unicode env var leaves `api_key`
 /// as `None`, which then triggers the existing `validate_api_key_presence`
 /// error if no usable key emerged from any layer.
 fn apply_standard_env_var_fallback(config: &mut TribalConfig) {
+    normalise_api_key(&mut config.embedding.api_key);
+    normalise_api_key(&mut config.inference.extraction.api_key);
+    normalise_api_key(&mut config.inference.triage.api_key);
+    normalise_api_key(&mut config.inference.relation.api_key);
+
     apply_stage_fallback(&mut config.embedding.api_key, config.embedding.provider);
     apply_stage_fallback(
         &mut config.inference.extraction.api_key,
@@ -312,14 +324,31 @@ fn apply_standard_env_var_fallback(config: &mut TribalConfig) {
     );
 }
 
+/// Resets `api_key` to `None` if its trimmed form is empty; otherwise
+/// stores the trimmed value, eliminating surrounding whitespace from
+/// every source.
+fn normalise_api_key(api_key: &mut Option<String>) {
+    *api_key = api_key.take().and_then(trimmed_some);
+}
+
 fn apply_stage_fallback(api_key: &mut Option<String>, provider: ProviderKind) {
     if api_key.is_none()
         && provider.requires_api_key()
         && let Some(name) = provider.standard_env_var_name()
         && let Ok(value) = std::env::var(name)
-        && !value.is_empty()
+        && let Some(trimmed) = trimmed_some(value)
     {
-        *api_key = Some(value);
+        *api_key = Some(trimmed);
+    }
+}
+
+/// Returns `Some(trimmed)` when `value.trim()` is non-empty, else `None`.
+fn trimmed_some(value: String) -> Option<String> {
+    let trimmed = value.trim();
+    if trimmed.is_empty() {
+        None
+    } else {
+        Some(trimmed.to_owned())
     }
 }
 

--- a/crates/tribal-config/src/loader.rs
+++ b/crates/tribal-config/src/loader.rs
@@ -11,8 +11,10 @@ use serde::Serialize;
 use serde_json::Value as JsonValue;
 
 use crate::{
-    LoggingConfig, TelemetryConfig, TribalConfig, env::ENV_PREFIX, error::ConfigError,
-    sections::TransportKind,
+    LoggingConfig, TelemetryConfig, TribalConfig,
+    env::ENV_PREFIX,
+    error::ConfigError,
+    sections::{PromptSource, TransportKind},
 };
 
 // ---------------------------------------------------------------------------
@@ -226,7 +228,9 @@ fn restore_temp_dir_fallback_flags(config: &mut TribalConfig) {
 }
 
 fn expand_paths(config: &mut TribalConfig) {
-    config.prompts.directory = shellexpand::tilde(&config.prompts.directory).into_owned();
+    if let PromptSource::Disk { directory, .. } = &mut config.prompts.source {
+        *directory = shellexpand::tilde(directory).into_owned();
+    }
     config.telemetry.file_directory =
         shellexpand::tilde(&config.telemetry.file_directory).into_owned();
     config.logging.file_directory = shellexpand::tilde(&config.logging.file_directory).into_owned();
@@ -292,20 +296,44 @@ server:
     }
 
     #[test]
-    fn test_tilde_expansion() {
+    fn test_tilde_expansion_disk_prompts() {
         Jail::expect_with(|jail| {
+            jail.create_file(
+                "tribal.yaml",
+                r"
+prompts:
+  source:
+    kind: disk
+    directory: ~/somewhere
+",
+            )?;
+
             let path = jail.directory().join("tribal.yaml");
             let config = load_config(path.to_str().unwrap(), None, None).unwrap();
+
             assert!(
-                !config.prompts.directory.starts_with('~'),
-                "prompts.directory should be expanded: {}",
-                config.prompts.directory
+                matches!(
+                    &config.prompts.source,
+                    PromptSource::Disk { directory, .. } if !directory.starts_with('~'),
+                ),
+                "prompts directory should be expanded: {:?}",
+                config.prompts.source,
             );
             assert!(
                 !config.telemetry.file_directory.starts_with('~'),
                 "telemetry.file_directory should be expanded: {}",
-                config.telemetry.file_directory
+                config.telemetry.file_directory,
             );
+            Ok(())
+        });
+    }
+
+    #[test]
+    fn test_tilde_expansion_embedded_prompts_no_op() {
+        Jail::expect_with(|jail| {
+            let path = jail.directory().join("tribal.yaml");
+            let config = load_config(path.to_str().unwrap(), None, None).unwrap();
+            assert_eq!(config.prompts.source, PromptSource::Embedded);
             Ok(())
         });
     }
@@ -415,7 +443,8 @@ server:
             jail.set_env("TRIBAL_EMBEDDING__DIMENSIONS", "1024");
             jail.set_env("TRIBAL_INFERENCE__EXTRACTION__TEMPERATURE", "0.5");
             jail.set_env("TRIBAL_LIMITS__PROVIDERS__OLLAMA__MAX_IN_FLIGHT", "4");
-            jail.set_env("TRIBAL_PROMPTS__HOT_RELOAD", "true");
+            jail.set_env("TRIBAL_PROMPTS__SOURCE__KIND", "disk");
+            jail.set_env("TRIBAL_PROMPTS__SOURCE__HOT_RELOAD", "true");
             jail.set_env("TRIBAL_DISCOVERY__MAX_LIMIT", "100");
             jail.set_env("TRIBAL_EXPLORATION__MAX_DEPTH", "5");
             jail.set_env("TRIBAL_LOGGING__LEVEL", "debug");
@@ -434,7 +463,17 @@ server:
                 config.limits.providers[&ProviderKind::Ollama].max_in_flight,
                 4
             );
-            assert!(config.prompts.hot_reload);
+            assert!(
+                matches!(
+                    config.prompts.source,
+                    PromptSource::Disk {
+                        hot_reload: true,
+                        ..
+                    },
+                ),
+                "expected Disk variant with hot_reload=true, got {:?}",
+                config.prompts.source,
+            );
             assert_eq!(config.discovery.max_limit, 100);
             assert_eq!(config.exploration.max_depth, 5);
             assert_eq!(config.logging.level, "debug");

--- a/crates/tribal-config/src/loader.rs
+++ b/crates/tribal-config/src/loader.rs
@@ -14,7 +14,7 @@ use crate::{
     LoggingConfig, TelemetryConfig, TribalConfig,
     env::ENV_PREFIX,
     error::ConfigError,
-    sections::{ProviderKind, PromptSource, TransportKind},
+    sections::{PromptSource, ProviderKind, TransportKind},
 };
 
 // ---------------------------------------------------------------------------
@@ -67,6 +67,18 @@ pub struct CliOverrides {
     /// Database-related CLI overrides.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub database: Option<DatabaseCliOverrides>,
+
+    /// Embedding-stage CLI overrides.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub embedding: Option<EmbeddingCliOverrides>,
+
+    /// Inference-stage CLI overrides.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub inference: Option<InferenceCliOverrides>,
+
+    /// Telemetry CLI overrides.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub telemetry: Option<TelemetryCliOverrides>,
 }
 
 /// Server-related CLI flag overrides.
@@ -87,6 +99,54 @@ pub struct DatabaseCliOverrides {
     /// Database URL override from `--database-url`.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub url: Option<String>,
+}
+
+/// Embedding-stage CLI flag overrides.
+#[derive(Debug, Serialize)]
+pub struct EmbeddingCliOverrides {
+    /// Provider override from `--embedding-provider`.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub provider: Option<ProviderKind>,
+
+    /// Model name override from `--embedding-model`.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub model: Option<String>,
+}
+
+/// Inference-stage CLI flag overrides.
+#[derive(Debug, Serialize)]
+pub struct InferenceCliOverrides {
+    /// Extraction-stage overrides.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub extraction: Option<InferenceStageCliOverrides>,
+
+    /// Triage-stage overrides.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub triage: Option<InferenceStageCliOverrides>,
+
+    /// Relation-stage overrides.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub relation: Option<InferenceStageCliOverrides>,
+}
+
+/// Per-stage inference CLI flag overrides.
+#[derive(Debug, Serialize)]
+pub struct InferenceStageCliOverrides {
+    /// Provider override.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub provider: Option<ProviderKind>,
+
+    /// Model name override.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub model: Option<String>,
+}
+
+/// Telemetry CLI flag overrides.
+#[derive(Debug, Serialize)]
+pub struct TelemetryCliOverrides {
+    /// OTLP exporter endpoint override from `--telemetry-otlp-endpoint`.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub otlp_endpoint: Option<String>,
 }
 
 // ---------------------------------------------------------------------------
@@ -396,7 +456,7 @@ prompts:
                     transport: Some(TransportKind::Sse),
                     bind_address: None,
                 }),
-                database: None,
+                ..CliOverrides::default()
             };
 
             let path = jail.directory().join("tribal.yaml");
@@ -619,10 +679,10 @@ prompts:
             )?;
 
             let overrides = CliOverrides {
-                server: None,
                 database: Some(DatabaseCliOverrides {
                     url: Some("postgres://cli-wins/tribal".into()),
                 }),
+                ..CliOverrides::default()
             };
 
             let path = jail.directory().join("tribal.yaml");
@@ -661,10 +721,7 @@ prompts:
 
             let path = jail.directory().join("tribal.yaml");
             let config = load_config(path.to_str().unwrap(), None, None).unwrap();
-            assert_eq!(
-                config.embedding.api_key.as_deref(),
-                Some("from-tribal-env"),
-            );
+            assert_eq!(config.embedding.api_key.as_deref(), Some("from-tribal-env"),);
             Ok(())
         });
     }
@@ -742,6 +799,72 @@ inference:
                     config.embedding.api_key,
                 );
             }
+            Ok(())
+        });
+    }
+
+    // -- Provider / Telemetry CliOverrides cascade ---------------------------
+
+    #[test]
+    fn test_provider_cli_overrides_cascade() {
+        Jail::expect_with(|jail| {
+            let overrides = CliOverrides {
+                embedding: Some(EmbeddingCliOverrides {
+                    provider: Some(ProviderKind::OpenAi),
+                    model: Some("text-embedding-3-small".into()),
+                }),
+                inference: Some(InferenceCliOverrides {
+                    extraction: Some(InferenceStageCliOverrides {
+                        provider: Some(ProviderKind::Anthropic),
+                        model: Some("claude-opus-4".into()),
+                    }),
+                    triage: Some(InferenceStageCliOverrides {
+                        provider: Some(ProviderKind::OpenAi),
+                        model: Some("gpt-5".into()),
+                    }),
+                    relation: Some(InferenceStageCliOverrides {
+                        provider: Some(ProviderKind::Anthropic),
+                        model: Some("claude-haiku-5".into()),
+                    }),
+                }),
+                ..CliOverrides::default()
+            };
+
+            let path = jail.directory().join("tribal.yaml");
+            let config = load_config(path.to_str().unwrap(), Some(overrides), None).unwrap();
+
+            assert_eq!(config.embedding.provider, ProviderKind::OpenAi);
+            assert_eq!(config.embedding.model, "text-embedding-3-small");
+            assert_eq!(
+                config.inference.extraction.provider,
+                ProviderKind::Anthropic,
+            );
+            assert_eq!(config.inference.extraction.model, "claude-opus-4");
+            assert_eq!(config.inference.triage.provider, ProviderKind::OpenAi);
+            assert_eq!(config.inference.triage.model, "gpt-5");
+            assert_eq!(config.inference.relation.provider, ProviderKind::Anthropic);
+            assert_eq!(config.inference.relation.model, "claude-haiku-5");
+            Ok(())
+        });
+    }
+
+    #[test]
+    fn test_telemetry_cli_overrides_cascade() {
+        Jail::expect_with(|jail| {
+            let overrides = CliOverrides {
+                telemetry: Some(TelemetryCliOverrides {
+                    otlp_endpoint: Some("http://collector.internal:4317".into()),
+                }),
+                ..CliOverrides::default()
+            };
+
+            let path = jail.directory().join("tribal.yaml");
+            let config = load_config(path.to_str().unwrap(), Some(overrides), None).unwrap();
+
+            assert_eq!(
+                config.telemetry.otlp_endpoint.as_deref(),
+                Some("http://collector.internal:4317"),
+            );
             Ok(())
         });
     }

--- a/crates/tribal-config/src/loader.rs
+++ b/crates/tribal-config/src/loader.rs
@@ -14,7 +14,7 @@ use crate::{
     LoggingConfig, TelemetryConfig, TribalConfig,
     env::ENV_PREFIX,
     error::ConfigError,
-    sections::{PromptSource, TransportKind},
+    sections::{ProviderKind, PromptSource, TransportKind},
 };
 
 // ---------------------------------------------------------------------------
@@ -162,6 +162,7 @@ pub fn load_config(
         source: Box::new(source),
     })?;
 
+    apply_standard_env_var_fallback(&mut config);
     expand_paths(&mut config);
     restore_temp_dir_fallback_flags(&mut config);
 
@@ -224,6 +225,40 @@ fn restore_temp_dir_fallback_flags(config: &mut TribalConfig) {
     let default_telemetry = TelemetryConfig::default();
     if config.telemetry.file_directory == default_telemetry.file_directory {
         config.telemetry.used_temp_dir_fallback = default_telemetry.used_temp_dir_fallback;
+    }
+}
+
+/// Populates `api_key` for any embedding or inference stage where the
+/// config file and the `TRIBAL_*__API_KEY` env var both left it `None`,
+/// using the provider's standard env var (`OPENAI_API_KEY`,
+/// `ANTHROPIC_API_KEY`) as a final fallback.
+///
+/// Silent best-effort: a missing or non-Unicode env var leaves `api_key`
+/// as `None`, which then triggers the existing `validate_api_key_presence`
+/// error if no usable key emerged from any layer.
+fn apply_standard_env_var_fallback(config: &mut TribalConfig) {
+    apply_stage_fallback(&mut config.embedding.api_key, config.embedding.provider);
+    apply_stage_fallback(
+        &mut config.inference.extraction.api_key,
+        config.inference.extraction.provider,
+    );
+    apply_stage_fallback(
+        &mut config.inference.triage.api_key,
+        config.inference.triage.provider,
+    );
+    apply_stage_fallback(
+        &mut config.inference.relation.api_key,
+        config.inference.relation.provider,
+    );
+}
+
+fn apply_stage_fallback(api_key: &mut Option<String>, provider: ProviderKind) {
+    if api_key.is_none()
+        && provider.requires_api_key()
+        && let Some(name) = provider.standard_env_var_name()
+        && let Ok(value) = std::env::var(name)
+    {
+        *api_key = Some(value);
     }
 }
 
@@ -595,6 +630,118 @@ prompts:
             let config =
                 load_config(path.to_str().unwrap(), Some(overrides), Some(&defaults)).unwrap();
             assert_eq!(config.database.url, "postgres://cli-wins/tribal");
+            Ok(())
+        });
+    }
+
+    // -- Standard provider env-var fallback (closes #144) --------------------
+
+    #[test]
+    fn test_openai_api_key_fallback_file_wins() {
+        Jail::expect_with(|jail| {
+            jail.create_file(
+                "tribal.yaml",
+                "embedding:\n  provider: openai\n  api_key: \"from-file\"\n",
+            )?;
+            jail.set_env("OPENAI_API_KEY", "from-standard-env");
+
+            let path = jail.directory().join("tribal.yaml");
+            let config = load_config(path.to_str().unwrap(), None, None).unwrap();
+            assert_eq!(config.embedding.api_key.as_deref(), Some("from-file"));
+            Ok(())
+        });
+    }
+
+    #[test]
+    fn test_tribal_env_api_key_beats_standard_env() {
+        Jail::expect_with(|jail| {
+            jail.create_file("tribal.yaml", "embedding:\n  provider: openai\n")?;
+            jail.set_env("TRIBAL_EMBEDDING__API_KEY", "from-tribal-env");
+            jail.set_env("OPENAI_API_KEY", "from-standard-env");
+
+            let path = jail.directory().join("tribal.yaml");
+            let config = load_config(path.to_str().unwrap(), None, None).unwrap();
+            assert_eq!(
+                config.embedding.api_key.as_deref(),
+                Some("from-tribal-env"),
+            );
+            Ok(())
+        });
+    }
+
+    #[test]
+    fn test_openai_api_key_satisfies_validation() {
+        Jail::expect_with(|jail| {
+            jail.create_file("tribal.yaml", "embedding:\n  provider: openai\n")?;
+            jail.set_env("OPENAI_API_KEY", "from-standard-env");
+
+            let path = jail.directory().join("tribal.yaml");
+            let config = load_config(path.to_str().unwrap(), None, None).unwrap();
+            assert_eq!(
+                config.embedding.api_key.as_deref(),
+                Some("from-standard-env"),
+            );
+            Ok(())
+        });
+    }
+
+    #[test]
+    fn test_mixed_provider_mixed_stage_fallback() {
+        Jail::expect_with(|jail| {
+            jail.create_file(
+                "tribal.yaml",
+                r"
+embedding:
+  provider: openai
+inference:
+  triage:
+    provider: anthropic
+",
+            )?;
+            jail.set_env("OPENAI_API_KEY", "openai-key");
+            jail.set_env("ANTHROPIC_API_KEY", "anthropic-key");
+
+            let path = jail.directory().join("tribal.yaml");
+            let config = load_config(path.to_str().unwrap(), None, None).unwrap();
+            assert_eq!(config.embedding.api_key.as_deref(), Some("openai-key"));
+            assert_eq!(
+                config.inference.triage.api_key.as_deref(),
+                Some("anthropic-key"),
+            );
+            Ok(())
+        });
+    }
+
+    #[test]
+    fn test_no_key_providers_ignore_all_standard_env_vars() {
+        Jail::expect_with(|jail| {
+            // Set every standard env var that any provider exposes, so the
+            // sweep below covers each `ProviderKind` against the full set.
+            for kind in ProviderKind::ALL {
+                if let Some(name) = kind.standard_env_var_name() {
+                    jail.set_env(name, "should-be-ignored");
+                }
+            }
+
+            // For every provider that does not require an API key, the
+            // fallback must leave `api_key` as `None`.
+            for provider in ProviderKind::ALL
+                .into_iter()
+                .filter(|k| !k.requires_api_key())
+            {
+                jail.create_file(
+                    "tribal.yaml",
+                    &format!("embedding:\n  provider: {provider}\n"),
+                )?;
+                let path = jail.directory().join("tribal.yaml");
+                let config = load_config(path.to_str().unwrap(), None, None).unwrap();
+                assert_eq!(config.embedding.provider, provider);
+                assert!(
+                    config.embedding.api_key.is_none(),
+                    "{provider} should not consume any standard env var, got {:?}",
+                    config.embedding.api_key,
+                );
+            }
             Ok(())
         });
     }

--- a/crates/tribal-config/src/redact.rs
+++ b/crates/tribal-config/src/redact.rs
@@ -56,18 +56,17 @@ impl SecretField {
     /// The exhaustive match ensures a new variant without a
     /// corresponding mutation arm is a compile error.
     fn plant_sentinel(self, config: &mut TribalConfig, value: &str) {
+        let key = || {
+            value
+                .parse::<tribal_domain::ApiKey>()
+                .expect("sentinel value must be a valid api key")
+        };
         match self {
             Self::DatabaseUrl => config.database.url = value.to_owned(),
-            Self::EmbeddingApiKey => config.embedding.api_key = Some(value.to_owned()),
-            Self::ExtractionApiKey => {
-                config.inference.extraction.api_key = Some(value.to_owned());
-            }
-            Self::TriageApiKey => {
-                config.inference.triage.api_key = Some(value.to_owned());
-            }
-            Self::RelationApiKey => {
-                config.inference.relation.api_key = Some(value.to_owned());
-            }
+            Self::EmbeddingApiKey => config.embedding.api_key = Some(key()),
+            Self::ExtractionApiKey => config.inference.extraction.api_key = Some(key()),
+            Self::TriageApiKey => config.inference.triage.api_key = Some(key()),
+            Self::RelationApiKey => config.inference.relation.api_key = Some(key()),
         }
     }
 

--- a/crates/tribal-config/src/redact.rs
+++ b/crates/tribal-config/src/redact.rs
@@ -5,11 +5,10 @@
 //! dot-path, the struct field mutation (in tests), and the sentinel
 //! generation.
 
+use tribal_domain::REDACTED;
+
 #[cfg(test)]
 use crate::TribalConfig;
-
-/// Placeholder substituted for secret values in redacted output.
-const REDACTED: &str = "********";
 
 /// Configuration fields that contain sensitive values.
 ///

--- a/crates/tribal-config/src/sections.rs
+++ b/crates/tribal-config/src/sections.rs
@@ -35,7 +35,7 @@ pub use exploration::{
 pub use inference::{InferenceConfig, StageInferenceConfig};
 pub use limits::{LimitsConfig, ProviderLimitsConfig};
 pub use logging::{LogFormat, LogOutput, LoggingConfig};
-pub use prompts::PromptsConfig;
+pub use prompts::{PromptSource, PromptsConfig};
 pub use provider_kind::{
     DEFAULT_ANTHROPIC_BASE_URL, DEFAULT_OLLAMA_BASE_URL, DEFAULT_OPENAI_BASE_URL, ProviderKind,
 };

--- a/crates/tribal-config/src/sections/embedding.rs
+++ b/crates/tribal-config/src/sections/embedding.rs
@@ -1,6 +1,7 @@
 //! Embedding provider configuration.
 
 use serde::{Deserialize, Serialize};
+use tribal_domain::ApiKey;
 
 use super::provider_kind::ProviderKind;
 
@@ -54,11 +55,11 @@ pub struct EmbeddingConfig {
 
     /// API key for cloud providers.
     ///
-    /// Required when `provider` is `anthropic` or `openai`.  Prefer
+    /// Required when `provider` is `anthropic` or `openai`. Prefer
     /// setting via environment variable to avoid plaintext secrets in
     /// configuration files.
     #[serde(default)]
-    pub api_key: Option<String>,
+    pub api_key: Option<ApiKey>,
 }
 
 impl Default for EmbeddingConfig {

--- a/crates/tribal-config/src/sections/inference.rs
+++ b/crates/tribal-config/src/sections/inference.rs
@@ -4,6 +4,7 @@
 //! configurable with its own provider, model, and parameters.
 
 use serde::{Deserialize, Serialize};
+use tribal_domain::ApiKey;
 
 use super::provider_kind::ProviderKind;
 
@@ -81,7 +82,7 @@ pub struct StageInferenceConfig {
 
     /// API key for cloud providers.
     #[serde(default)]
-    pub api_key: Option<String>,
+    pub api_key: Option<ApiKey>,
 
     /// Sampling temperature.
     pub temperature: f64,

--- a/crates/tribal-config/src/sections/prompts.rs
+++ b/crates/tribal-config/src/sections/prompts.rs
@@ -30,7 +30,12 @@ fn default_directory() -> String {
 #[serde(tag = "kind", rename_all = "snake_case", deny_unknown_fields)]
 pub enum PromptSource {
     /// Prompts compiled into the binary.
-    Embedded,
+    ///
+    /// Empty struct variant rather than a unit variant: serde's
+    /// `deny_unknown_fields` is only honoured for struct-variant arms of
+    /// internally-tagged enums, so the empty braces are what make
+    /// `{kind: embedded, hot_reload: true}` fail to deserialise.
+    Embedded {},
 
     /// Prompts read from a directory on disk.
     Disk {
@@ -46,7 +51,7 @@ pub enum PromptSource {
 
 impl Default for PromptSource {
     fn default() -> Self {
-        Self::Embedded
+        Self::Embedded {}
     }
 }
 
@@ -73,18 +78,18 @@ mod tests {
     #[test]
     fn test_prompts_config_default_is_embedded() {
         let config = PromptsConfig::default();
-        assert_eq!(config.source, PromptSource::Embedded);
+        assert_eq!(config.source, PromptSource::Embedded {});
     }
 
     #[test]
     fn test_prompt_source_serde_roundtrip_embedded() {
         let yaml = "kind: embedded\n";
         let parsed: PromptSource = serde_yaml::from_str(yaml).unwrap();
-        assert_eq!(parsed, PromptSource::Embedded);
+        assert_eq!(parsed, PromptSource::Embedded {});
 
-        let serialised = serde_yaml::to_string(&PromptSource::Embedded).unwrap();
+        let serialised = serde_yaml::to_string(&PromptSource::Embedded {}).unwrap();
         let reparsed: PromptSource = serde_yaml::from_str(&serialised).unwrap();
-        assert_eq!(reparsed, PromptSource::Embedded);
+        assert_eq!(reparsed, PromptSource::Embedded {});
     }
 
     #[test]

--- a/crates/tribal-config/src/sections/prompts.rs
+++ b/crates/tribal-config/src/sections/prompts.rs
@@ -1,4 +1,4 @@
-//! Prompt file configuration.
+//! Prompt source configuration.
 
 use serde::{Deserialize, Serialize};
 
@@ -6,7 +6,7 @@ use serde::{Deserialize, Serialize};
 // Constants
 // ---------------------------------------------------------------------------
 
-/// Default prompt template directory.
+/// Default prompt template directory used by [`PromptSource::Disk`].
 pub const DEFAULT_DIRECTORY: &str = "~/.config/tribal/prompts";
 
 fn default_directory() -> String {
@@ -14,31 +14,56 @@ fn default_directory() -> String {
 }
 
 // ---------------------------------------------------------------------------
+// PromptSource
+// ---------------------------------------------------------------------------
+
+/// Where the active prompts are loaded from.
+///
+/// `Embedded` reads the six prompts compiled into the binary via
+/// `include_str!`. `Disk` reads them from `directory`, writing the
+/// embedded defaults on first run if files are missing; setting
+/// `hot_reload: true` spawns a watcher that reloads on file change.
+///
+/// The shape makes invalid states unrepresentable — `hot_reload` is only
+/// reachable when an on-disk source actually exists.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(tag = "kind", rename_all = "snake_case", deny_unknown_fields)]
+pub enum PromptSource {
+    /// Prompts compiled into the binary.
+    Embedded,
+
+    /// Prompts read from a directory on disk.
+    Disk {
+        /// Directory containing prompt template files. Supports tilde (`~`).
+        #[serde(default = "default_directory")]
+        directory: String,
+
+        /// Whether to watch for file changes and reload automatically.
+        #[serde(default)]
+        hot_reload: bool,
+    },
+}
+
+impl Default for PromptSource {
+    fn default() -> Self {
+        Self::Embedded
+    }
+}
+
+// ---------------------------------------------------------------------------
 // PromptsConfig
 // ---------------------------------------------------------------------------
 
-/// Prompt file location and hot-reload settings.
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+/// Wrapper around [`PromptSource`].
+///
+/// A struct rather than an inline enum so future prompt-wide knobs (e.g.
+/// global cache settings) can land without breaking the YAML schema.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Default)]
 #[serde(deny_unknown_fields)]
 pub struct PromptsConfig {
-    /// Directory containing prompt template files.
-    ///
-    /// Supports tilde expansion (`~`).
-    #[serde(default = "default_directory")]
-    pub directory: String,
-
-    /// Whether to watch for file changes and reload automatically.
+    /// Where the active prompts are loaded from.
     #[serde(default)]
-    pub hot_reload: bool,
-}
-
-impl Default for PromptsConfig {
-    fn default() -> Self {
-        Self {
-            directory: default_directory(),
-            hot_reload: false,
-        }
-    }
+    pub source: PromptSource,
 }
 
 #[cfg(test)]
@@ -46,9 +71,68 @@ mod tests {
     use super::*;
 
     #[test]
-    fn test_default_values() {
+    fn test_prompts_config_default_is_embedded() {
         let config = PromptsConfig::default();
-        assert_eq!(config.directory, DEFAULT_DIRECTORY);
-        assert!(!config.hot_reload);
+        assert_eq!(config.source, PromptSource::Embedded);
+    }
+
+    #[test]
+    fn test_prompt_source_serde_roundtrip_embedded() {
+        let yaml = "kind: embedded\n";
+        let parsed: PromptSource = serde_yaml::from_str(yaml).unwrap();
+        assert_eq!(parsed, PromptSource::Embedded);
+
+        let serialised = serde_yaml::to_string(&PromptSource::Embedded).unwrap();
+        let reparsed: PromptSource = serde_yaml::from_str(&serialised).unwrap();
+        assert_eq!(reparsed, PromptSource::Embedded);
+    }
+
+    #[test]
+    fn test_prompt_source_serde_roundtrip_disk_default_hot_reload() {
+        let yaml = "kind: disk\ndirectory: /tmp/prompts\n";
+        let parsed: PromptSource = serde_yaml::from_str(yaml).unwrap();
+        assert_eq!(
+            parsed,
+            PromptSource::Disk {
+                directory: "/tmp/prompts".into(),
+                hot_reload: false,
+            },
+        );
+    }
+
+    #[test]
+    fn test_prompt_source_serde_roundtrip_disk_hot_reload_true() {
+        let yaml = "kind: disk\ndirectory: /tmp/prompts\nhot_reload: true\n";
+        let parsed: PromptSource = serde_yaml::from_str(yaml).unwrap();
+        assert_eq!(
+            parsed,
+            PromptSource::Disk {
+                directory: "/tmp/prompts".into(),
+                hot_reload: true,
+            },
+        );
+    }
+
+    #[test]
+    fn test_prompt_source_disk_omits_directory_uses_default() {
+        let yaml = "kind: disk\n";
+        let parsed: PromptSource = serde_yaml::from_str(yaml).unwrap();
+        assert_eq!(
+            parsed,
+            PromptSource::Disk {
+                directory: DEFAULT_DIRECTORY.into(),
+                hot_reload: false,
+            },
+        );
+    }
+
+    #[test]
+    fn test_prompt_source_rejects_hot_reload_on_embedded() {
+        let yaml = "kind: embedded\nhot_reload: true\n";
+        let result: Result<PromptSource, _> = serde_yaml::from_str(yaml);
+        assert!(
+            result.is_err(),
+            "embedded variant must reject hot_reload field",
+        );
     }
 }

--- a/crates/tribal-config/src/sections/provider_kind.rs
+++ b/crates/tribal-config/src/sections/provider_kind.rs
@@ -3,7 +3,11 @@
 //! [`ProviderKind`] identifies which LLM provider is used for embedding
 //! and inference stages.
 
+use std::str::FromStr;
+
 use serde::{Deserialize, Serialize};
+
+use crate::env::{ENV_ANTHROPIC_API_KEY, ENV_OPENAI_API_KEY};
 
 // ---------------------------------------------------------------------------
 // Constants
@@ -42,6 +46,27 @@ pub enum ProviderKind {
 }
 
 impl ProviderKind {
+    /// All variants, in canonical order.
+    ///
+    /// Compile-time forced: every variant must be listed in [`Self::as_str`]
+    /// to satisfy the exhaustive match, so any new variant added to the enum
+    /// will fail the build until it is added to [`Self::as_str`].
+    pub const ALL: [Self; 3] = [Self::Ollama, Self::Anthropic, Self::OpenAi];
+
+    /// Canonical lowercase name.
+    ///
+    /// Matches the serde `rename_all = "lowercase"` form and is the single
+    /// source of truth for both [`Display`](std::fmt::Display) and
+    /// [`FromStr`](std::str::FromStr).
+    #[must_use]
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::Ollama => "ollama",
+            Self::Anthropic => "anthropic",
+            Self::OpenAi => "openai",
+        }
+    }
+
     /// Returns `true` for cloud providers that require an API key.
     #[must_use]
     pub fn requires_api_key(self) -> bool {
@@ -59,15 +84,44 @@ impl ProviderKind {
             Self::OpenAi => DEFAULT_OPENAI_BASE_URL,
         }
     }
+
+    /// Returns the standard environment variable name carrying this
+    /// provider's API key, if one applies.
+    ///
+    /// Consulted as a final fallback by the config loader when no
+    /// config-file `api_key` or `TRIBAL_*__API_KEY` env var is supplied.
+    /// Returns `None` for providers that do not require an API key.
+    #[must_use]
+    pub fn standard_env_var_name(self) -> Option<&'static str> {
+        match self {
+            Self::Ollama => None,
+            Self::Anthropic => Some(ENV_ANTHROPIC_API_KEY),
+            Self::OpenAi => Some(ENV_OPENAI_API_KEY),
+        }
+    }
+}
+
+impl FromStr for ProviderKind {
+    type Err = String;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        Self::ALL
+            .into_iter()
+            .find(|kind| kind.as_str() == s)
+            .ok_or_else(|| {
+                let expected = Self::ALL
+                    .iter()
+                    .map(|k| k.as_str())
+                    .collect::<Vec<_>>()
+                    .join(", ");
+                format!("unknown provider: {s} (expected one of {expected})")
+            })
+    }
 }
 
 impl std::fmt::Display for ProviderKind {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match self {
-            Self::Ollama => write!(f, "ollama"),
-            Self::Anthropic => write!(f, "anthropic"),
-            Self::OpenAi => write!(f, "openai"),
-        }
+        write!(f, "{}", self.as_str())
     }
 }
 

--- a/crates/tribal-config/src/sections/provider_kind.rs
+++ b/crates/tribal-config/src/sections/provider_kind.rs
@@ -170,4 +170,33 @@ mod tests {
             DEFAULT_OPENAI_BASE_URL,
         );
     }
+
+    #[test]
+    fn test_standard_env_var_name() {
+        assert_eq!(ProviderKind::Ollama.standard_env_var_name(), None);
+        assert_eq!(
+            ProviderKind::Anthropic.standard_env_var_name(),
+            Some(ENV_ANTHROPIC_API_KEY),
+        );
+        assert_eq!(
+            ProviderKind::OpenAi.standard_env_var_name(),
+            Some(ENV_OPENAI_API_KEY),
+        );
+    }
+
+    #[test]
+    fn test_from_str_valid() {
+        for kind in ProviderKind::ALL {
+            assert_eq!(kind.as_str().parse::<ProviderKind>().unwrap(), kind);
+        }
+    }
+
+    #[test]
+    fn test_from_str_invalid() {
+        let err = "grpc".parse::<ProviderKind>().unwrap_err();
+        assert_eq!(
+            err,
+            "unknown provider: grpc (expected one of ollama, anthropic, openai)",
+        );
+    }
 }

--- a/crates/tribal-config/src/sections/root.rs
+++ b/crates/tribal-config/src/sections/root.rs
@@ -96,6 +96,21 @@ impl TribalConfig {
             source: Box::new(e),
         })
     }
+
+    /// Builds the smallest configuration that passes [`crate::validate`].
+    ///
+    /// Defaults for every field except those that have no sensible
+    /// default and must be supplied by the caller. The signature is
+    /// the agreed point of update: when a new always-required field
+    /// joins the schema, it joins this parameter list, forcing every
+    /// caller to provide a value rather than hand-rolling a sentinel
+    /// at each call site.
+    #[must_use]
+    pub fn minimum_valid(database_url: impl Into<String>) -> Self {
+        let mut config = Self::default();
+        config.database.url = database_url.into();
+        config
+    }
 }
 
 impl Default for TribalConfig {

--- a/crates/tribal-config/src/validation.rs
+++ b/crates/tribal-config/src/validation.rs
@@ -309,9 +309,7 @@ mod tests {
     use crate::{DEFAULT_BIND_ADDRESS, ProviderKind};
 
     fn valid_config() -> TribalConfig {
-        let mut config = TribalConfig::default();
-        config.database.url = "postgres://localhost/tribal".into();
-        config
+        TribalConfig::minimum_valid("postgres://localhost/tribal")
     }
 
     #[test]

--- a/crates/tribal-config/src/validation.rs
+++ b/crates/tribal-config/src/validation.rs
@@ -524,7 +524,7 @@ mod tests {
     fn test_validate_rejects_anthropic_embedding_provider() {
         let mut config = valid_config();
         config.embedding.provider = ProviderKind::Anthropic;
-        config.embedding.api_key = Some("sk-test".into());
+        config.embedding.api_key = Some("sk-test".parse().expect("test fixture is valid"));
         let err = validate(&config).unwrap_err();
         let msg = err.to_string();
         assert!(msg.contains("Anthropic does not provide an embedding API"));

--- a/crates/tribal-domain/src/api_key.rs
+++ b/crates/tribal-domain/src/api_key.rs
@@ -1,0 +1,193 @@
+//! Sealed API-key type.
+
+use std::str::FromStr;
+
+use serde::{Deserialize, Serialize};
+use thiserror::Error;
+
+// ---------------------------------------------------------------------------
+// Error
+// ---------------------------------------------------------------------------
+
+/// Failure parsing an [`ApiKey`].
+#[derive(Debug, Clone, PartialEq, Eq, Error)]
+pub enum ApiKeyParseError {
+    /// The input was empty.
+    #[error("api key must not be empty")]
+    Empty,
+
+    /// The input contained one or more whitespace characters.
+    ///
+    /// No production provider issues keys that include whitespace; an
+    /// input that does is almost certainly the result of a trailing
+    /// newline, a wrapped value, or a misconfigured shell substitution.
+    /// Rejecting strictly surfaces the malformed value at the boundary
+    /// instead of silently emitting a broken `Authorization` header.
+    #[error("api key must not contain whitespace")]
+    ContainsWhitespace {
+        /// The full input string that failed to parse.
+        input: String,
+    },
+}
+
+// ---------------------------------------------------------------------------
+// ApiKey
+// ---------------------------------------------------------------------------
+
+/// Provider API key, sealed at construction.
+///
+/// An `ApiKey` value is guaranteed non-empty and free of whitespace.
+/// Every entry point — [`FromStr`], [`TryFrom<String>`], and the serde
+/// `try_from = "String"` deserialise path — funnels through the same
+/// strict validation, so downstream code can rely on the type without
+/// re-checking.
+///
+/// **No `Display`**: deliberately omitted so that accidental
+/// `format!("{key}")` calls fail to compile, preventing the secret from
+/// leaking into log lines or error messages. Use [`Self::as_str`] when
+/// the raw value is genuinely required (e.g. constructing an
+/// `Authorization` header). Serde serialisation goes through
+/// [`From<ApiKey> for String`] rather than `Display`.
+///
+/// Opportunistic callers — where an empty or malformed input should be
+/// treated as "not set" rather than an error — should use
+/// `value.parse::<ApiKey>().ok()` to convert the [`Result`] into an
+/// `Option`, matching the standard idiom.
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(try_from = "String", into = "String")]
+pub struct ApiKey(String);
+
+impl ApiKey {
+    /// Returns the raw key string.
+    ///
+    /// Callers are responsible for not logging or persisting the result;
+    /// redaction lives at the config presentation layer, not on this
+    /// accessor.
+    #[must_use]
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+}
+
+impl AsRef<str> for ApiKey {
+    fn as_ref(&self) -> &str {
+        &self.0
+    }
+}
+
+impl FromStr for ApiKey {
+    type Err = ApiKeyParseError;
+
+    fn from_str(raw: &str) -> Result<Self, Self::Err> {
+        if raw.is_empty() {
+            return Err(ApiKeyParseError::Empty);
+        }
+        if raw.chars().any(char::is_whitespace) {
+            return Err(ApiKeyParseError::ContainsWhitespace {
+                input: raw.to_owned(),
+            });
+        }
+        Ok(Self(raw.to_owned()))
+    }
+}
+
+impl TryFrom<String> for ApiKey {
+    type Error = ApiKeyParseError;
+
+    fn try_from(value: String) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
+
+impl From<ApiKey> for String {
+    fn from(key: ApiKey) -> Self {
+        key.0
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_from_str_accepts_non_empty_no_whitespace() {
+        assert_eq!("sk-abc".parse::<ApiKey>().unwrap().as_str(), "sk-abc");
+    }
+
+    #[test]
+    fn test_from_str_rejects_empty() {
+        assert_eq!("".parse::<ApiKey>(), Err(ApiKeyParseError::Empty));
+    }
+
+    #[test]
+    fn test_from_str_rejects_whitespace_only() {
+        let err = "   ".parse::<ApiKey>().unwrap_err();
+        assert!(matches!(err, ApiKeyParseError::ContainsWhitespace { .. }));
+    }
+
+    #[test]
+    fn test_from_str_rejects_leading_whitespace() {
+        let err = "  sk-abc".parse::<ApiKey>().unwrap_err();
+        assert!(matches!(err, ApiKeyParseError::ContainsWhitespace { .. }));
+    }
+
+    #[test]
+    fn test_from_str_rejects_trailing_whitespace() {
+        let err = "sk-abc\n".parse::<ApiKey>().unwrap_err();
+        assert!(matches!(err, ApiKeyParseError::ContainsWhitespace { .. }));
+    }
+
+    #[test]
+    fn test_from_str_rejects_internal_whitespace() {
+        let err = "sk abc".parse::<ApiKey>().unwrap_err();
+        assert!(matches!(err, ApiKeyParseError::ContainsWhitespace { .. }));
+    }
+
+    #[test]
+    fn test_opportunistic_ok_returns_none_on_malformed() {
+        assert!("".parse::<ApiKey>().ok().is_none());
+        assert!("   ".parse::<ApiKey>().ok().is_none());
+        assert!("sk-abc\n".parse::<ApiKey>().ok().is_none());
+    }
+
+    #[test]
+    fn test_try_from_string_delegates_to_from_str() {
+        let key = ApiKey::try_from("sk-abc".to_owned()).unwrap();
+        assert_eq!(key.as_str(), "sk-abc");
+        assert!(ApiKey::try_from(String::new()).is_err());
+    }
+
+    #[test]
+    fn test_into_string_returns_inner() {
+        let key: ApiKey = "sk-abc".parse().unwrap();
+        assert_eq!(String::from(key), "sk-abc");
+    }
+
+    #[test]
+    fn test_deserialize_accepts_non_empty() {
+        let key: ApiKey = serde_json::from_str("\"sk-abc\"").unwrap();
+        assert_eq!(key.as_str(), "sk-abc");
+    }
+
+    #[test]
+    fn test_deserialize_rejects_empty() {
+        let err = serde_json::from_str::<ApiKey>("\"\"").unwrap_err();
+        assert!(err.to_string().contains("empty"));
+    }
+
+    #[test]
+    fn test_deserialize_rejects_whitespace() {
+        let err = serde_json::from_str::<ApiKey>("\"  sk-abc\"").unwrap_err();
+        assert!(err.to_string().contains("whitespace"));
+    }
+
+    #[test]
+    fn test_serialize_emits_inner_string() {
+        let key: ApiKey = "sk-abc".parse().unwrap();
+        assert_eq!(serde_json::to_string(&key).unwrap(), "\"sk-abc\"");
+    }
+}

--- a/crates/tribal-domain/src/api_key.rs
+++ b/crates/tribal-domain/src/api_key.rs
@@ -12,6 +12,11 @@ use crate::REDACTED;
 // ---------------------------------------------------------------------------
 
 /// Failure parsing an [`ApiKey`].
+///
+/// Variants are intentionally fieldless: parse failures may originate
+/// from a value that is *almost* a real key (a sk-… string with a
+/// trailing newline, say), so carrying the raw input here would defeat
+/// the redaction discipline enforced on [`ApiKey`] itself.
 #[derive(Debug, Clone, PartialEq, Eq, Error)]
 pub enum ApiKeyParseError {
     /// The input was empty.
@@ -26,10 +31,7 @@ pub enum ApiKeyParseError {
     /// Rejecting strictly surfaces the malformed value at the boundary
     /// instead of silently emitting a broken `Authorization` header.
     #[error("api key must not contain whitespace")]
-    ContainsWhitespace {
-        /// The full input string that failed to parse.
-        input: String,
-    },
+    ContainsWhitespace,
 }
 
 // ---------------------------------------------------------------------------
@@ -95,9 +97,7 @@ impl FromStr for ApiKey {
             return Err(ApiKeyParseError::Empty);
         }
         if raw.chars().any(char::is_whitespace) {
-            return Err(ApiKeyParseError::ContainsWhitespace {
-                input: raw.to_owned(),
-            });
+            return Err(ApiKeyParseError::ContainsWhitespace);
         }
         Ok(Self(raw.to_owned()))
     }
@@ -138,25 +138,25 @@ mod tests {
     #[test]
     fn test_from_str_rejects_whitespace_only() {
         let err = "   ".parse::<ApiKey>().unwrap_err();
-        assert!(matches!(err, ApiKeyParseError::ContainsWhitespace { .. }));
+        assert_eq!(err, ApiKeyParseError::ContainsWhitespace);
     }
 
     #[test]
     fn test_from_str_rejects_leading_whitespace() {
         let err = "  sk-abc".parse::<ApiKey>().unwrap_err();
-        assert!(matches!(err, ApiKeyParseError::ContainsWhitespace { .. }));
+        assert_eq!(err, ApiKeyParseError::ContainsWhitespace);
     }
 
     #[test]
     fn test_from_str_rejects_trailing_whitespace() {
         let err = "sk-abc\n".parse::<ApiKey>().unwrap_err();
-        assert!(matches!(err, ApiKeyParseError::ContainsWhitespace { .. }));
+        assert_eq!(err, ApiKeyParseError::ContainsWhitespace);
     }
 
     #[test]
     fn test_from_str_rejects_internal_whitespace() {
         let err = "sk abc".parse::<ApiKey>().unwrap_err();
-        assert!(matches!(err, ApiKeyParseError::ContainsWhitespace { .. }));
+        assert_eq!(err, ApiKeyParseError::ContainsWhitespace);
     }
 
     #[test]
@@ -214,6 +214,24 @@ mod tests {
         assert!(
             debug.contains(REDACTED),
             "debug missing placeholder: {debug}"
+        );
+    }
+
+    #[test]
+    fn test_parse_error_debug_does_not_leak_malformed_input() {
+        // A real key with a trailing newline is the realistic malformed
+        // case; the parse error must not carry the value through to any
+        // log line, tracing call, or test diagnostic.
+        let err = "sk-secret-with-newline\n".parse::<ApiKey>().unwrap_err();
+        let debug = format!("{err:?}");
+        let display = format!("{err}");
+        assert!(
+            !debug.contains("sk-secret-with-newline"),
+            "debug leaked malformed input: {debug}",
+        );
+        assert!(
+            !display.contains("sk-secret-with-newline"),
+            "display leaked malformed input: {display}",
         );
     }
 }

--- a/crates/tribal-domain/src/api_key.rs
+++ b/crates/tribal-domain/src/api_key.rs
@@ -1,9 +1,11 @@
 //! Sealed API-key type.
 
-use std::str::FromStr;
+use std::{fmt, str::FromStr};
 
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
+
+use crate::REDACTED;
 
 // ---------------------------------------------------------------------------
 // Error
@@ -49,13 +51,23 @@ pub enum ApiKeyParseError {
 /// `Authorization` header). Serde serialisation goes through
 /// [`From<ApiKey> for String`] rather than `Display`.
 ///
+/// **Redacting `Debug`**: implemented by hand rather than derived, so
+/// that `tracing::debug!("{key:?}")` and similar paths cannot leak the
+/// raw value either.
+///
 /// Opportunistic callers — where an empty or malformed input should be
 /// treated as "not set" rather than an error — should use
 /// `value.parse::<ApiKey>().ok()` to convert the [`Result`] into an
 /// `Option`, matching the standard idiom.
-#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[derive(Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
 #[serde(try_from = "String", into = "String")]
 pub struct ApiKey(String);
+
+impl fmt::Debug for ApiKey {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_tuple("ApiKey").field(&REDACTED).finish()
+    }
+}
 
 impl ApiKey {
     /// Returns the raw key string.
@@ -189,5 +201,19 @@ mod tests {
     fn test_serialize_emits_inner_string() {
         let key: ApiKey = "sk-abc".parse().unwrap();
         assert_eq!(serde_json::to_string(&key).unwrap(), "\"sk-abc\"");
+    }
+
+    #[test]
+    fn test_debug_does_not_leak_inner_value() {
+        let key: ApiKey = "sk-secret-abc".parse().unwrap();
+        let debug = format!("{key:?}");
+        assert!(
+            !debug.contains("sk-secret-abc"),
+            "debug leaked key: {debug}"
+        );
+        assert!(
+            debug.contains(REDACTED),
+            "debug missing placeholder: {debug}"
+        );
     }
 }

--- a/crates/tribal-domain/src/lib.rs
+++ b/crates/tribal-domain/src/lib.rs
@@ -81,7 +81,7 @@ mod task;
 mod token_usage;
 mod triage;
 
-pub use api_key::ApiKey;
+pub use api_key::{ApiKey, ApiKeyParseError};
 pub use auth_token::{AuthToken, AuthTokenBuilder};
 pub use candidate::{Candidate, RelationHint, SuggestedReference};
 pub use discovery::{Direction, DiscoveryField, ExplorationField};

--- a/crates/tribal-domain/src/lib.rs
+++ b/crates/tribal-domain/src/lib.rs
@@ -65,6 +65,7 @@ mod project;
 mod prompt_role;
 mod prompt_stage;
 mod prompt_version;
+mod redaction;
 mod reference;
 mod reference_kind;
 mod relation;
@@ -108,6 +109,7 @@ pub use project::{Project, ProjectBuilder};
 pub use prompt_role::PromptRole;
 pub use prompt_stage::PromptStage;
 pub use prompt_version::{PromptVersion, PromptVersionBuilder};
+pub use redaction::REDACTED;
 pub use reference::{Reference, ReferenceBuilder};
 pub use reference_kind::ReferenceKind;
 pub use relation::{

--- a/crates/tribal-domain/src/lib.rs
+++ b/crates/tribal-domain/src/lib.rs
@@ -44,6 +44,7 @@ macro_rules! enum_text_conversions {
     };
 }
 
+mod api_key;
 mod auth_token;
 mod candidate;
 mod discovery;
@@ -79,6 +80,7 @@ mod task;
 mod token_usage;
 mod triage;
 
+pub use api_key::ApiKey;
 pub use auth_token::{AuthToken, AuthTokenBuilder};
 pub use candidate::{Candidate, RelationHint, SuggestedReference};
 pub use discovery::{Direction, DiscoveryField, ExplorationField};

--- a/crates/tribal-domain/src/redaction.rs
+++ b/crates/tribal-domain/src/redaction.rs
@@ -1,0 +1,5 @@
+//! Redaction primitives shared across crates.
+
+/// Placeholder substituted for secret values in any presentation layer
+/// that needs to elide them.
+pub const REDACTED: &str = "********";

--- a/crates/tribal-e2e/tests/e2e/concurrent_ingests.rs
+++ b/crates/tribal-e2e/tests/e2e/concurrent_ingests.rs
@@ -27,7 +27,8 @@ async fn test_concurrent_identical_ingests() {
         // OpenAI relation exercises the OpenAI envelope abstraction.
         setup.config(|c| {
             c.inference.relation.provider = ProviderKind::OpenAi;
-            c.inference.relation.api_key = Some("sk-e2e-000000".to_owned());
+            c.inference.relation.api_key =
+                Some("sk-e2e-000000".parse().expect("test fixture is valid"));
         });
     })
     .await;

--- a/crates/tribal-e2e/tests/e2e/cross_batch_relations.rs
+++ b/crates/tribal-e2e/tests/e2e/cross_batch_relations.rs
@@ -26,7 +26,8 @@ async fn test_cross_batch_relations() {
         // Anthropic triage exercises the Anthropic envelope abstraction.
         setup.config(|c| {
             c.inference.triage.provider = ProviderKind::Anthropic;
-            c.inference.triage.api_key = Some("sk-ant-e2e-000000".to_owned());
+            c.inference.triage.api_key =
+                Some("sk-ant-e2e-000000".parse().expect("test fixture is valid"));
         });
 
         setup.graph(|g| {

--- a/crates/tribal-e2e/tests/e2e/duplicate_batch.rs
+++ b/crates/tribal-e2e/tests/e2e/duplicate_batch.rs
@@ -25,9 +25,10 @@ async fn test_duplicate_only_batch() {
         // envelope handling across all three provider implementations.
         setup.config(|c| {
             c.embedding.provider = ProviderKind::OpenAi;
-            c.embedding.api_key = Some("sk-e2e-000000".to_owned());
+            c.embedding.api_key = Some("sk-e2e-000000".parse().expect("test fixture is valid"));
             c.inference.extraction.provider = ProviderKind::Anthropic;
-            c.inference.extraction.api_key = Some("sk-ant-e2e-000000".to_owned());
+            c.inference.extraction.api_key =
+                Some("sk-ant-e2e-000000".parse().expect("test fixture is valid"));
         });
 
         setup.graph(|g| {

--- a/crates/tribal-e2e/tests/e2e/explore.rs
+++ b/crates/tribal-e2e/tests/e2e/explore.rs
@@ -20,7 +20,8 @@ async fn test_explore_graph_traversal() {
         // Anthropic extraction exercises the Anthropic envelope abstraction.
         setup.config(|c| {
             c.inference.extraction.provider = ProviderKind::Anthropic;
-            c.inference.extraction.api_key = Some("sk-ant-e2e-000000".to_owned());
+            c.inference.extraction.api_key =
+                Some("sk-ant-e2e-000000".parse().expect("test fixture is valid"));
         });
     })
     .await;

--- a/crates/tribal-e2e/tests/e2e/feedback.rs
+++ b/crates/tribal-e2e/tests/e2e/feedback.rs
@@ -22,7 +22,7 @@ async fn test_feedback_after_discovery() {
         // OpenAI embedding exercises the OpenAI embed envelope abstraction.
         setup.config(|c| {
             c.embedding.provider = ProviderKind::OpenAi;
-            c.embedding.api_key = Some("sk-e2e-000000".to_owned());
+            c.embedding.api_key = Some("sk-e2e-000000".parse().expect("test fixture is valid"));
         });
     })
     .await;

--- a/crates/tribal-e2e/tests/e2e/provider_retry.rs
+++ b/crates/tribal-e2e/tests/e2e/provider_retry.rs
@@ -23,7 +23,8 @@ async fn test_provider_failure_and_retry() {
         // OpenAI extraction exercises the OpenAI envelope abstraction.
         setup.config(|c| {
             c.inference.extraction.provider = ProviderKind::OpenAi;
-            c.inference.extraction.api_key = Some("sk-e2e-000000".to_owned());
+            c.inference.extraction.api_key =
+                Some("sk-e2e-000000".parse().expect("test fixture is valid"));
         });
     })
     .await;

--- a/crates/tribal-e2e/tests/e2e/relation_normalisation.rs
+++ b/crates/tribal-e2e/tests/e2e/relation_normalisation.rs
@@ -30,7 +30,8 @@ async fn test_relation_normalisation_drops_invalid_edges() {
         // OpenAI triage exercises the OpenAI envelope abstraction.
         setup.config(|c| {
             c.inference.triage.provider = ProviderKind::OpenAi;
-            c.inference.triage.api_key = Some("sk-e2e-000000".to_owned());
+            c.inference.triage.api_key =
+                Some("sk-e2e-000000".parse().expect("test fixture is valid"));
         });
     })
     .await;

--- a/crates/tribal-e2e/tests/e2e/standing.rs
+++ b/crates/tribal-e2e/tests/e2e/standing.rs
@@ -27,7 +27,8 @@ async fn test_standing_and_supersession() {
         // Anthropic relation exercises the Anthropic envelope abstraction.
         setup.config(|c| {
             c.inference.relation.provider = ProviderKind::Anthropic;
-            c.inference.relation.api_key = Some("sk-ant-e2e-000000".to_owned());
+            c.inference.relation.api_key =
+                Some("sk-ant-e2e-000000".parse().expect("test fixture is valid"));
         });
 
         setup.graph(|g| {

--- a/crates/tribal-e2e/tests/harness/config.rs
+++ b/crates/tribal-e2e/tests/harness/config.rs
@@ -1,4 +1,4 @@
-use tribal_config::TribalConfig;
+use tribal_config::{PromptSource, TribalConfig};
 
 // ---------------------------------------------------------------------------
 // Constants
@@ -63,7 +63,10 @@ pub fn test_config(
     config.inference.relation.base_url = Some(relation_url.to_owned());
 
     // -- Prompts -------------------------------------------------------------
-    config.prompts.directory = prompts_dir.to_owned();
+    config.prompts.source = PromptSource::Disk {
+        directory: prompts_dir.to_owned(),
+        hot_reload: false,
+    };
 
     // -- Worker timings ------------------------------------------------------
     config.worker.poll_interval_ms = POLL_INTERVAL_MS;

--- a/crates/tribal-inference/src/registry.rs
+++ b/crates/tribal-inference/src/registry.rs
@@ -580,7 +580,7 @@ mod tests {
 
         let embedding_limits = ProviderLimits {
             max_in_flight: 2,
-            request_timeout: Duration::from_secs(60),
+            request_timeout: Duration::from_mins(1),
         };
         let inference_limits = ProviderLimits {
             max_in_flight: 4,

--- a/crates/tribal-mcp/src/sweep.rs
+++ b/crates/tribal-mcp/src/sweep.rs
@@ -102,11 +102,11 @@ mod tests {
         let job_id = JobId::new();
         txs.insert(
             job_id,
-            make_entry(Duration::from_secs(60), Some(Duration::from_secs(400))),
+            make_entry(Duration::from_mins(1), Some(Duration::from_secs(400))),
         );
 
-        let terminal_ttl = Duration::from_secs(300);
-        let hard_ttl = Duration::from_secs(3600);
+        let terminal_ttl = Duration::from_mins(5);
+        let hard_ttl = Duration::from_hours(1);
         sweep_once(&txs, terminal_ttl, hard_ttl, Instant::now());
 
         assert!(txs.is_empty(), "terminal entry past TTL should be evicted");
@@ -118,11 +118,11 @@ mod tests {
         let job_id = JobId::new();
         txs.insert(
             job_id,
-            make_entry(Duration::from_secs(60), Some(Duration::from_secs(10))),
+            make_entry(Duration::from_mins(1), Some(Duration::from_secs(10))),
         );
 
-        let terminal_ttl = Duration::from_secs(300);
-        let hard_ttl = Duration::from_secs(3600);
+        let terminal_ttl = Duration::from_mins(5);
+        let hard_ttl = Duration::from_hours(1);
         sweep_once(&txs, terminal_ttl, hard_ttl, Instant::now());
 
         assert_eq!(txs.len(), 1, "recent terminal entry should be retained");
@@ -135,8 +135,8 @@ mod tests {
         // Non-terminal entry past hard TTL.
         txs.insert(job_id, make_entry(Duration::from_secs(4000), None));
 
-        let terminal_ttl = Duration::from_secs(300);
-        let hard_ttl = Duration::from_secs(3600);
+        let terminal_ttl = Duration::from_mins(5);
+        let hard_ttl = Duration::from_hours(1);
         sweep_once(&txs, terminal_ttl, hard_ttl, Instant::now());
 
         assert!(
@@ -151,8 +151,8 @@ mod tests {
         let job_id = JobId::new();
         txs.insert(job_id, make_entry(Duration::from_secs(10), None));
 
-        let terminal_ttl = Duration::from_secs(300);
-        let hard_ttl = Duration::from_secs(3600);
+        let terminal_ttl = Duration::from_mins(5);
+        let hard_ttl = Duration::from_hours(1);
         sweep_once(&txs, terminal_ttl, hard_ttl, Instant::now());
 
         assert_eq!(txs.len(), 1, "fresh non-terminal entry should be retained");

--- a/crates/tribal-server/src/cli/command.rs
+++ b/crates/tribal-server/src/cli/command.rs
@@ -164,7 +164,7 @@ impl ServeArgs {
 
         let overrides = CliOverrides {
             server,
-            database: None,
+            ..CliOverrides::default()
         };
         (overrides, self.project)
     }
@@ -198,8 +198,8 @@ impl DatabaseArgs {
             .map(|url| DatabaseCliOverrides { url: Some(url) });
 
         CliOverrides {
-            server: None,
             database,
+            ..CliOverrides::default()
         }
     }
 }

--- a/crates/tribal-server/src/cli/command.rs
+++ b/crates/tribal-server/src/cli/command.rs
@@ -1,7 +1,11 @@
 //! Clap command and argument definitions for the Tribal CLI.
 
 use clap::{ArgAction, Args, CommandFactory, Parser, Subcommand, error::ErrorKind};
-use tribal_config::{CliOverrides, DatabaseCliOverrides, ServerCliOverrides, TransportKind};
+use tribal_config::{
+    CliOverrides, DatabaseCliOverrides, EmbeddingCliOverrides, InferenceCliOverrides,
+    InferenceStageCliOverrides, ProviderKind, ServerCliOverrides, TelemetryCliOverrides,
+    TransportKind,
+};
 
 use super::{default_values::DEFAULT_CONFIG_PATH, styles::STYLES};
 
@@ -199,6 +203,153 @@ impl DatabaseArgs {
 
         CliOverrides {
             database,
+            ..CliOverrides::default()
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Shared provider arguments
+// ---------------------------------------------------------------------------
+
+/// Provider and model selection flags shared across CLI commands.
+///
+/// Flattened into command-specific args structs via `#[command(flatten)]`.
+/// The `into_cli_overrides` method projects each flag into the figment
+/// overlay layer.
+///
+/// API keys are intentionally absent: the cascade picks them up from
+/// `OPENAI_API_KEY` / `ANTHROPIC_API_KEY` or from `TRIBAL_*__API_KEY`,
+/// never from flags.
+#[derive(Debug, Args)]
+pub struct ProviderArgs {
+    /// Embedding provider override.
+    #[arg(
+        long = "embedding-provider",
+        value_parser = clap::value_parser!(ProviderKind),
+        help_heading = "Providers",
+    )]
+    pub embedding_provider: Option<ProviderKind>,
+
+    /// Embedding model name override.
+    #[arg(long = "embedding-model", help_heading = "Providers")]
+    pub embedding_model: Option<String>,
+
+    /// Extraction-stage inference provider override.
+    #[arg(
+        long = "inference-extraction-provider",
+        value_parser = clap::value_parser!(ProviderKind),
+        help_heading = "Providers",
+    )]
+    pub inference_extraction_provider: Option<ProviderKind>,
+
+    /// Extraction-stage inference model name override.
+    #[arg(long = "inference-extraction-model", help_heading = "Providers")]
+    pub inference_extraction_model: Option<String>,
+
+    /// Triage-stage inference provider override.
+    #[arg(
+        long = "inference-triage-provider",
+        value_parser = clap::value_parser!(ProviderKind),
+        help_heading = "Providers",
+    )]
+    pub inference_triage_provider: Option<ProviderKind>,
+
+    /// Triage-stage inference model name override.
+    #[arg(long = "inference-triage-model", help_heading = "Providers")]
+    pub inference_triage_model: Option<String>,
+
+    /// Relation-stage inference provider override.
+    #[arg(
+        long = "inference-relation-provider",
+        value_parser = clap::value_parser!(ProviderKind),
+        help_heading = "Providers",
+    )]
+    pub inference_relation_provider: Option<ProviderKind>,
+
+    /// Relation-stage inference model name override.
+    #[arg(long = "inference-relation-model", help_heading = "Providers")]
+    pub inference_relation_model: Option<String>,
+}
+
+impl ProviderArgs {
+    /// Builds [`CliOverrides`] from explicitly-passed CLI flags.
+    ///
+    /// Each subtree (`embedding`, `inference.*`) is populated only when at
+    /// least one of its flags was supplied, so absent flags never mask
+    /// lower-precedence layers.
+    pub fn into_cli_overrides(self) -> CliOverrides {
+        let embedding = match (self.embedding_provider, self.embedding_model) {
+            (None, None) => None,
+            (provider, model) => Some(EmbeddingCliOverrides { provider, model }),
+        };
+
+        let extraction = inference_stage_overrides(
+            self.inference_extraction_provider,
+            self.inference_extraction_model,
+        );
+        let triage =
+            inference_stage_overrides(self.inference_triage_provider, self.inference_triage_model);
+        let relation = inference_stage_overrides(
+            self.inference_relation_provider,
+            self.inference_relation_model,
+        );
+
+        let inference = if extraction.is_none() && triage.is_none() && relation.is_none() {
+            None
+        } else {
+            Some(InferenceCliOverrides {
+                extraction,
+                triage,
+                relation,
+            })
+        };
+
+        CliOverrides {
+            embedding,
+            inference,
+            ..CliOverrides::default()
+        }
+    }
+}
+
+/// Projects a `(provider, model)` pair into an
+/// [`InferenceStageCliOverrides`], returning `None` when both are absent so
+/// the subtree is omitted from the figment overlay.
+fn inference_stage_overrides(
+    provider: Option<ProviderKind>,
+    model: Option<String>,
+) -> Option<InferenceStageCliOverrides> {
+    match (provider, model) {
+        (None, None) => None,
+        (provider, model) => Some(InferenceStageCliOverrides { provider, model }),
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Shared telemetry arguments
+// ---------------------------------------------------------------------------
+
+/// Telemetry flags shared across CLI commands.
+///
+/// Flattened into command-specific args structs via `#[command(flatten)]`.
+#[derive(Debug, Args)]
+pub struct TelemetryArgs {
+    /// OTLP exporter endpoint override.
+    #[arg(long = "telemetry-otlp-endpoint", help_heading = "Telemetry")]
+    pub telemetry_otlp_endpoint: Option<String>,
+}
+
+impl TelemetryArgs {
+    /// Builds [`CliOverrides`] from explicitly-passed CLI flags.
+    pub fn into_cli_overrides(self) -> CliOverrides {
+        let telemetry = self
+            .telemetry_otlp_endpoint
+            .map(|otlp_endpoint| TelemetryCliOverrides {
+                otlp_endpoint: Some(otlp_endpoint),
+            });
+        CliOverrides {
+            telemetry,
             ..CliOverrides::default()
         }
     }
@@ -625,6 +776,143 @@ mod tests {
         let overrides = args.into_cli_overrides();
         let database = overrides.database.unwrap();
         assert_eq!(database.url.as_deref(), Some("postgres://h/db"));
+    }
+
+    // -- ProviderArgs / TelemetryArgs ---------------------------------------
+
+    /// Parser harness flattening [`ProviderArgs`] for standalone clap tests.
+    #[derive(Debug, Parser)]
+    #[command(no_binary_name = true)]
+    struct ProviderArgsHarness {
+        #[command(flatten)]
+        args: ProviderArgs,
+    }
+
+    /// Parser harness flattening [`TelemetryArgs`] for standalone clap tests.
+    #[derive(Debug, Parser)]
+    #[command(no_binary_name = true)]
+    struct TelemetryArgsHarness {
+        #[command(flatten)]
+        args: TelemetryArgs,
+    }
+
+    #[test]
+    fn test_provider_args_parses_all_flags() {
+        let parsed = ProviderArgsHarness::try_parse_from([
+            "--embedding-provider",
+            "openai",
+            "--embedding-model",
+            "text-embedding-3-small",
+            "--inference-extraction-provider",
+            "anthropic",
+            "--inference-extraction-model",
+            "claude-opus-4",
+            "--inference-triage-provider",
+            "openai",
+            "--inference-triage-model",
+            "gpt-5",
+            "--inference-relation-provider",
+            "anthropic",
+            "--inference-relation-model",
+            "claude-haiku-5",
+        ])
+        .unwrap();
+        let args = parsed.args;
+        assert_eq!(args.embedding_provider, Some(ProviderKind::OpenAi));
+        assert_eq!(
+            args.embedding_model.as_deref(),
+            Some("text-embedding-3-small"),
+        );
+        assert_eq!(
+            args.inference_extraction_provider,
+            Some(ProviderKind::Anthropic),
+        );
+        assert_eq!(
+            args.inference_extraction_model.as_deref(),
+            Some("claude-opus-4"),
+        );
+        assert_eq!(args.inference_triage_provider, Some(ProviderKind::OpenAi));
+        assert_eq!(args.inference_triage_model.as_deref(), Some("gpt-5"));
+        assert_eq!(
+            args.inference_relation_provider,
+            Some(ProviderKind::Anthropic),
+        );
+        assert_eq!(
+            args.inference_relation_model.as_deref(),
+            Some("claude-haiku-5"),
+        );
+    }
+
+    #[test]
+    fn test_provider_args_invalid_provider_rejected() {
+        let result = ProviderArgsHarness::try_parse_from(["--embedding-provider", "grpc"]);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_provider_args_into_cli_overrides_no_flags() {
+        let parsed = ProviderArgsHarness::try_parse_from(std::iter::empty::<&str>()).unwrap();
+        let overrides = parsed.args.into_cli_overrides();
+        assert!(overrides.embedding.is_none());
+        assert!(overrides.inference.is_none());
+    }
+
+    #[test]
+    fn test_provider_args_into_cli_overrides_populated() {
+        let parsed = ProviderArgsHarness::try_parse_from([
+            "--embedding-provider",
+            "openai",
+            "--inference-triage-model",
+            "gpt-5",
+        ])
+        .unwrap();
+        let overrides = parsed.args.into_cli_overrides();
+
+        let embedding = overrides.embedding.expect("embedding subtree populated");
+        assert_eq!(embedding.provider, Some(ProviderKind::OpenAi));
+        assert!(embedding.model.is_none());
+
+        let inference = overrides.inference.expect("inference subtree populated");
+        assert!(inference.extraction.is_none());
+        assert!(inference.relation.is_none());
+        let triage = inference.triage.expect("triage stage populated");
+        assert!(triage.provider.is_none());
+        assert_eq!(triage.model.as_deref(), Some("gpt-5"));
+    }
+
+    #[test]
+    fn test_telemetry_args_parses_endpoint() {
+        let parsed = TelemetryArgsHarness::try_parse_from([
+            "--telemetry-otlp-endpoint",
+            "http://collector.internal:4317",
+        ])
+        .unwrap();
+        assert_eq!(
+            parsed.args.telemetry_otlp_endpoint.as_deref(),
+            Some("http://collector.internal:4317"),
+        );
+    }
+
+    #[test]
+    fn test_telemetry_args_into_cli_overrides_populated() {
+        let parsed = TelemetryArgsHarness::try_parse_from([
+            "--telemetry-otlp-endpoint",
+            "http://collector.internal:4317",
+        ])
+        .unwrap();
+        let overrides = parsed.args.into_cli_overrides();
+        let telemetry = overrides.telemetry.expect("telemetry subtree populated");
+        assert_eq!(
+            telemetry.otlp_endpoint.as_deref(),
+            Some("http://collector.internal:4317"),
+        );
+    }
+
+    #[test]
+    fn test_telemetry_args_into_cli_overrides_no_flags() {
+        let parsed = TelemetryArgsHarness::try_parse_from(std::iter::empty::<&str>()).unwrap();
+        let overrides = parsed.args.into_cli_overrides();
+        assert!(overrides.telemetry.is_none());
     }
 
     // -- Setup defaults ------------------------------------------------------

--- a/crates/tribal-server/src/cli/command.rs
+++ b/crates/tribal-server/src/cli/command.rs
@@ -272,6 +272,11 @@ pub struct ProviderArgs {
     pub inference_relation_model: Option<String>,
 }
 
+// Allowed dead-code: consumed by the `tribal bootstrap` subcommand.
+// Tests exercise this impl directly, but `#[cfg(test)]` usage does not
+// satisfy the production-side reachability check. Remove the annotation
+// when bootstrap flattens [`ProviderArgs`].
+#[allow(dead_code)]
 impl ProviderArgs {
     /// Builds [`CliOverrides`] from explicitly-passed CLI flags.
     ///
@@ -316,6 +321,10 @@ impl ProviderArgs {
 /// Projects a `(provider, model)` pair into an
 /// [`InferenceStageCliOverrides`], returning `None` when both are absent so
 /// the subtree is omitted from the figment overlay.
+//
+// Allowed dead-code: called only by [`ProviderArgs::into_cli_overrides`];
+// removed alongside that impl when `tribal bootstrap` flattens the args.
+#[allow(dead_code)]
 fn inference_stage_overrides(
     provider: Option<ProviderKind>,
     model: Option<String>,
@@ -340,6 +349,11 @@ pub struct TelemetryArgs {
     pub telemetry_otlp_endpoint: Option<String>,
 }
 
+// Allowed dead-code: consumed by the `tribal bootstrap` subcommand.
+// Tests exercise this impl directly, but `#[cfg(test)]` usage does not
+// satisfy the production-side reachability check. Remove the annotation
+// when bootstrap flattens [`TelemetryArgs`].
+#[allow(dead_code)]
 impl TelemetryArgs {
     /// Builds [`CliOverrides`] from explicitly-passed CLI flags.
     pub fn into_cli_overrides(self) -> CliOverrides {

--- a/crates/tribal-server/src/commands/setup/config_file.rs
+++ b/crates/tribal-server/src/commands/setup/config_file.rs
@@ -144,8 +144,7 @@ mod tests {
             .await
             .unwrap();
 
-        let mut config = TribalConfig::default();
-        config.database.url = "postgres://resolved-url/db".to_owned();
+        let config = TribalConfig::minimum_valid("postgres://resolved-url/db");
 
         let warnings = read_and_check_divergence(path_str, &config).await;
         assert_eq!(warnings.len(), 1);

--- a/crates/tribal-server/src/commands/setup/output.rs
+++ b/crates/tribal-server/src/commands/setup/output.rs
@@ -66,31 +66,48 @@ pub(super) fn config_file(out: &mut dyn Write, outcome: &ConfigFileOutcome) {
 }
 
 /// Displays the bearer token and next-step instructions.
-pub(super) fn instructions(out: &mut dyn Write, raw_token: &str) {
-    write_line(out, "");
-    write_line(out, "Setup complete. Your bearer token:");
-    write_line(out, "");
-    write_line(out, &format!("  {raw_token}"));
-    write_line(out, "");
-    write_line(out, "Save this token — it will not be shown again.");
-    write_line(out, "");
-    write_line(out, "Next steps:");
-    write_line(
+///
+/// Unlike the other `output::*` helpers, this one propagates IO failures
+/// rather than swallowing them: the raw bearer token is shown only here,
+/// the database stores just the hash, and the message itself promises
+/// the token "will not be shown again". A silent write failure would
+/// leave the user without recoverable credentials.
+pub(super) fn instructions(out: &mut dyn Write, raw_token: &str) -> io::Result<()> {
+    try_write_line(out, "")?;
+    try_write_line(out, "Setup complete. Your bearer token:")?;
+    try_write_line(out, "")?;
+    try_write_line(out, &format!("  {raw_token}"))?;
+    try_write_line(out, "")?;
+    try_write_line(out, "Save this token — it will not be shown again.")?;
+    try_write_line(out, "")?;
+    try_write_line(out, "Next steps:")?;
+    try_write_line(
         out,
         &format!("  1. Export the token:  export TRIBAL_AUTH_TOKEN=\"{raw_token}\""),
-    );
-    write_line(out, "  2. Register a project:  tribal project register");
-    write_line(out, "");
+    )?;
+    try_write_line(out, "  2. Register a project:  tribal project register")?;
+    try_write_line(out, "")?;
+    Ok(())
 }
 
 // ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------
 
-/// Writes `line` followed by a newline. IO errors are ignored — output is a
-/// best-effort signal, not a correctness mechanism.
+/// Writes `line` followed by a newline, swallowing IO errors.
+///
+/// Suitable for progress lines where loss of output is not a correctness
+/// issue. For output the caller cannot afford to lose (e.g. credentials),
+/// use [`try_write_line`].
 fn write_line(out: &mut dyn Write, line: &str) {
-    let _ = writeln!(out, "{line}");
-    // Flush is a best-effort hint for unbuffered stderr; ignore the result.
-    let _: io::Result<()> = out.flush();
+    let _ = try_write_line(out, line);
+}
+
+/// Writes `line` followed by a newline, returning any IO failure.
+///
+/// Both flavours route through the same code path so that the eventual
+/// move to a CLI design system has a single point of substitution.
+fn try_write_line(out: &mut dyn Write, line: &str) -> io::Result<()> {
+    writeln!(out, "{line}")?;
+    out.flush()
 }

--- a/crates/tribal-server/src/commands/setup/output.rs
+++ b/crates/tribal-server/src/commands/setup/output.rs
@@ -1,6 +1,10 @@
 //! Terminal output for the `tribal setup` command.
 //!
 //! All user-facing presentation lives here, separated from business logic.
+//! Each function takes the destination writer as a parameter so callers
+//! can pipe output to stderr (production) or a `Vec<u8>` (tests).
+
+use std::io::{self, Write};
 
 use super::config_file::ConfigFileOutcome;
 
@@ -9,66 +13,84 @@ use super::config_file::ConfigFileOutcome;
 // ---------------------------------------------------------------------------
 
 /// Reports that the config directory was created or already existed.
-pub(super) fn config_directory(path: &str) {
-    eprintln!("  config directory: {path}");
+pub(super) fn config_directory(out: &mut dyn Write, path: &str) {
+    write_line(out, &format!("  config directory: {path}"));
 }
 
 /// Reports that prompt files were written.
-pub(super) fn prompt_files(path: &str) {
-    eprintln!("  prompt files: {path}");
+pub(super) fn prompt_files(out: &mut dyn Write, path: &str) {
+    write_line(out, &format!("  prompt files: {path}"));
 }
 
 /// Reports a successful database connection.
-pub(super) fn database_connected() {
-    eprintln!("  database: connected");
+pub(super) fn database_connected(out: &mut dyn Write) {
+    write_line(out, "  database: connected");
 }
 
 /// Prints a hint when the database connection fails.
-pub(super) fn database_unreachable() {
-    eprintln!("  hint: verify that PostgreSQL is running and the target database exists");
+pub(super) fn database_unreachable(out: &mut dyn Write) {
+    write_line(
+        out,
+        "  hint: verify that PostgreSQL is running and the target database exists",
+    );
 }
 
 /// Reports that migrations completed.
-pub(super) fn migrations_complete() {
-    eprintln!("  migrations: complete");
+pub(super) fn migrations_complete(out: &mut dyn Write) {
+    write_line(out, "  migrations: complete");
 }
 
 /// Reports the principal that was found or created.
-pub(super) fn principal(key: &str) {
-    eprintln!("  principal: {key}");
+pub(super) fn principal(out: &mut dyn Write, key: &str) {
+    write_line(out, &format!("  principal: {key}"));
 }
 
 /// Reports that a token was created with its expiry date.
-pub(super) fn token_created(expires_date: &str) {
-    eprintln!("  token: created (expires {expires_date})");
+pub(super) fn token_created(out: &mut dyn Write, expires_date: &str) {
+    write_line(out, &format!("  token: created (expires {expires_date})"));
 }
 
 /// Reports the config file outcome (written, skipped, warnings).
-pub(super) fn config_file(outcome: &ConfigFileOutcome) {
+pub(super) fn config_file(out: &mut dyn Write, outcome: &ConfigFileOutcome) {
     match outcome {
         ConfigFileOutcome::Written { path } => {
-            eprintln!("  config file: written to {path}");
+            write_line(out, &format!("  config file: written to {path}"));
         }
         ConfigFileOutcome::AlreadyExists { warnings } => {
-            eprintln!("  config file: already exists, skipping");
+            write_line(out, "  config file: already exists, skipping");
             for warning in warnings {
-                eprintln!("  warning: {warning}");
+                write_line(out, &format!("  warning: {warning}"));
             }
         }
     }
 }
 
 /// Displays the bearer token and next-step instructions.
-pub(super) fn instructions(raw_token: &str) {
-    eprintln!();
-    eprintln!("Setup complete. Your bearer token:");
-    eprintln!();
-    eprintln!("  {raw_token}");
-    eprintln!();
-    eprintln!("Save this token — it will not be shown again.");
-    eprintln!();
-    eprintln!("Next steps:");
-    eprintln!("  1. Export the token:  export TRIBAL_AUTH_TOKEN=\"{raw_token}\"");
-    eprintln!("  2. Register a project:  tribal project register");
-    eprintln!();
+pub(super) fn instructions(out: &mut dyn Write, raw_token: &str) {
+    write_line(out, "");
+    write_line(out, "Setup complete. Your bearer token:");
+    write_line(out, "");
+    write_line(out, &format!("  {raw_token}"));
+    write_line(out, "");
+    write_line(out, "Save this token — it will not be shown again.");
+    write_line(out, "");
+    write_line(out, "Next steps:");
+    write_line(
+        out,
+        &format!("  1. Export the token:  export TRIBAL_AUTH_TOKEN=\"{raw_token}\""),
+    );
+    write_line(out, "  2. Register a project:  tribal project register");
+    write_line(out, "");
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/// Writes `line` followed by a newline. IO errors are ignored — output is a
+/// best-effort signal, not a correctness mechanism.
+fn write_line(out: &mut dyn Write, line: &str) {
+    let _ = writeln!(out, "{line}");
+    // Flush is a best-effort hint for unbuffered stderr; ignore the result.
+    let _: io::Result<()> = out.flush();
 }

--- a/crates/tribal-server/src/commands/setup/run.rs
+++ b/crates/tribal-server/src/commands/setup/run.rs
@@ -91,12 +91,6 @@ async fn run_async(
         })?;
     output::config_directory(out, &config_dir.to_string_lossy());
 
-    if let PromptSource::Disk { directory, .. } = &config.prompts.source {
-        let prompts_dir = Path::new(directory);
-        ensure_prompt_files(prompts_dir).await?;
-        output::prompt_files(out, &prompts_dir.to_string_lossy());
-    }
-
     let pool = tribal_db::create_pool(
         &config.database,
         POOL_NAME_SETUP,
@@ -112,6 +106,15 @@ async fn run_async(
 
     run_migrations(&pool).await?;
     output::migrations_complete(out);
+
+    // Disk prompt-file IO runs after migrations so a setup that fails
+    // at the database or migration step does not leave a half-written
+    // prompts directory or emit the prompts-directory line.
+    if let PromptSource::Disk { directory, .. } = &config.prompts.source {
+        let prompts_dir = Path::new(directory);
+        ensure_prompt_files(prompts_dir).await?;
+        output::prompt_files(out, &prompts_dir.to_string_lossy());
+    }
 
     let mut conn = pool.acquire().await.map_err(|err| {
         AppError::pool_acquire(POOL_NAME_SETUP, "acquiring setup connection", err)
@@ -174,8 +177,7 @@ mod tests {
         let config_dir = tempfile::tempdir().expect("config dir");
         let config_path = config_dir.path().join("tribal.yaml");
 
-        let mut config = TribalConfig::default();
-        config.database.url = ctx.database_url().to_owned();
+        let mut config = TribalConfig::minimum_valid(ctx.database_url());
         config.database.max_connect_attempts = 1;
         // Default `PromptSource::Embedded` — no `prompts.source` override
         // needed.
@@ -212,8 +214,7 @@ mod tests {
         let config_dir = tempfile::tempdir().expect("config dir");
         let config_path = config_dir.path().join("tribal.yaml");
 
-        let mut config = TribalConfig::default();
-        config.database.url = ctx.database_url().to_owned();
+        let mut config = TribalConfig::minimum_valid(ctx.database_url());
         config.database.max_connect_attempts = 1;
         config.prompts.source = PromptSource::Disk {
             directory: prompts_dir.path().to_string_lossy().into_owned(),
@@ -243,5 +244,45 @@ mod tests {
 
         let mut conn = pool.acquire().await.expect("acquire connection");
         assert_eq!(count_prompt_versions(&mut conn).await, 0);
+    }
+
+    #[tokio::test]
+    async fn test_setup_disk_writes_no_prompts_when_database_unreachable() {
+        // Port 1 is privileged on every supported platform, so nothing
+        // listens there; `create_pool` fails fast with
+        // `max_connect_attempts = 1`. No testcontainers handle is needed.
+        let prompts_dir = tempfile::tempdir().expect("prompts dir");
+        let config_dir = tempfile::tempdir().expect("config dir");
+        let config_path = config_dir.path().join("tribal.yaml");
+
+        let mut config = TribalConfig::minimum_valid("postgres://invalid:invalid@127.0.0.1:1/x");
+        config.database.max_connect_attempts = 1;
+        config.prompts.source = PromptSource::Disk {
+            directory: prompts_dir.path().to_string_lossy().into_owned(),
+            hot_reload: false,
+        };
+        let expires_at = Utc::now() + chrono::Duration::hours(1);
+
+        let mut buf: Vec<u8> = Vec::new();
+        let result = run_async(&config, config_path.to_str().unwrap(), expires_at, &mut buf).await;
+        assert!(
+            result.is_err(),
+            "setup must fail when the database is unreachable",
+        );
+
+        let captured = String::from_utf8(buf).expect("utf8");
+        assert!(
+            !captured.contains("prompt files:"),
+            "no prompts-directory line should appear when the database fails first, got:\n{captured}",
+        );
+
+        let entries: Vec<_> = std::fs::read_dir(prompts_dir.path())
+            .expect("read prompts dir")
+            .collect();
+        assert!(
+            entries.is_empty(),
+            "prompts dir must remain empty when the database fails first, got {} entries",
+            entries.len(),
+        );
     }
 }

--- a/crates/tribal-server/src/commands/setup/run.rs
+++ b/crates/tribal-server/src/commands/setup/run.rs
@@ -145,3 +145,100 @@ async fn run_async(
 
     Ok(())
 }
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use tribal_test_utils::{
+        count_prompt_versions, serial_lock, test_context, truncate_all_tables,
+    };
+
+    use super::*;
+
+    #[tokio::test]
+    async fn test_setup_embedded_omits_prompts_directory_line() {
+        let _guard = serial_lock().await;
+        let ctx = test_context().await;
+        let pool = ctx.create_pool().await.expect("create pool");
+
+        let mut conn = pool.acquire().await.expect("acquire connection");
+        truncate_all_tables(&mut conn).await;
+        drop(conn);
+
+        let config_dir = tempfile::tempdir().expect("config dir");
+        let config_path = config_dir.path().join("tribal.yaml");
+
+        let mut config = TribalConfig::default();
+        config.database.url = ctx.database_url().to_owned();
+        config.database.max_connect_attempts = 1;
+        // Default `PromptSource::Embedded` — no `prompts.source` override
+        // needed.
+        let expires_at = Utc::now() + chrono::Duration::hours(1);
+
+        let mut buf: Vec<u8> = Vec::new();
+        run_async(&config, config_path.to_str().unwrap(), expires_at, &mut buf)
+            .await
+            .expect("setup succeeds");
+
+        let captured = String::from_utf8(buf).expect("utf8");
+        assert!(
+            !captured.contains("prompt files:"),
+            "embedded mode must not emit the prompts-directory line, got:\n{captured}",
+        );
+
+        // Setup does not upsert prompts — that responsibility belongs to
+        // `serve`.
+        let mut conn = pool.acquire().await.expect("acquire connection");
+        assert_eq!(count_prompt_versions(&mut conn).await, 0);
+    }
+
+    #[tokio::test]
+    async fn test_setup_disk_emits_prompts_directory_line_and_writes_files() {
+        let _guard = serial_lock().await;
+        let ctx = test_context().await;
+        let pool = ctx.create_pool().await.expect("create pool");
+
+        let mut conn = pool.acquire().await.expect("acquire connection");
+        truncate_all_tables(&mut conn).await;
+        drop(conn);
+
+        let prompts_dir = tempfile::tempdir().expect("prompts dir");
+        let config_dir = tempfile::tempdir().expect("config dir");
+        let config_path = config_dir.path().join("tribal.yaml");
+
+        let mut config = TribalConfig::default();
+        config.database.url = ctx.database_url().to_owned();
+        config.database.max_connect_attempts = 1;
+        config.prompts.source = PromptSource::Disk {
+            directory: prompts_dir.path().to_string_lossy().into_owned(),
+            hot_reload: false,
+        };
+        let expires_at = Utc::now() + chrono::Duration::hours(1);
+
+        let mut buf: Vec<u8> = Vec::new();
+        run_async(&config, config_path.to_str().unwrap(), expires_at, &mut buf)
+            .await
+            .expect("setup succeeds");
+
+        let captured = String::from_utf8(buf).expect("utf8");
+        let expected = format!("prompt files: {}", prompts_dir.path().display());
+        assert!(
+            captured.contains(&expected),
+            "disk mode must emit the prompts-directory line, got:\n{captured}",
+        );
+
+        // The six embedded defaults must have been written to disk.
+        for stage in ["extraction", "triage", "relation"] {
+            for role in ["system.tera", "user.tera"] {
+                let file = prompts_dir.path().join(stage).join(role);
+                assert!(file.exists(), "missing prompt file: {}", file.display());
+            }
+        }
+
+        let mut conn = pool.acquire().await.expect("acquire connection");
+        assert_eq!(count_prompt_versions(&mut conn).await, 0);
+    }
+}

--- a/crates/tribal-server/src/commands/setup/run.rs
+++ b/crates/tribal-server/src/commands/setup/run.rs
@@ -141,7 +141,10 @@ async fn run_async(
     let outcome = config_file::write_if_absent(config_path, config).await?;
     output::config_file(out, &outcome);
 
-    output::instructions(out, &raw_token);
+    output::instructions(out, &raw_token).map_err(|source| AppError::SetupIo {
+        context: "writing bearer token output".into(),
+        source,
+    })?;
 
     Ok(())
 }

--- a/crates/tribal-server/src/commands/setup/run.rs
+++ b/crates/tribal-server/src/commands/setup/run.rs
@@ -4,7 +4,7 @@ use std::path::Path;
 
 use chrono::{DateTime, Utc};
 use tribal_common::sha256_hex;
-use tribal_config::{TribalConfig, load_config};
+use tribal_config::{PromptSource, TribalConfig, load_config};
 use tribal_db::{AuthTokenRepository, NewAuthToken, PgAuthTokenRepository};
 use tribal_domain::{LOCAL_PRINCIPAL_KEY, full_access_scopes};
 
@@ -81,9 +81,11 @@ async fn run_async(
         })?;
     output::config_directory(&config_dir.to_string_lossy());
 
-    let prompts_dir = Path::new(&config.prompts.directory);
-    ensure_prompt_files(prompts_dir).await?;
-    output::prompt_files(&prompts_dir.to_string_lossy());
+    if let PromptSource::Disk { directory, .. } = &config.prompts.source {
+        let prompts_dir = Path::new(directory);
+        ensure_prompt_files(prompts_dir).await?;
+        output::prompt_files(&prompts_dir.to_string_lossy());
+    }
 
     let pool = tribal_db::create_pool(
         &config.database,

--- a/crates/tribal-server/src/commands/setup/run.rs
+++ b/crates/tribal-server/src/commands/setup/run.rs
@@ -1,6 +1,9 @@
 //! Core setup flow: entry point and async orchestration.
 
-use std::path::Path;
+use std::{
+    io::{self, Write},
+    path::Path,
+};
 
 use chrono::{DateTime, Utc};
 use tribal_common::sha256_hex;
@@ -57,7 +60,13 @@ pub(crate) fn run(config_path: &str, args: SetupArgs) -> Result<(), AppError> {
         .build()
         .map_err(|source| AppError::Runtime { source })?;
 
-    rt.block_on(run_async(&config, &expanded_config_path, expires_at))
+    let mut stderr = io::stderr().lock();
+    rt.block_on(run_async(
+        &config,
+        &expanded_config_path,
+        expires_at,
+        &mut stderr,
+    ))
 }
 
 // ---------------------------------------------------------------------------
@@ -69,6 +78,7 @@ async fn run_async(
     config: &TribalConfig,
     config_path: &str,
     expires_at: DateTime<Utc>,
+    out: &mut dyn Write,
 ) -> Result<(), AppError> {
     let config_dir = Path::new(config_path)
         .parent()
@@ -79,12 +89,12 @@ async fn run_async(
             context: format!("create config directory {}", config_dir.display()),
             source,
         })?;
-    output::config_directory(&config_dir.to_string_lossy());
+    output::config_directory(out, &config_dir.to_string_lossy());
 
     if let PromptSource::Disk { directory, .. } = &config.prompts.source {
         let prompts_dir = Path::new(directory);
         ensure_prompt_files(prompts_dir).await?;
-        output::prompt_files(&prompts_dir.to_string_lossy());
+        output::prompt_files(out, &prompts_dir.to_string_lossy());
     }
 
     let pool = tribal_db::create_pool(
@@ -95,20 +105,20 @@ async fn run_async(
     )
     .await
     .map_err(|source| {
-        output::database_unreachable();
+        output::database_unreachable(out);
         AppError::Database { source }
     })?;
-    output::database_connected();
+    output::database_connected(out);
 
     run_migrations(&pool).await?;
-    output::migrations_complete();
+    output::migrations_complete(out);
 
     let mut conn = pool.acquire().await.map_err(|err| {
         AppError::pool_acquire(POOL_NAME_SETUP, "acquiring setup connection", err)
     })?;
 
     let principal = find_or_create_principal(&mut conn, LOCAL_PRINCIPAL_KEY).await?;
-    output::principal(principal.principal_key());
+    output::principal(out, principal.principal_key());
 
     let raw_token = generate_raw_token();
     let token_hash = sha256_hex(&raw_token);
@@ -124,14 +134,14 @@ async fn run_async(
         .insert(&mut conn, &new_token)
         .await
         .map_err(|source| AppError::Database { source })?;
-    output::token_created(&expires_at.format(TIMESTAMP_FORMAT).to_string());
+    output::token_created(out, &expires_at.format(TIMESTAMP_FORMAT).to_string());
 
     drop(conn);
 
     let outcome = config_file::write_if_absent(config_path, config).await?;
-    output::config_file(&outcome);
+    output::config_file(out, &outcome);
 
-    output::instructions(&raw_token);
+    output::instructions(out, &raw_token);
 
     Ok(())
 }

--- a/crates/tribal-server/src/main.rs
+++ b/crates/tribal-server/src/main.rs
@@ -2,13 +2,16 @@
 #![deny(warnings)]
 //! Tribal server binary — CLI entry point.
 
-use std::process;
+use std::process::ExitCode;
 
 use tribal::App;
 
-fn main() {
-    if let Err(err) = App::parse().run() {
-        eprintln!("{err}");
-        process::exit(err.exit_code());
+fn main() -> ExitCode {
+    match App::parse().run() {
+        Ok(()) => ExitCode::SUCCESS,
+        Err(err) => {
+            eprintln!("{err}");
+            u8::try_from(err.exit_code()).map_or(ExitCode::FAILURE, ExitCode::from)
+        }
     }
 }

--- a/crates/tribal-server/src/orchestration.rs
+++ b/crates/tribal-server/src/orchestration.rs
@@ -16,7 +16,7 @@ use tokio::{
 };
 use tokio_util::sync::CancellationToken;
 use tribal_common::JobStateTxs;
-use tribal_config::TribalConfig;
+use tribal_config::{PromptSource, TribalConfig};
 use tribal_mcp::{AppState, build_inference_parameters};
 use tribal_telemetry::{MetricsRecorder, TelemetryGuard};
 use tribal_worker::{Worker, WorkerError};
@@ -26,7 +26,8 @@ use crate::{
     startup::{
         POOL_NAME_MCP, POOL_NAME_WORKER, build_embedding_provider, build_inference_provider,
         build_provider_registry, check_first_run, create_pool_with_retry, ensure_prompt_files,
-        generate_instance_id, init_prompt_watcher, load_prompts, resolve_project, run_migrations,
+        generate_instance_id, init_prompt_watcher, load_prompts, load_prompts_embedded,
+        resolve_project, run_migrations,
     },
 };
 
@@ -285,8 +286,12 @@ pub fn start_server(
     // JoinHandle discarded — the watcher is a convenience feature, not
     // a correctness mechanism.  If it panics, prompts remain at the last
     // loaded version until the process restarts.
-    if config.prompts.hot_reload {
-        let prompts_dir = expand_prompts_dir(&config.prompts.directory);
+    if let PromptSource::Disk {
+        directory,
+        hot_reload: true,
+    } = &config.prompts.source
+    {
+        let prompts_dir = expand_prompts_dir(directory);
         let watcher_future = init_prompt_watcher(
             prompts_dir,
             state.mcp_pool().clone(),
@@ -352,9 +357,14 @@ async fn bootstrap(
 
     // -- Prompts -------------------------------------------------------------
 
-    let prompts_dir = expand_prompts_dir(&config.prompts.directory);
-    ensure_prompt_files(&prompts_dir).await?;
-    let active_prompt_versions = load_prompts(&pool_mcp, &prompts_dir).await?;
+    let active_prompt_versions = match &config.prompts.source {
+        PromptSource::Embedded {} => load_prompts_embedded(&pool_mcp).await?,
+        PromptSource::Disk { directory, .. } => {
+            let prompts_dir = expand_prompts_dir(directory);
+            ensure_prompt_files(&prompts_dir).await?;
+            load_prompts(&pool_mcp, &prompts_dir).await?
+        }
+    };
 
     // -- Providers -----------------------------------------------------------
 

--- a/crates/tribal-server/src/orchestration.rs
+++ b/crates/tribal-server/src/orchestration.rs
@@ -481,6 +481,9 @@ impl Drop for WorkerDeathGuard {
 // ---------------------------------------------------------------------------
 
 /// Expands tilde (`~`) in the prompts directory path.
+///
+/// Defensive: covers programmatic callers that assemble a config
+/// without routing it through the loader's path-expansion contract.
 fn expand_prompts_dir(raw: &str) -> PathBuf {
     PathBuf::from(shellexpand::tilde(raw).as_ref())
 }

--- a/crates/tribal-server/src/startup.rs
+++ b/crates/tribal-server/src/startup.rs
@@ -18,7 +18,9 @@ pub(crate) use database::create_pool_with_retry;
 pub(crate) use instance_id::generate_instance_id;
 pub(crate) use migration::{check_first_run, run_migrations};
 pub(crate) use project::resolve_project;
-pub(crate) use prompts::{PromptTemplateLocation, ensure_prompt_files, load_prompts};
+pub(crate) use prompts::{
+    PromptTemplateLocation, ensure_prompt_files, load_prompts, load_prompts_embedded,
+};
 pub(crate) use providers::{
     build_embedding_provider, build_inference_provider, build_provider_registry,
 };

--- a/crates/tribal-server/src/startup/prompts.rs
+++ b/crates/tribal-server/src/startup/prompts.rs
@@ -194,6 +194,44 @@ pub(crate) async fn load_prompts(
     pool: &PgPool,
     prompts_dir: &Path,
 ) -> Result<ActivePromptVersions, AppError> {
+    let mut contents = Vec::with_capacity(PromptTemplateLocation::ALL.len());
+    for location in PromptTemplateLocation::ALL {
+        let file_path = location.resolve(prompts_dir);
+        let content = tokio::fs::read_to_string(&file_path)
+            .await
+            .map_err(|source| AppError::PromptIo {
+                context: format!("read {}", file_path.display()),
+                source,
+            })?;
+        contents.push((location, content));
+    }
+    upsert_prompt_versions(pool, contents).await
+}
+
+/// Hashes and upserts the six prompts compiled into the binary.
+///
+/// Used when [`PromptSource::Embedded`](tribal_config::PromptSource::Embedded)
+/// is in effect: no filesystem IO, no user-editable files. The on-disk
+/// equivalent is [`load_prompts`].
+pub(crate) async fn load_prompts_embedded(
+    pool: &PgPool,
+) -> Result<ActivePromptVersions, AppError> {
+    let contents = PromptTemplateLocation::ALL
+        .into_iter()
+        .map(|location| (location, embedded_default(location).to_owned()));
+    upsert_prompt_versions(pool, contents).await
+}
+
+/// Hashes each `(location, content)` pair and upserts via the prompt-version
+/// repository.
+///
+/// Shared by [`load_prompts`] and [`load_prompts_embedded`] so the disk and
+/// embedded paths produce byte-identical database rows when the on-disk
+/// files contain the embedded defaults.
+async fn upsert_prompt_versions(
+    pool: &PgPool,
+    contents: impl IntoIterator<Item = (PromptTemplateLocation, String)>,
+) -> Result<ActivePromptVersions, AppError> {
     let repo = PgPromptVersionRepository;
     let mut conn = pool
         .acquire()
@@ -203,16 +241,7 @@ pub(crate) async fn load_prompts(
     let mut versions: HashMap<(PromptStage, PromptRole), PromptVersionId> =
         HashMap::with_capacity(PromptTemplateLocation::ALL.len());
 
-    for location in &PromptTemplateLocation::ALL {
-        let file_path = location.resolve(prompts_dir);
-
-        let content = tokio::fs::read_to_string(&file_path)
-            .await
-            .map_err(|source| AppError::PromptIo {
-                context: format!("read {}", file_path.display()),
-                source,
-            })?;
-
+    for (location, content) in contents {
         let content_hash = sha256_hex(&content);
         let stage = location.stage();
         let role = location.role();

--- a/crates/tribal-server/src/startup/prompts.rs
+++ b/crates/tribal-server/src/startup/prompts.rs
@@ -213,9 +213,7 @@ pub(crate) async fn load_prompts(
 /// Used when [`PromptSource::Embedded`](tribal_config::PromptSource::Embedded)
 /// is in effect: no filesystem IO, no user-editable files. The on-disk
 /// equivalent is [`load_prompts`].
-pub(crate) async fn load_prompts_embedded(
-    pool: &PgPool,
-) -> Result<ActivePromptVersions, AppError> {
+pub(crate) async fn load_prompts_embedded(pool: &PgPool) -> Result<ActivePromptVersions, AppError> {
     let contents = PromptTemplateLocation::ALL
         .into_iter()
         .map(|location| (location, embedded_default(location).to_owned()));

--- a/crates/tribal-server/src/startup/prompts.rs
+++ b/crates/tribal-server/src/startup/prompts.rs
@@ -456,4 +456,42 @@ mod tests {
         let content = std::fs::read_to_string(&custom_path).expect("should read");
         assert_eq!(content, custom, "existing file must not be overwritten");
     }
+
+    #[tokio::test]
+    async fn test_embedded_and_disk_paths_produce_equal_version_ids() {
+        use tribal_test_utils::{serial_lock, test_context, truncate_all_tables};
+
+        let _guard = serial_lock().await;
+        let ctx = test_context().await;
+        let pool = ctx.create_pool().await.expect("create pool");
+
+        let mut conn = pool.acquire().await.expect("acquire connection");
+        truncate_all_tables(&mut conn).await;
+        drop(conn);
+
+        // `ensure_prompt_files` writes the embedded defaults to disk, so
+        // both paths receive byte-identical content. Equal `content_hash`
+        // values yield equal `PromptVersionId`s through the upsert.
+        let prompts_dir = tempfile::tempdir().expect("create prompts dir");
+        ensure_prompt_files(prompts_dir.path())
+            .await
+            .expect("write defaults");
+
+        let embedded = load_prompts_embedded(&pool)
+            .await
+            .expect("load embedded prompts");
+        let disk = load_prompts(&pool, prompts_dir.path())
+            .await
+            .expect("load disk prompts");
+
+        for location in &PromptTemplateLocation::ALL {
+            let stage = location.stage();
+            let role = location.role();
+            assert_eq!(
+                embedded.get_version(stage, role),
+                disk.get_version(stage, role),
+                "embedded and disk paths must produce equal version IDs for {stage}/{role}",
+            );
+        }
+    }
 }

--- a/crates/tribal-server/src/startup/providers.rs
+++ b/crates/tribal-server/src/startup/providers.rs
@@ -89,7 +89,11 @@ pub(crate) async fn build_embedding_provider(
                 client,
                 &url,
                 &config.model,
-                config.api_key.as_deref().unwrap_or_default(),
+                config
+                    .api_key
+                    .as_ref()
+                    .map(tribal_domain::ApiKey::as_str)
+                    .unwrap_or_default(),
                 config.dimensions,
             );
             if let Err(e) = p.probe_model().await {
@@ -137,7 +141,11 @@ pub(crate) async fn build_inference_provider(
                 client,
                 &url,
                 &config.model,
-                config.api_key.as_deref().unwrap_or_default(),
+                config
+                    .api_key
+                    .as_ref()
+                    .map(tribal_domain::ApiKey::as_str)
+                    .unwrap_or_default(),
             );
             if let Err(e) = p.probe_model().await {
                 tracing::warn!(%e, "inference model probe failed (non-fatal)");
@@ -149,7 +157,11 @@ pub(crate) async fn build_inference_provider(
                 client,
                 &url,
                 &config.model,
-                config.api_key.as_deref().unwrap_or_default(),
+                config
+                    .api_key
+                    .as_ref()
+                    .map(tribal_domain::ApiKey::as_str)
+                    .unwrap_or_default(),
             );
             if let Err(e) = p.probe_model().await {
                 tracing::warn!(%e, "inference model probe failed (non-fatal)");

--- a/crates/tribal-server/src/transport/sse_lifecycle.rs
+++ b/crates/tribal-server/src/transport/sse_lifecycle.rs
@@ -49,7 +49,7 @@ const CLOSURE_REASON_IDLE: &str = "idle_timeout";
 /// Fallback duration used when a configured lifecycle timeout overflows
 /// `Instant`.  One year is far beyond any realistic timeout and safely
 /// within `Instant`'s representable range on all platforms.
-const OVERFLOW_FALLBACK: Duration = Duration::from_secs(365 * 24 * 3600);
+const OVERFLOW_FALLBACK: Duration = Duration::new(365 * 24 * 3600, 0);
 
 // ---------------------------------------------------------------------------
 // Activity tracker

--- a/crates/tribal-server/src/transport/sse_lifecycle.rs
+++ b/crates/tribal-server/src/transport/sse_lifecycle.rs
@@ -49,6 +49,8 @@ const CLOSURE_REASON_IDLE: &str = "idle_timeout";
 /// Fallback duration used when a configured lifecycle timeout overflows
 /// `Instant`.  One year is far beyond any realistic timeout and safely
 /// within `Instant`'s representable range on all platforms.
+// `Duration::from_days` is not yet stable as a const fn (rust-lang #120301),
+// so the year-in-seconds literal is the cleanest option in const context.
 const OVERFLOW_FALLBACK: Duration = Duration::new(365 * 24 * 3600, 0);
 
 // ---------------------------------------------------------------------------
@@ -563,7 +565,7 @@ mod tests {
 
     /// Long deadline used as the "other" timeout when only one deadline
     /// is under test, ensuring it never fires.
-    const FAR_FUTURE: Duration = Duration::from_secs(60);
+    const FAR_FUTURE: Duration = Duration::from_mins(1);
 
     // -- Mock body ----------------------------------------------------------
 

--- a/crates/tribal-test-utils/src/duration.rs
+++ b/crates/tribal-test-utils/src/duration.rs
@@ -57,7 +57,7 @@ pub const HEARTBEAT_DETECT: Duration = Duration::from_secs(2);
 ///
 /// Must exceed `test_config().task_timeout_ms` (`5_000`) by a wide
 /// margin to guarantee the reclaim sweep treats the task as stale.
-pub const STALE_HEARTBEAT_BACKDATE: Duration = Duration::from_secs(120);
+pub const STALE_HEARTBEAT_BACKDATE: Duration = Duration::from_mins(2);
 
 // ---------------------------------------------------------------------------
 // Mock provider simulation

--- a/crates/tribal-test-utils/src/lifecycle.rs
+++ b/crates/tribal-test-utils/src/lifecycle.rs
@@ -273,6 +273,26 @@ pub async fn count_tasks_by_status(conn: &mut PgConnection, status: &str) -> i64
 }
 
 // ---------------------------------------------------------------------------
+// count_prompt_versions
+// ---------------------------------------------------------------------------
+
+/// Counts rows in the `prompt_versions` table.
+///
+/// Used by setup-flow tests to assert that the `tribal setup` command
+/// does not upsert prompts (that responsibility belongs to `tribal
+/// serve`).
+///
+/// # Panics
+///
+/// Panics if the database query fails.
+pub async fn count_prompt_versions(conn: &mut PgConnection) -> i64 {
+    sqlx::query_scalar("SELECT count(*) FROM prompt_versions")
+        .fetch_one(&mut *conn)
+        .await
+        .expect("lifecycle: count prompt versions")
+}
+
+// ---------------------------------------------------------------------------
 // set_task_status_by_job
 // ---------------------------------------------------------------------------
 


### PR DESCRIPTION
Back from evals.

Implements standard environment variable fallback behaviour to remove friction; if there is an `OPENAI_API_KEY` or an `ANTHROPIC_API_KEY` available in the environment it can now be relied upon for compatible providers at any stage in the pipeline.

Makes updates to config shape to ensure invalid states are unrepresentable, as well as some other quality-of-life updates.

Closes tribal-memory/cortex#45. Closes tribal-memory/cortex#42.

Let's go M8!