### PR TITLE
[REFACTOR] Replace harness enumeration with abstract phrasing

### DIFF
--- a/crates/tribal-server/src/commands/bootstrap/output/action_list.rs
+++ b/crates/tribal-server/src/commands/bootstrap/output/action_list.rs
@@ -276,7 +276,7 @@ fn push_wire_up_step(steps: &mut Vec<ActionStep>) {
         vec![
             BodyLine::new("claude mcp add-json tribal \"$(tribal mcp-config)\"")
                 .indented_by(DEEPER),
-            BodyLine::new("For Codex / Gemini CLI / OpenCode, see the installation skill."),
+            BodyLine::new("For other harnesses, see the installation skill."),
         ],
     ));
 }

--- a/crates/tribal-server/src/commands/bootstrap/snapshots/stderr-http-credentials-failed.txt
+++ b/crates/tribal-server/src/commands/bootstrap/snapshots/stderr-http-credentials-failed.txt
@@ -35,7 +35,7 @@ Next steps:
 
 6. Wire Tribal into your agent harness. For Claude Code:
      claude mcp add-json tribal "$(tribal mcp-config)"
-   For Codex / Gemini CLI / OpenCode, see the installation skill.
+   For other harnesses, see the installation skill.
 
 7. (Optional) Install Tribal skills into your agent:
    npx skills add samfolo/tribal-skills

--- a/crates/tribal-server/src/commands/bootstrap/snapshots/stderr-http-flags-file-exists.txt
+++ b/crates/tribal-server/src/commands/bootstrap/snapshots/stderr-http-flags-file-exists.txt
@@ -45,7 +45,7 @@ Next steps:
 
 7. Wire Tribal into your agent harness. For Claude Code:
      claude mcp add-json tribal "$(tribal mcp-config)"
-   For Codex / Gemini CLI / OpenCode, see the installation skill.
+   For other harnesses, see the installation skill.
 
 8. (Optional) Install Tribal skills into your agent:
    npx skills add samfolo/tribal-skills

--- a/crates/tribal-server/src/commands/bootstrap/snapshots/stderr-http-flags-first-run.txt
+++ b/crates/tribal-server/src/commands/bootstrap/snapshots/stderr-http-flags-first-run.txt
@@ -38,7 +38,7 @@ Next steps:
 
 7. Wire Tribal into your agent harness. For Claude Code:
      claude mcp add-json tribal "$(tribal mcp-config)"
-   For Codex / Gemini CLI / OpenCode, see the installation skill.
+   For other harnesses, see the installation skill.
 
 8. (Optional) Install Tribal skills into your agent:
    npx skills add samfolo/tribal-skills

--- a/crates/tribal-server/src/commands/bootstrap/snapshots/stderr-http-no-flags-file-exists.txt
+++ b/crates/tribal-server/src/commands/bootstrap/snapshots/stderr-http-no-flags-file-exists.txt
@@ -37,7 +37,7 @@ Next steps:
 
 6. Wire Tribal into your agent harness. For Claude Code:
      claude mcp add-json tribal "$(tribal mcp-config)"
-   For Codex / Gemini CLI / OpenCode, see the installation skill.
+   For other harnesses, see the installation skill.
 
 7. (Optional) Install Tribal skills into your agent:
    npx skills add samfolo/tribal-skills

--- a/crates/tribal-server/src/commands/bootstrap/snapshots/stderr-http-no-flags-first-run.txt
+++ b/crates/tribal-server/src/commands/bootstrap/snapshots/stderr-http-no-flags-first-run.txt
@@ -35,7 +35,7 @@ Next steps:
 
 6. Wire Tribal into your agent harness. For Claude Code:
      claude mcp add-json tribal "$(tribal mcp-config)"
-   For Codex / Gemini CLI / OpenCode, see the installation skill.
+   For other harnesses, see the installation skill.
 
 7. (Optional) Install Tribal skills into your agent:
    npx skills add samfolo/tribal-skills

--- a/crates/tribal-server/src/commands/bootstrap/snapshots/stderr-stdio-credentials-failed.txt
+++ b/crates/tribal-server/src/commands/bootstrap/snapshots/stderr-stdio-credentials-failed.txt
@@ -14,7 +14,7 @@ Next steps:
 
 3. Wire Tribal into your agent harness. For Claude Code:
      claude mcp add-json tribal "$(tribal mcp-config)"
-   For Codex / Gemini CLI / OpenCode, see the installation skill.
+   For other harnesses, see the installation skill.
 
 4. (Optional) Install Tribal skills into your agent:
    npx skills add samfolo/tribal-skills

--- a/crates/tribal-server/src/commands/bootstrap/snapshots/stderr-stdio-flags-file-exists.txt
+++ b/crates/tribal-server/src/commands/bootstrap/snapshots/stderr-stdio-flags-file-exists.txt
@@ -24,7 +24,7 @@ Next steps:
 
 4. Wire Tribal into your agent harness. For Claude Code:
      claude mcp add-json tribal "$(tribal mcp-config)"
-   For Codex / Gemini CLI / OpenCode, see the installation skill.
+   For other harnesses, see the installation skill.
 
 5. (Optional) Install Tribal skills into your agent:
    npx skills add samfolo/tribal-skills

--- a/crates/tribal-server/src/commands/bootstrap/snapshots/stderr-stdio-flags-first-run.txt
+++ b/crates/tribal-server/src/commands/bootstrap/snapshots/stderr-stdio-flags-first-run.txt
@@ -17,7 +17,7 @@ Next steps:
 
 4. Wire Tribal into your agent harness. For Claude Code:
      claude mcp add-json tribal "$(tribal mcp-config)"
-   For Codex / Gemini CLI / OpenCode, see the installation skill.
+   For other harnesses, see the installation skill.
 
 5. (Optional) Install Tribal skills into your agent:
    npx skills add samfolo/tribal-skills

--- a/crates/tribal-server/src/commands/bootstrap/snapshots/stderr-stdio-no-flags-file-exists.txt
+++ b/crates/tribal-server/src/commands/bootstrap/snapshots/stderr-stdio-no-flags-file-exists.txt
@@ -16,7 +16,7 @@ Next steps:
 
 3. Wire Tribal into your agent harness. For Claude Code:
      claude mcp add-json tribal "$(tribal mcp-config)"
-   For Codex / Gemini CLI / OpenCode, see the installation skill.
+   For other harnesses, see the installation skill.
 
 4. (Optional) Install Tribal skills into your agent:
    npx skills add samfolo/tribal-skills

--- a/crates/tribal-server/src/commands/bootstrap/snapshots/stderr-stdio-no-flags-first-run.txt
+++ b/crates/tribal-server/src/commands/bootstrap/snapshots/stderr-stdio-no-flags-first-run.txt
@@ -14,7 +14,7 @@ Next steps:
 
 3. Wire Tribal into your agent harness. For Claude Code:
      claude mcp add-json tribal "$(tribal mcp-config)"
-   For Codex / Gemini CLI / OpenCode, see the installation skill.
+   For other harnesses, see the installation skill.
 
 4. (Optional) Install Tribal skills into your agent:
    npx skills add samfolo/tribal-skills


### PR DESCRIPTION
The fallback line in bootstrap's wire-up step previously enumerated specific harnesses ("Codex / Gemini CLI / OpenCode") that drift as the ecosystem evolves (Antigravity CLI was added without this line being updated).

Replaces with "other harnesses" and defers to the installation skill for the authoritative per-harness list.

Snapshots regenerated; 21 bootstrap tests pass.