### PR TITLE
[TRIBAL 8.4] Implement docker compose onboarding and GHCR publish workflow

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,11 @@
+target/
+.git/
+.github/
+node_modules/
+.claude/
+.scratch/
+.idea/
+.vscode/
+*.swp
+.DS_Store
+docs/

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,11 +1,17 @@
 target/
 .git/
 .github/
-node_modules/
 .claude/
+.codex/
+.reviews/
 .scratch/
-.idea/
-.vscode/
 *.swp
 .DS_Store
 docs/
+
+# Environment files may carry real API keys; keep them out of the
+# build context. `.env.example` is the documented template and is safe
+# to ship.
+.env
+.env.*
+!.env.example

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,7 +29,10 @@ jobs:
       - run: cargo sqlx prepare --check --workspace
       - name: Install yq
         run: |
-          sudo curl -L \
+          # --fail aborts on 4xx/5xx so a transient error response is not
+          # written as the executable; --silent --show-error keeps output
+          # quiet on success but surfaces real failures.
+          sudo curl --fail --silent --show-error --location \
             https://github.com/mikefarah/yq/releases/download/v4.44.3/yq_linux_amd64 \
             -o /usr/local/bin/yq
           sudo chmod +x /usr/local/bin/yq

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
     name: Lint & Format
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: dtolnay/rust-toolchain@nightly
         with:
           components: rustfmt
@@ -27,12 +27,28 @@ jobs:
       - run: cargo clippy --workspace --all-targets -- -D warnings
       - run: cargo install sqlx-cli --version ^0.8 --locked --no-default-features --features postgres
       - run: cargo sqlx prepare --check --workspace
+      - name: Install yq
+        run: |
+          sudo curl -L \
+            https://github.com/mikefarah/yq/releases/download/v4.44.3/yq_linux_amd64 \
+            -o /usr/local/bin/yq
+          sudo chmod +x /usr/local/bin/yq
+      - name: Compose image pin matches workspace version
+        run: |
+          version=$(cargo metadata --no-deps --format-version=1 \
+            | jq -r '.packages[] | select(.name=="tribal") | .version')
+          expected="ghcr.io/samfolo/tribal:${version}"
+          actual=$(yq -r '.services.tribal.image' docker-compose.yml)
+          if [[ "$actual" != "$expected" ]]; then
+            echo "::error::docker-compose.yml image tag drift: expected '${expected}', found '${actual}'"
+            exit 1
+          fi
 
   test:
     name: Test
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
       - run: cargo test --workspace --exclude tribal-e2e --features tribal/test-helpers
@@ -41,7 +57,7 @@ jobs:
     name: E2E Tests
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
       - run: cargo test -p tribal-e2e
@@ -50,7 +66,7 @@ jobs:
     name: Security & Licence Audit
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
       - run: cargo install cargo-deny

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -7,6 +7,9 @@ on:
   pull_request:
     branches: [main]
 
+env:
+  IMAGE_NAME: ghcr.io/samfolo/tribal
+
 jobs:
   shellcheck:
     name: Shellcheck entrypoint
@@ -18,44 +21,119 @@ jobs:
       - run: shellcheck scripts/tribal-entrypoint
 
   build-verify:
-    name: Build image (verify)
+    name: Build image (verify) - ${{ matrix.platform }}
     if: ${{ !startsWith(github.ref, 'refs/tags/') }}
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.runs-on }}
     permissions:
       contents: read
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - platform: linux/amd64
+            runs-on: ubuntu-latest
+          - platform: linux/arm64
+            runs-on: ubuntu-24.04-arm
     steps:
       - uses: actions/checkout@v6
       - uses: docker/setup-buildx-action@v4
+      - name: Extract metadata
+        id: meta
+        uses: docker/metadata-action@v6
+        with:
+          images: ${{ env.IMAGE_NAME }}
       - uses: docker/build-push-action@v7
         with:
           context: .
-          platforms: linux/amd64
+          platforms: ${{ matrix.platform }}
           push: false
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha,scope=${{ matrix.platform }}
+          cache-to: type=gha,mode=max,scope=${{ matrix.platform }}
 
   publish:
-    name: Build and push image to GHCR
+    name: Build and push - ${{ matrix.platform }}
+    if: startsWith(github.ref, 'refs/tags/')
+    runs-on: ${{ matrix.runs-on }}
+    permissions:
+      contents: read
+      packages: write
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - platform: linux/amd64
+            runs-on: ubuntu-latest
+          - platform: linux/arm64
+            runs-on: ubuntu-24.04-arm
+    steps:
+      - uses: actions/checkout@v6
+      - uses: docker/setup-buildx-action@v4
+      - uses: docker/login-action@v4
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Extract metadata
+        id: meta
+        uses: docker/metadata-action@v6
+        with:
+          images: ${{ env.IMAGE_NAME }}
+      - name: Build and push by digest
+        id: build
+        uses: docker/build-push-action@v7
+        with:
+          context: .
+          platforms: ${{ matrix.platform }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha,scope=${{ matrix.platform }}
+          cache-to: type=gha,mode=max,scope=${{ matrix.platform }}
+          outputs: type=image,name=${{ env.IMAGE_NAME }},push-by-digest=true,name-canonical=true,push=true
+      - name: Export digest
+        run: |
+          mkdir -p /tmp/digests
+          digest="${{ steps.build.outputs.digest }}"
+          touch "/tmp/digests/${digest#sha256:}"
+      - name: Upload digest artefact
+        uses: actions/upload-artifact@v7
+        with:
+          name: digests-${{ matrix.platform == 'linux/amd64' && 'amd64' || 'arm64' }}
+          path: /tmp/digests/*
+          if-no-files-found: error
+          retention-days: 1
+
+  merge:
+    name: Merge multi-arch manifest
+    needs: publish
     if: startsWith(github.ref, 'refs/tags/')
     runs-on: ubuntu-latest
     permissions:
       contents: read
       packages: write
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/download-artifact@v8
+        with:
+          path: /tmp/digests
+          pattern: digests-*
+          merge-multiple: true
       - uses: docker/setup-buildx-action@v4
+      - uses: docker/login-action@v4
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
       - name: Determine version tag
         id: version
         run: |
           tag="${GITHUB_REF#refs/tags/}"
           version="${tag#v}"
           echo "version=${version}" >> "$GITHUB_OUTPUT"
-      - uses: docker/login-action@v4
-        with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-      - uses: docker/build-push-action@v7
-        with:
-          context: .
-          platforms: linux/amd64
-          push: true
-          tags: ghcr.io/samfolo/tribal:${{ steps.version.outputs.version }}
+      - name: Create manifest list
+        working-directory: /tmp/digests
+        run: |
+          docker buildx imagetools create \
+            -t ${{ env.IMAGE_NAME }}:${{ steps.version.outputs.version }} \
+            $(printf '${{ env.IMAGE_NAME }}@sha256:%s ' *)
+      - name: Inspect image
+        run: |
+          docker buildx imagetools inspect ${{ env.IMAGE_NAME }}:${{ steps.version.outputs.version }}

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,0 +1,61 @@
+name: Docker
+
+on:
+  push:
+    branches: ["**"]
+    tags: ['**[0-9]+.[0-9]+.[0-9]+*']
+  pull_request:
+    branches: [main]
+
+jobs:
+  shellcheck:
+    name: Shellcheck entrypoint
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v6
+      - run: shellcheck scripts/tribal-entrypoint
+
+  build-verify:
+    name: Build image (verify)
+    if: ${{ !startsWith(github.ref, 'refs/tags/') }}
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v6
+      - uses: docker/setup-buildx-action@v4
+      - uses: docker/build-push-action@v7
+        with:
+          context: .
+          platforms: linux/amd64
+          push: false
+
+  publish:
+    name: Build and push image to GHCR
+    if: startsWith(github.ref, 'refs/tags/')
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - uses: actions/checkout@v6
+      - uses: docker/setup-buildx-action@v4
+      - name: Determine version tag
+        id: version
+        run: |
+          tag="${GITHUB_REF#refs/tags/}"
+          version="${tag#v}"
+          echo "version=${version}" >> "$GITHUB_OUTPUT"
+      - uses: docker/login-action@v4
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - uses: docker/build-push-action@v7
+        with:
+          context: .
+          platforms: linux/amd64
+          push: true
+          tags: ghcr.io/samfolo/tribal:${{ steps.version.outputs.version }}

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -42,6 +42,13 @@ jobs:
             runs-on: ubuntu-24.04-arm
     steps:
       - uses: actions/checkout@v6
+        with:
+          # build.rs derives `TRIBAL_GIT_DESCRIBE` from the working-tree git
+          # state; fetch tags + history so the description is meaningful.
+          fetch-depth: 0
+      - name: Compute build version
+        id: describe
+        run: echo "value=$(git describe --always --dirty --tags)" >> "$GITHUB_OUTPUT"
       - uses: docker/setup-buildx-action@v4
       - name: Extract metadata
         id: meta
@@ -54,6 +61,8 @@ jobs:
           platforms: ${{ matrix.platform }}
           push: false
           labels: ${{ steps.meta.outputs.labels }}
+          build-args: |
+            TRIBAL_GIT_DESCRIBE=${{ steps.describe.outputs.value }}
           cache-from: type=gha,scope=${{ matrix.platform }}
           cache-to: type=gha,mode=max,scope=${{ matrix.platform }}
 
@@ -91,7 +100,7 @@ jobs:
 
   publish:
     name: Build and push - ${{ matrix.platform }}
-    needs: validate-tag
+    needs: [shellcheck, validate-tag]
     if: startsWith(github.ref, 'refs/tags/')
     runs-on: ${{ matrix.runs-on }}
     permissions:
@@ -107,6 +116,13 @@ jobs:
             runs-on: ubuntu-24.04-arm
     steps:
       - uses: actions/checkout@v6
+        with:
+          # build.rs derives `TRIBAL_GIT_DESCRIBE` from the working-tree git
+          # state; fetch tags + history so the description is meaningful.
+          fetch-depth: 0
+      - name: Compute build version
+        id: describe
+        run: echo "value=$(git describe --always --dirty --tags)" >> "$GITHUB_OUTPUT"
       - uses: docker/setup-buildx-action@v4
       - uses: docker/login-action@v4
         with:
@@ -118,6 +134,8 @@ jobs:
         uses: docker/metadata-action@v6
         with:
           images: ${{ env.IMAGE_NAME }}
+          tags: |
+            type=semver,pattern={{version}}
       - name: Build and push by digest
         id: build
         uses: docker/build-push-action@v7
@@ -125,6 +143,8 @@ jobs:
           context: .
           platforms: ${{ matrix.platform }}
           labels: ${{ steps.meta.outputs.labels }}
+          build-args: |
+            TRIBAL_GIT_DESCRIBE=${{ steps.describe.outputs.value }}
           cache-from: type=gha,scope=${{ matrix.platform }}
           cache-to: type=gha,mode=max,scope=${{ matrix.platform }}
           outputs: type=image,name=${{ env.IMAGE_NAME }},push-by-digest=true,name-canonical=true,push=true
@@ -143,7 +163,7 @@ jobs:
 
   merge:
     name: Merge multi-arch manifest
-    needs: [validate-tag, publish]
+    needs: [shellcheck, validate-tag, publish]
     if: startsWith(github.ref, 'refs/tags/')
     runs-on: ubuntu-latest
     permissions:

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -7,6 +7,12 @@ on:
   pull_request:
     branches: [main]
 
+# Default-deny at the workflow level so every future job must opt in to
+# any capability beyond the implicit `metadata: read` grant — keeps a
+# new job from silently inheriting the repo's default permissive token
+# permissions if added without a job-level `permissions:` block.
+permissions: {}
+
 env:
   IMAGE_NAME: ghcr.io/samfolo/tribal
 
@@ -51,8 +57,41 @@ jobs:
           cache-from: type=gha,scope=${{ matrix.platform }}
           cache-to: type=gha,mode=max,scope=${{ matrix.platform }}
 
+  validate-tag:
+    name: Validate tag matches workspace version
+    if: startsWith(github.ref, 'refs/tags/')
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    outputs:
+      version: ${{ steps.meta.outputs.version }}
+    steps:
+      - uses: actions/checkout@v6
+      - name: Parse tag with metadata-action
+        id: meta
+        uses: docker/metadata-action@v6
+        with:
+          images: ${{ env.IMAGE_NAME }}
+          tags: |
+            type=semver,pattern={{version}}
+      - name: Cross-check parsed version against workspace.package.version
+        env:
+          PARSED_VERSION: ${{ steps.meta.outputs.version }}
+        run: |
+          if [[ -z "$PARSED_VERSION" ]]; then
+            echo "::error::tag '${GITHUB_REF#refs/tags/}' did not parse as SemVer via docker/metadata-action"
+            exit 1
+          fi
+          expected=$(cargo metadata --no-deps --format-version=1 \
+            | jq -r '.packages[] | select(.name=="tribal") | .version')
+          if [[ "$PARSED_VERSION" != "$expected" ]]; then
+            echo "::error::tag SemVer '${PARSED_VERSION}' does not match workspace.package.version '${expected}'; bump Cargo.toml or retag"
+            exit 1
+          fi
+
   publish:
     name: Build and push - ${{ matrix.platform }}
+    needs: validate-tag
     if: startsWith(github.ref, 'refs/tags/')
     runs-on: ${{ matrix.runs-on }}
     permissions:
@@ -104,12 +143,14 @@ jobs:
 
   merge:
     name: Merge multi-arch manifest
-    needs: publish
+    needs: [validate-tag, publish]
     if: startsWith(github.ref, 'refs/tags/')
     runs-on: ubuntu-latest
     permissions:
       contents: read
       packages: write
+    env:
+      VERSION: ${{ needs.validate-tag.outputs.version }}
     steps:
       - uses: actions/download-artifact@v8
         with:
@@ -122,18 +163,12 @@ jobs:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
-      - name: Determine version tag
-        id: version
-        run: |
-          tag="${GITHUB_REF#refs/tags/}"
-          version="${tag#v}"
-          echo "version=${version}" >> "$GITHUB_OUTPUT"
       - name: Create manifest list
         working-directory: /tmp/digests
         run: |
           docker buildx imagetools create \
-            -t ${{ env.IMAGE_NAME }}:${{ steps.version.outputs.version }} \
-            $(printf '${{ env.IMAGE_NAME }}@sha256:%s ' *)
+            -t "${IMAGE_NAME}:${VERSION}" \
+            $(printf "${IMAGE_NAME}@sha256:%s " *)
       - name: Inspect image
         run: |
-          docker buildx imagetools inspect ${{ env.IMAGE_NAME }}:${{ steps.version.outputs.version }}
+          docker buildx imagetools inspect "${IMAGE_NAME}:${VERSION}"

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,13 @@
-FROM rust:1-slim AS builder
+FROM rust:bookworm AS builder
 WORKDIR /app
 COPY . .
-RUN cargo build --release -p tribal-server
+RUN cargo build --release -p tribal
 
 FROM debian:bookworm-slim
-RUN apt-get update && apt-get install -y ca-certificates && rm -rf /var/lib/apt/lists/*
-COPY --from=builder /app/target/release/tribal-server /usr/local/bin/tribal
-ENTRYPOINT ["tribal"]
-CMD ["serve", "--transport", "http"]
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends ca-certificates bash jq curl \
+    && rm -rf /var/lib/apt/lists/*
+COPY --from=builder /app/target/release/tribal /usr/local/bin/tribal
+COPY scripts/tribal-entrypoint /usr/local/bin/tribal-entrypoint
+RUN chmod +x /usr/local/bin/tribal-entrypoint
+ENTRYPOINT ["/usr/local/bin/tribal-entrypoint"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,8 @@
 FROM rust:bookworm AS chef
-RUN cargo install cargo-chef --locked
+# Pinned so future cargo-chef releases cannot change recipe semantics
+# without an intentional bump here; Dependabot (or a manual sweep) can
+# advance the version when needed.
+RUN cargo install cargo-chef --version 0.1.77 --locked
 WORKDIR /app
 
 FROM chef AS planner

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,13 +1,31 @@
-FROM rust:bookworm AS builder
+FROM rust:bookworm AS chef
+RUN cargo install cargo-chef --locked
 WORKDIR /app
-COPY . .
+
+FROM chef AS planner
+COPY Cargo.toml Cargo.lock ./
+COPY crates/ ./crates/
+RUN cargo chef prepare --recipe-path recipe.json
+
+FROM chef AS builder
+ENV SQLX_OFFLINE=true
+COPY --from=planner /app/recipe.json recipe.json
+RUN cargo chef cook --release --recipe-path recipe.json
+COPY Cargo.toml Cargo.lock ./
+COPY crates/ ./crates/
+COPY prompts/ ./prompts/
+COPY .sqlx/ ./.sqlx/
 RUN cargo build --release -p tribal
 
 FROM debian:bookworm-slim
 RUN apt-get update \
     && apt-get install -y --no-install-recommends ca-certificates bash jq curl \
-    && rm -rf /var/lib/apt/lists/*
+    && rm -rf /var/lib/apt/lists/* \
+    && groupadd --system --gid 10001 tribal \
+    && useradd --system --uid 10001 --gid tribal --home-dir /var/lib/tribal --no-create-home --shell /usr/sbin/nologin tribal \
+    && mkdir -p /var/lib/tribal \
+    && chown -R tribal:tribal /var/lib/tribal
 COPY --from=builder /app/target/release/tribal /usr/local/bin/tribal
-COPY scripts/tribal-entrypoint /usr/local/bin/tribal-entrypoint
-RUN chmod +x /usr/local/bin/tribal-entrypoint
+COPY --chmod=0755 scripts/tribal-entrypoint /usr/local/bin/tribal-entrypoint
+USER tribal:tribal
 ENTRYPOINT ["/usr/local/bin/tribal-entrypoint"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,16 @@ COPY crates/ ./crates/
 RUN cargo chef prepare --recipe-path recipe.json
 
 FROM chef AS builder
-ENV SQLX_OFFLINE=true
+# `.git/` is excluded from the build context (see `.dockerignore`), so
+# `build.rs` cannot derive the build version from `git describe` here.
+# Callers inject the host's `git describe` output via this build arg;
+# `build.rs` reads `TRIBAL_GIT_DESCRIBE` and embeds it into the binary
+# (with a `CARGO_PKG_VERSION` fallback if the arg is empty). Without
+# this plumbing every Docker image would share the same fingerprint
+# `build_version`, collapsing eval/feedback rows across releases.
+ARG TRIBAL_GIT_DESCRIBE=""
+ENV SQLX_OFFLINE=true \
+    TRIBAL_GIT_DESCRIBE=${TRIBAL_GIT_DESCRIBE}
 COPY --from=planner /app/recipe.json recipe.json
 RUN cargo chef cook --release --recipe-path recipe.json
 COPY Cargo.toml Cargo.lock ./
@@ -28,4 +37,5 @@ RUN apt-get update \
 COPY --from=builder /app/target/release/tribal /usr/local/bin/tribal
 COPY --chmod=0755 scripts/tribal-entrypoint /usr/local/bin/tribal-entrypoint
 USER tribal:tribal
+EXPOSE 8725
 ENTRYPOINT ["/usr/local/bin/tribal-entrypoint"]

--- a/crates/tribal-server/build.rs
+++ b/crates/tribal-server/build.rs
@@ -1,26 +1,21 @@
 //! Build script for `tribal-server`.
 //!
-//! Embeds a build-version string into the binary so that `tribal --version`,
-//! the MCP system fingerprint (`crates/tribal-mcp/src/fingerprint.rs`), and the
-//! `system_fingerprints` table can distinguish releases.
-//!
-//! The value is resolved in three tiers, in order:
-//!
-//! 1. `TRIBAL_GIT_DESCRIBE` from the environment. Builders without access to
-//!    `.git/` (notably the Docker image build, which excludes `.git/` via
-//!    `.dockerignore`) inject the host's `git describe` output via a build
-//!    argument so the embedded value reflects the release commit.
-//! 2. `git describe --always --dirty --tags` run against the current checkout.
-//!    Standard path for `cargo build` inside a git working tree.
-//! 3. `CARGO_PKG_VERSION` (the workspace package version). Last-resort
-//!    fallback that still produces a meaningful, fingerprint-distinct value
-//!    rather than a literal `"unknown"` — a binary built in a non-git context
-//!    without an explicit env override at least carries its workspace version.
+//! Embeds `TRIBAL_GIT_DESCRIBE` into the binary for `tribal --version` and
+//! the MCP system fingerprint (`crates/tribal-mcp/src/fingerprint.rs`).
+//! Cascade: env var (set by Docker builds, which strip `.git/`) →
+//! `git describe --always --tags` → `CARGO_PKG_VERSION`. `--dirty` is
+//! omitted because tracking working-tree state via `rerun-if-changed`
+//! would mean declaring every workspace source as an input; the embedded
+//! value reflects the last commit regardless of dirtiness.
 
 fn main() {
     println!("cargo:rerun-if-env-changed=TRIBAL_GIT_DESCRIBE");
-    println!("cargo:rerun-if-changed=.git/HEAD");
-    println!("cargo:rerun-if-changed=.git/refs/");
+    // `rerun-if-changed` paths are interpreted relative to the package
+    // manifest directory (`crates/tribal-server/`), so the workspace's
+    // `.git/` is two levels up.
+    println!("cargo:rerun-if-changed=../../.git/HEAD");
+    println!("cargo:rerun-if-changed=../../.git/refs");
+    println!("cargo:rerun-if-changed=../../.git/packed-refs");
 
     let build_version = std::env::var("TRIBAL_GIT_DESCRIBE")
         .ok()
@@ -36,7 +31,7 @@ fn main() {
 
 fn git_describe() -> Option<String> {
     std::process::Command::new("git")
-        .args(["describe", "--always", "--dirty", "--tags"])
+        .args(["describe", "--always", "--tags"])
         .output()
         .ok()
         .filter(|output| output.status.success())

--- a/crates/tribal-server/build.rs
+++ b/crates/tribal-server/build.rs
@@ -1,18 +1,45 @@
 //! Build script for `tribal-server`.
 //!
-//! Embeds the short git description into the binary so that
-//! `tribal --version` can display the exact commit.
+//! Embeds a build-version string into the binary so that `tribal --version`,
+//! the MCP system fingerprint (`crates/tribal-mcp/src/fingerprint.rs`), and the
+//! `system_fingerprints` table can distinguish releases.
+//!
+//! The value is resolved in three tiers, in order:
+//!
+//! 1. `TRIBAL_GIT_DESCRIBE` from the environment. Builders without access to
+//!    `.git/` (notably the Docker image build, which excludes `.git/` via
+//!    `.dockerignore`) inject the host's `git describe` output via a build
+//!    argument so the embedded value reflects the release commit.
+//! 2. `git describe --always --dirty --tags` run against the current checkout.
+//!    Standard path for `cargo build` inside a git working tree.
+//! 3. `CARGO_PKG_VERSION` (the workspace package version). Last-resort
+//!    fallback that still produces a meaningful, fingerprint-distinct value
+//!    rather than a literal `"unknown"` — a binary built in a non-git context
+//!    without an explicit env override at least carries its workspace version.
 
 fn main() {
-    let git_describe = std::process::Command::new("git")
+    println!("cargo:rerun-if-env-changed=TRIBAL_GIT_DESCRIBE");
+    println!("cargo:rerun-if-changed=.git/HEAD");
+    println!("cargo:rerun-if-changed=.git/refs/");
+
+    let build_version = std::env::var("TRIBAL_GIT_DESCRIBE")
+        .ok()
+        .filter(|value| !value.trim().is_empty())
+        .or_else(git_describe)
+        .unwrap_or_else(|| {
+            std::env::var("CARGO_PKG_VERSION")
+                .expect("CARGO_PKG_VERSION is set by Cargo during build")
+        });
+
+    println!("cargo:rustc-env=TRIBAL_GIT_DESCRIBE={build_version}");
+}
+
+fn git_describe() -> Option<String> {
+    std::process::Command::new("git")
         .args(["describe", "--always", "--dirty", "--tags"])
         .output()
         .ok()
-        .filter(|o| o.status.success())
-        .map(|o| String::from_utf8_lossy(&o.stdout).trim().to_string())
-        .unwrap_or_else(|| "unknown".to_string());
-
-    println!("cargo:rustc-env=TRIBAL_GIT_DESCRIBE={git_describe}");
-    println!("cargo:rerun-if-changed=.git/HEAD");
-    println!("cargo:rerun-if-changed=.git/refs/");
+        .filter(|output| output.status.success())
+        .map(|output| String::from_utf8_lossy(&output.stdout).trim().to_string())
+        .filter(|value| !value.is_empty())
 }

--- a/crates/tribal-server/src/commands/bootstrap/run.rs
+++ b/crates/tribal-server/src/commands/bootstrap/run.rs
@@ -8,7 +8,10 @@ use std::{
 
 use anstream::AutoStream;
 use chrono::{DateTime, Utc};
-use tribal_config::{Auth, CliOverrides, ConfigPersistence, TransportKind, TribalConfig};
+use tribal_config::{
+    Auth, CREDENTIALS_FILENAME, CliOverrides, ConfigPersistence, TRIBAL_DIRECTORY_NAME,
+    TransportKind, TribalConfig,
+};
 use tribal_domain::GitRemote;
 use tribal_ui::{Mode, StreamThemeContext, Theme, resolve_mode};
 
@@ -156,14 +159,23 @@ pub async fn run_async(
     )
     .await
     .inspect_err(|_| {
-        // Replay any progress captured before setup failed.
-        let _ = out_stderr.write_all(&setup_buf);
+        // Replay captured progress for human consumers. In `--json` mode
+        // the captured buffer carries the raw bearer token in
+        // human-readable form, so stderr stays silent — the `AppError`
+        // returned via `?` is the only signal a machine consumer needs.
+        if !opts.json {
+            let _ = out_stderr.write_all(&setup_buf);
+        }
     })?;
 
-    // From here on, any error path replays the captured setup output
-    // via the guard's `Drop` rather than peppering each bail-out with
-    // a manual replay.
-    let mut recovery = RecoveryGuard::arm(out_stderr, &setup_buf);
+    // From here on, any error path replays the recovery buffer via the
+    // guard's `Drop` rather than peppering each bail-out with a manual
+    // replay. `recovery_buf_for` strips the bearer-token-bearing setup
+    // output when `--json` is set (machine consumers must never see the
+    // token on stderr, most prominently container logs in the Docker
+    // install path).
+    let recovery_buf = recovery_buf_for(opts.json, setup_buf);
+    let mut recovery = RecoveryGuard::arm(out_stderr, &recovery_buf);
 
     // -- Register -----------------------------------------------------------
 
@@ -277,6 +289,33 @@ impl Drop for RecoveryGuard<'_> {
     }
 }
 
+/// Composes the non-secret message replayed to stderr on `--json`-mode
+/// bootstrap failures. The path segments are sourced from
+/// [`tribal_config::TRIBAL_DIRECTORY_NAME`] and
+/// [`tribal_config::CREDENTIALS_FILENAME`] so the message tracks the
+/// canonical credentials path without a second source of truth.
+fn json_recovery_message() -> Vec<u8> {
+    format!(
+        "bootstrap failed after setup; the bearer token (if persisted) lives in $XDG_CONFIG_HOME/{TRIBAL_DIRECTORY_NAME}/{CREDENTIALS_FILENAME}\n"
+    )
+    .into_bytes()
+}
+
+/// Returns the buffer the `RecoveryGuard` should replay on a
+/// post-setup failure. In `--json` mode, the captured `setup_buf` is
+/// discarded wholesale and a non-secret message is substituted —
+/// there is no string inspection, no extraction, no parsing of
+/// `setup_buf`. In human mode the original buffer is returned
+/// unchanged, since the terminal is the intended audience for the
+/// human-readable token block.
+fn recovery_buf_for(json_mode: bool, setup_buf: Vec<u8>) -> Vec<u8> {
+    if json_mode {
+        json_recovery_message()
+    } else {
+        setup_buf
+    }
+}
+
 // ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------
@@ -289,5 +328,60 @@ fn resolve_git_remote(explicit: Option<&str>) -> Result<GitRemote, AppError> {
             reason: e.to_string(),
         }),
         None => detect_git_remote(),
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const SECRET_TOKEN: &str = "tk_super_secret_bearer_value";
+
+    fn fixture_setup_buf() -> Vec<u8> {
+        format!(
+            "Setup complete. Your bearer token:\n  {SECRET_TOKEN}\nNext steps:\n  1. Export the token:  export TRIBAL_AUTH_TOKEN=\"{SECRET_TOKEN}\"\n"
+        )
+        .into_bytes()
+    }
+
+    #[test]
+    fn test_json_recovery_message_references_canonical_path_segments() {
+        let bytes = json_recovery_message();
+        let message = std::str::from_utf8(&bytes).expect("recovery message is valid UTF-8");
+        assert!(
+            message.contains(TRIBAL_DIRECTORY_NAME),
+            "recovery message must reference TRIBAL_DIRECTORY_NAME ({TRIBAL_DIRECTORY_NAME}); got: {message}",
+        );
+        assert!(
+            message.contains(CREDENTIALS_FILENAME),
+            "recovery message must reference CREDENTIALS_FILENAME ({CREDENTIALS_FILENAME}); got: {message}",
+        );
+    }
+
+    #[test]
+    fn test_recovery_buf_for_json_mode_discards_setup_buffer() {
+        let setup_buf = fixture_setup_buf();
+        let result = recovery_buf_for(true, setup_buf);
+        let result_str = std::str::from_utf8(&result).expect("recovery buffer is valid UTF-8");
+        assert!(
+            !result_str.contains(SECRET_TOKEN),
+            "json-mode recovery buffer must not echo the captured setup output's token; got: {result_str}",
+        );
+        assert_eq!(result, json_recovery_message());
+    }
+
+    #[test]
+    fn test_recovery_buf_for_human_mode_preserves_setup_buffer() {
+        let setup_buf = fixture_setup_buf();
+        let expected = setup_buf.clone();
+        let result = recovery_buf_for(false, setup_buf);
+        assert_eq!(
+            result, expected,
+            "human-mode recovery buffer must preserve the captured setup output verbatim for terminal replay",
+        );
     }
 }

--- a/crates/tribal-server/src/commands/bootstrap/run.rs
+++ b/crates/tribal-server/src/commands/bootstrap/run.rs
@@ -158,15 +158,7 @@ pub async fn run_async(
         &mut setup_buf,
     )
     .await
-    .inspect_err(|_| {
-        // Replay captured progress for human consumers. In `--json` mode
-        // the captured buffer carries the raw bearer token in
-        // human-readable form, so stderr stays silent — the `AppError`
-        // returned via `?` is the only signal a machine consumer needs.
-        if !opts.json {
-            let _ = out_stderr.write_all(&setup_buf);
-        }
-    })?;
+    .inspect_err(|_| replay_setup_on_failure(opts.json, out_stderr, &setup_buf))?;
 
     // From here on, any error path replays the recovery buffer via the
     // guard's `Drop` rather than peppering each bail-out with a manual
@@ -247,7 +239,7 @@ pub async fn run_async(
 }
 
 // ---------------------------------------------------------------------------
-// Recovery guard
+// Recovery
 // ---------------------------------------------------------------------------
 
 /// Replays a captured stderr buffer on drop when armed.
@@ -313,6 +305,17 @@ fn recovery_buf_for(json_mode: bool, setup_buf: Vec<u8>) -> Vec<u8> {
         json_recovery_message()
     } else {
         setup_buf
+    }
+}
+
+/// Replays the captured setup buffer to `dest` when setup itself
+/// fails. Gated symmetrically with [`recovery_buf_for`]: in `--json`
+/// mode the buffer carries the raw bearer token, so stderr stays
+/// silent and the `AppError` returned via `?` is the only signal a
+/// machine consumer needs.
+fn replay_setup_on_failure(json_mode: bool, dest: &mut dyn Write, setup_buf: &[u8]) {
+    if !json_mode {
+        let _ = dest.write_all(setup_buf);
     }
 }
 
@@ -382,6 +385,52 @@ mod tests {
         assert_eq!(
             result, expected,
             "human-mode recovery buffer must preserve the captured setup output verbatim for terminal replay",
+        );
+    }
+
+    #[test]
+    fn test_recovery_guard_replays_buffer_on_drop_when_armed() {
+        let buf = b"replay-payload".to_vec();
+        let mut dest: Vec<u8> = Vec::new();
+        {
+            let _guard = RecoveryGuard::arm(&mut dest, &buf);
+        }
+        assert_eq!(dest, buf);
+    }
+
+    #[test]
+    fn test_recovery_guard_suppresses_replay_after_disarm() {
+        let buf = b"replay-payload".to_vec();
+        let mut dest: Vec<u8> = Vec::new();
+        {
+            let mut guard = RecoveryGuard::arm(&mut dest, &buf);
+            guard.disarm();
+        }
+        assert!(
+            dest.is_empty(),
+            "disarmed guard must not replay on drop; got: {dest:?}",
+        );
+    }
+
+    #[test]
+    fn test_replay_setup_on_failure_writes_buffer_in_human_mode() {
+        let setup_buf = fixture_setup_buf();
+        let mut dest: Vec<u8> = Vec::new();
+        replay_setup_on_failure(false, &mut dest, &setup_buf);
+        assert_eq!(
+            dest, setup_buf,
+            "human-mode setup-failure replay must write the captured buffer to stderr",
+        );
+    }
+
+    #[test]
+    fn test_replay_setup_on_failure_is_silent_in_json_mode() {
+        let setup_buf = fixture_setup_buf();
+        let mut dest: Vec<u8> = Vec::new();
+        replay_setup_on_failure(true, &mut dest, &setup_buf);
+        assert!(
+            dest.is_empty(),
+            "json-mode setup-failure replay must not write the token-bearing setup buffer; got: {dest:?}",
         );
     }
 }

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -25,17 +25,31 @@ services:
         condition: service_healthy
     environment:
       TRIBAL_DATABASE__URL: postgres://tribal:tribal@postgres:5432/tribal
+      # http or sse — both accept a bind_address; stdio rejects it via
+      # validate_server. Swap to sse here if you prefer the legacy transport.
       TRIBAL_SERVER__TRANSPORT: "http"
       TRIBAL_SERVER__BIND_ADDRESS: "0.0.0.0:8725"
       TRIBAL_PUBLIC_MCP_URL: "http://127.0.0.1:8725/mcp"
+      # Redirect tribal.yaml and credentials.json into the state volume so
+      # they survive container restart. Resolves to
+      # /var/lib/tribal/tribal/{tribal.yaml,credentials.json} (the inner
+      # `tribal/` segment is the binary's own subdirectory under any
+      # XDG_CONFIG_HOME parent).
       XDG_CONFIG_HOME: "/var/lib/tribal"
       TRIBAL_CONFIG_PATH: "/var/lib/tribal/tribal/tribal.yaml"
+      # Ollama base URL — the binary default resolves to the container's
+      # own loopback (no Ollama there). Redirect to host.docker.internal
+      # so the container reaches Ollama on the host. extra_hosts (below)
+      # makes the name resolvable on Linux Docker (macOS / Windows Docker
+      # Desktop resolve it natively).
       TRIBAL_EMBEDDING__BASE_URL: "http://host.docker.internal:11434"
       TRIBAL_INFERENCE__EXTRACTION__BASE_URL: "http://host.docker.internal:11434"
       TRIBAL_INFERENCE__TRIAGE__BASE_URL: "http://host.docker.internal:11434"
       TRIBAL_INFERENCE__RELATION__BASE_URL: "http://host.docker.internal:11434"
       TRIBAL_PROJECT_NAME: ${TRIBAL_PROJECT_NAME:-tribal-docker-local}
       TRIBAL_PROJECT_REMOTE: ${TRIBAL_PROJECT_REMOTE:-https://example.com/local/tribal-docker.git}
+      # Provider env vars passed through from the host shell. Optional;
+      # required only for real ingest against the listed cloud providers.
       OPENAI_API_KEY: ${OPENAI_API_KEY:-}
       ANTHROPIC_API_KEY: ${ANTHROPIC_API_KEY:-}
     volumes:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,6 +12,11 @@ services:
       interval: 2s
       timeout: 3s
       retries: 30
+    logging:
+      driver: json-file
+      options:
+        max-size: "10m"
+        max-file: "3"
 
   tribal:
     image: ghcr.io/samfolo/tribal:0.1.1
@@ -46,6 +51,11 @@ services:
       timeout: 5s
       retries: 20
       start_period: 15s
+    logging:
+      driver: json-file
+      options:
+        max-size: "10m"
+        max-file: "3"
 
 volumes:
   tribal_pgdata:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,52 @@
+services:
+  postgres:
+    image: pgvector/pgvector:pg17
+    environment:
+      POSTGRES_USER: tribal
+      POSTGRES_PASSWORD: tribal
+      POSTGRES_DB: tribal
+    volumes:
+      - tribal_pgdata:/var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD", "pg_isready", "-U", "tribal"]
+      interval: 2s
+      timeout: 3s
+      retries: 30
+
+  tribal:
+    image: ghcr.io/samfolo/tribal:0.1.1
+    depends_on:
+      postgres:
+        condition: service_healthy
+    environment:
+      TRIBAL_DATABASE__URL: postgres://tribal:tribal@postgres:5432/tribal
+      TRIBAL_SERVER__TRANSPORT: "http"
+      TRIBAL_SERVER__BIND_ADDRESS: "0.0.0.0:8725"
+      TRIBAL_PUBLIC_MCP_URL: "http://127.0.0.1:8725/mcp"
+      XDG_CONFIG_HOME: "/var/lib/tribal"
+      TRIBAL_CONFIG_PATH: "/var/lib/tribal/tribal/tribal.yaml"
+      TRIBAL_EMBEDDING__BASE_URL: "http://host.docker.internal:11434"
+      TRIBAL_INFERENCE__EXTRACTION__BASE_URL: "http://host.docker.internal:11434"
+      TRIBAL_INFERENCE__TRIAGE__BASE_URL: "http://host.docker.internal:11434"
+      TRIBAL_INFERENCE__RELATION__BASE_URL: "http://host.docker.internal:11434"
+      TRIBAL_PROJECT_NAME: ${TRIBAL_PROJECT_NAME:-tribal-docker-local}
+      TRIBAL_PROJECT_REMOTE: ${TRIBAL_PROJECT_REMOTE:-https://example.com/local/tribal-docker.git}
+      OPENAI_API_KEY: ${OPENAI_API_KEY:-}
+      ANTHROPIC_API_KEY: ${ANTHROPIC_API_KEY:-}
+    volumes:
+      - tribal_state:/var/lib/tribal
+    entrypoint: /usr/local/bin/tribal-entrypoint
+    ports:
+      - "127.0.0.1:8725:8725"
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
+    healthcheck:
+      test: ["CMD", "tribal", "check", "--json"]
+      interval: 5s
+      timeout: 5s
+      retries: 20
+      start_period: 15s
+
+volumes:
+  tribal_pgdata:
+  tribal_state:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -54,7 +54,7 @@ services:
       ANTHROPIC_API_KEY: ${ANTHROPIC_API_KEY:-}
     volumes:
       - tribal_state:/var/lib/tribal
-    entrypoint: /usr/local/bin/tribal-entrypoint
+    entrypoint: ["/usr/local/bin/tribal-entrypoint"]
     ports:
       - "127.0.0.1:8725:8725"
     extra_hosts:

--- a/scripts/tribal-entrypoint
+++ b/scripts/tribal-entrypoint
@@ -128,6 +128,15 @@ subsequent_run() {
     echo "$PROJECT_ID_FILE is empty or multi-line; recreate it with 'docker compose run --rm tribal --reset'" >&2
     exit 1
   fi
+  # Mirror the credentials-file validity check from first_run: the host
+  # shell's wire-up one-liner depends on credentials.json carrying a
+  # readable bearer token, and tribal check's healthcheck downgrades a
+  # missing file to a warning (not a failure), so the container would
+  # otherwise come up "healthy" while the handoff is silently broken.
+  if [[ ! -s "$CREDENTIALS_FILE" ]] || ! jq -e '.auth.token | type == "string" and length > 0' "$CREDENTIALS_FILE" >/dev/null 2>&1; then
+    echo "$CREDENTIALS_FILE is missing or has no .auth.token; recreate it with 'docker compose run --rm tribal --reset'" >&2
+    exit 1
+  fi
   print_brief_status
   exec tribal serve --project "$project_id"
 }

--- a/scripts/tribal-entrypoint
+++ b/scripts/tribal-entrypoint
@@ -13,8 +13,11 @@
 #      into the first-run flow. Bootstrap is idempotent against the existing
 #      Postgres project row (UniqueViolation -> find_by_git_remote).
 #
-# XDG_CONFIG_HOME=/var/lib/tribal makes Tribal nest under /var/lib/tribal/tribal/,
-# so credentials.json, tribal.yaml, and project_id all live in that directory.
+# XDG_CONFIG_HOME is the parent directory; Tribal then nests its own files
+# under a `tribal/` subdirectory (the binary's credential resolver, not a
+# Docker-specific choice). With XDG_CONFIG_HOME=/var/lib/tribal, the
+# resolved paths become /var/lib/tribal/tribal/{tribal.yaml,credentials.json},
+# which is why every state path below carries the inner `tribal/` segment.
 
 set -euo pipefail
 
@@ -78,7 +81,24 @@ first_run() {
     --remote "$TRIBAL_PROJECT_REMOTE" \
     --name "$TRIBAL_PROJECT_NAME" \
     --json)"
-  project_id="$(jq -e -r '.project_id' <<<"$bootstrap_json")"
+
+  if ! project_id="$(jq -e -r '.project_id | select(type == "string" and length > 0)' <<<"$bootstrap_json")"; then
+    echo "tribal bootstrap returned JSON without a non-empty string .project_id; refusing to continue" >&2
+    exit 1
+  fi
+
+  # `tribal bootstrap` is warn-and-success on credentials-file persistence:
+  # a write failure leaves the JSON payload intact but no credentials.json
+  # on disk. The Docker handoff is the credentials file itself (the token
+  # never appears in container logs or onboarding text), so a missing or
+  # malformed file means the host-shell wire-up one-liner has nothing to
+  # read. Fail fast and surface a non-secret error instead of starting
+  # serve under a silently-broken handoff.
+  if [[ ! -s "$CREDENTIALS_FILE" ]] || ! jq -e '.auth.token | type == "string" and length > 0' "$CREDENTIALS_FILE" >/dev/null 2>&1; then
+    echo "tribal bootstrap succeeded but $CREDENTIALS_FILE is missing or has no .auth.token; cannot hand off credentials" >&2
+    exit 1
+  fi
+
   install -m 0644 /dev/stdin "$PROJECT_ID_FILE" <<<"$project_id"
   print_full_onboarding
   exec tribal serve --transport http --project "$project_id"
@@ -96,13 +116,9 @@ subsequent_run() {
 if [[ $# -eq 1 && "${1:-}" == "--reset" ]]; then
   rm -f "$CREDENTIALS_FILE" "$PROJECT_ID_FILE"
   first_run
-fi
-
-if [[ $# -gt 0 ]]; then
+elif [[ $# -gt 0 ]]; then
   exec "$@"
-fi
-
-if [[ -f "$PROJECT_ID_FILE" ]]; then
+elif [[ -f "$PROJECT_ID_FILE" ]]; then
   subsequent_run
 else
   first_run

--- a/scripts/tribal-entrypoint
+++ b/scripts/tribal-entrypoint
@@ -101,12 +101,9 @@ first_run() {
   fi
 
   # `tribal bootstrap` is warn-and-success on credentials-file persistence:
-  # a write failure leaves the JSON payload intact but no credentials.json
-  # on disk. The Docker handoff is the credentials file itself (the token
-  # never appears in container logs or onboarding text), so a missing or
-  # malformed file means the host-shell wire-up one-liner has nothing to
-  # read. Fail fast and surface a non-secret error instead of starting
-  # serve under a silently-broken handoff.
+  # the JSON payload survives a write failure, leaving the container with
+  # no token to hand off. Fail loudly here so the host-shell wire-up
+  # one-liner never sees a "ready" container without a usable file.
   if [[ ! -s "$CREDENTIALS_FILE" ]] || ! jq -e '.auth.token | type == "string" and length > 0' "$CREDENTIALS_FILE" >/dev/null 2>&1; then
     echo "tribal bootstrap succeeded but $CREDENTIALS_FILE is missing or has no .auth.token; cannot hand off credentials" >&2
     exit 1
@@ -124,15 +121,13 @@ first_run() {
 subsequent_run() {
   local project_id
   project_id="$(cat "$PROJECT_ID_FILE")"
-  if [[ -z "$project_id" || "$project_id" == *$'\n'* ]]; then
-    echo "$PROJECT_ID_FILE is empty or multi-line; recreate it with 'docker compose run --rm tribal --reset'" >&2
+  if [[ -z "$project_id" || "$project_id" =~ [[:space:]] ]]; then
+    echo "$PROJECT_ID_FILE is empty or contains whitespace; recreate it with 'docker compose run --rm tribal --reset'" >&2
     exit 1
   fi
-  # Mirror the credentials-file validity check from first_run: the host
-  # shell's wire-up one-liner depends on credentials.json carrying a
-  # readable bearer token, and tribal check's healthcheck downgrades a
-  # missing file to a warning (not a failure), so the container would
-  # otherwise come up "healthy" while the handoff is silently broken.
+  # `tribal check` downgrades a missing credentials.json to a warning,
+  # so without this guard the container reaches healthy while the
+  # host-shell wire-up has no token to surface.
   if [[ ! -s "$CREDENTIALS_FILE" ]] || ! jq -e '.auth.token | type == "string" and length > 0' "$CREDENTIALS_FILE" >/dev/null 2>&1; then
     echo "$CREDENTIALS_FILE is missing or has no .auth.token; recreate it with 'docker compose run --rm tribal --reset'" >&2
     exit 1

--- a/scripts/tribal-entrypoint
+++ b/scripts/tribal-entrypoint
@@ -1,0 +1,109 @@
+#!/usr/bin/env bash
+#
+# Tribal container entrypoint. Four flows dispatched on positional args:
+#
+#   1. Arg pass-through: any arg(s) other than the sole --reset -> exec "$@".
+#      Lets `docker run --rm <image> tribal --version` and similar one-offs
+#      bypass the bootstrap orchestration.
+#   2. First run: no args, no project_id file -> tribal bootstrap, persist
+#      project_id, print onboarding block to stderr, exec tribal serve.
+#   3. Subsequent run: no args, project_id file present -> read project_id,
+#      print brief stderr summary, exec tribal serve. No re-mint.
+#   4. --reset (sole arg): delete credentials.json + project_id, then fall
+#      into the first-run flow. Bootstrap is idempotent against the existing
+#      Postgres project row (UniqueViolation -> find_by_git_remote).
+#
+# XDG_CONFIG_HOME=/var/lib/tribal makes Tribal nest under /var/lib/tribal/tribal/,
+# so credentials.json, tribal.yaml, and project_id all live in that directory.
+
+set -euo pipefail
+
+STATE_DIR="/var/lib/tribal/tribal"
+PROJECT_ID_FILE="${STATE_DIR}/project_id"
+CREDENTIALS_FILE="${STATE_DIR}/credentials.json"
+
+print_full_onboarding() {
+  cat >&2 <<'EOF'
+================================================================
+Tribal is running on http://localhost:8725/mcp.
+
+To wire Tribal into Claude Code, run this from your host shell:
+  claude mcp add-json tribal "$(docker compose exec tribal sh -c 'TRIBAL_PROJECT_ID=$(cat /var/lib/tribal/tribal/project_id) tribal mcp-config')"
+
+For Codex / Gemini CLI / OpenCode, see the installation skill.
+
+To verify your installation is healthy:
+  docker compose exec tribal tribal check
+
+To verify your providers are ready for real ingest:
+  docker compose exec tribal tribal check --providers
+
+This compose flow uses a placeholder git remote
+(https://example.com/local/tribal-docker.git). To re-register
+against your real repo, ask your agent (after wiring) to run:
+  tribal project register --remote <your-repo-url>
+
+Provider configuration is your responsibility:
+  - Ollama: ensure it's running and reachable (default
+    http://host.docker.internal:11434 from the container).
+  - Cloud providers: pass your API keys via the compose env
+    (OPENAI_API_KEY, ANTHROPIC_API_KEY, ...).
+
+To install Tribal's skills into your agent:
+  npx skills add samfolo/tribal-skills
+
+To remove Tribal entirely:
+  docker compose down -v
+  npx skills remove samfolo/tribal-skills
+================================================================
+EOF
+}
+
+print_brief_status() {
+  cat >&2 <<'EOF'
+Tribal is running on http://localhost:8725/mcp.
+
+To wire into Claude Code (from your host shell):
+  claude mcp add-json tribal "$(docker compose exec tribal sh -c 'TRIBAL_PROJECT_ID=$(cat /var/lib/tribal/tribal/project_id) tribal mcp-config')"
+EOF
+}
+
+first_run() {
+  mkdir -p "$STATE_DIR"
+  : "${TRIBAL_PROJECT_REMOTE:?TRIBAL_PROJECT_REMOTE must be set (compose provides a default; see docker-compose.yml)}"
+  : "${TRIBAL_PROJECT_NAME:?TRIBAL_PROJECT_NAME must be set (compose provides a default; see docker-compose.yml)}"
+  local bootstrap_json project_id
+  bootstrap_json="$(tribal bootstrap \
+    --transport http \
+    --remote "$TRIBAL_PROJECT_REMOTE" \
+    --name "$TRIBAL_PROJECT_NAME" \
+    --json)"
+  project_id="$(jq -e -r '.project_id' <<<"$bootstrap_json")"
+  install -m 0644 /dev/stdin "$PROJECT_ID_FILE" <<<"$project_id"
+  print_full_onboarding
+  exec tribal serve --transport http --project "$project_id"
+}
+
+subsequent_run() {
+  local project_id
+  project_id="$(cat "$PROJECT_ID_FILE")"
+  print_brief_status
+  exec tribal serve --transport http --project "$project_id"
+}
+
+# -- Dispatch --
+
+if [[ $# -eq 1 && "${1:-}" == "--reset" ]]; then
+  rm -f "$CREDENTIALS_FILE" "$PROJECT_ID_FILE"
+  first_run
+fi
+
+if [[ $# -gt 0 ]]; then
+  exec "$@"
+fi
+
+if [[ -f "$PROJECT_ID_FILE" ]]; then
+  subsequent_run
+else
+  first_run
+fi

--- a/scripts/tribal-entrypoint
+++ b/scripts/tribal-entrypoint
@@ -18,6 +18,17 @@
 # Docker-specific choice). With XDG_CONFIG_HOME=/var/lib/tribal, the
 # resolved paths become /var/lib/tribal/tribal/{tribal.yaml,credentials.json},
 # which is why every state path below carries the inner `tribal/` segment.
+#
+# Env-var plumbing differs by purpose:
+#   - TRIBAL_PROJECT_REMOTE, TRIBAL_PROJECT_NAME: script-side variables,
+#     read here and forwarded to `tribal bootstrap --remote / --name`.
+#     One-shot inputs that identify the project to register; not part
+#     of the binary's persisted config and not loaded by figment.
+#   - TRIBAL_SERVER__TRANSPORT, TRIBAL_SERVER__BIND_ADDRESS, TRIBAL_*__*:
+#     figment-loaded config fields (the double underscore is figment's
+#     nested-path separator). The binary reads these directly. We do
+#     NOT pass `--transport` here so a compose user can swap http/sse
+#     by changing TRIBAL_SERVER__TRANSPORT alone.
 
 set -euo pipefail
 
@@ -75,9 +86,11 @@ first_run() {
   mkdir -p "$STATE_DIR"
   : "${TRIBAL_PROJECT_REMOTE:?TRIBAL_PROJECT_REMOTE must be set (compose provides a default; see docker-compose.yml)}"
   : "${TRIBAL_PROJECT_NAME:?TRIBAL_PROJECT_NAME must be set (compose provides a default; see docker-compose.yml)}"
+  # Transport selection flows through TRIBAL_SERVER__TRANSPORT (env →
+  # figment → config); deliberately not passed as `--transport` so a
+  # compose user can swap to sse via env without editing the script.
   local bootstrap_json project_id
   bootstrap_json="$(tribal bootstrap \
-    --transport http \
     --remote "$TRIBAL_PROJECT_REMOTE" \
     --name "$TRIBAL_PROJECT_NAME" \
     --json)"
@@ -99,16 +112,24 @@ first_run() {
     exit 1
   fi
 
+  # `install -m 0644` is not a tempfile+rename atomic write, but project_id
+  # is a single short line and a mid-write interrupt is extraordinarily
+  # unlikely; the subsequent-run flow's content validation catches a
+  # corrupt file on the next start regardless.
   install -m 0644 /dev/stdin "$PROJECT_ID_FILE" <<<"$project_id"
   print_full_onboarding
-  exec tribal serve --transport http --project "$project_id"
+  exec tribal serve --project "$project_id"
 }
 
 subsequent_run() {
   local project_id
   project_id="$(cat "$PROJECT_ID_FILE")"
+  if [[ -z "$project_id" || "$project_id" == *$'\n'* ]]; then
+    echo "$PROJECT_ID_FILE is empty or multi-line; recreate it with 'docker compose run --rm tribal --reset'" >&2
+    exit 1
+  fi
   print_brief_status
-  exec tribal serve --transport http --project "$project_id"
+  exec tribal serve --project "$project_id"
 }
 
 # -- Dispatch --


### PR DESCRIPTION
Implements the `docker compose` onboarding flow and GHCR publish workflow.

First-touch demos no longer need to mess around with setting up a containerised Postgres instance, or setting up Tribal as a server.

Closes tribal-memory/cortex#38.