### PR TITLE
[CHORE] Prep tribal release (URL migration + 0.2.0)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,7 +40,7 @@ jobs:
         run: |
           version=$(cargo metadata --no-deps --format-version=1 \
             | jq -r '.packages[] | select(.name=="tribal") | .version')
-          expected="ghcr.io/samfolo/tribal:${version}"
+          expected="ghcr.io/tribal-memory/tribal:${version}"
           actual=$(yq -r '.services.tribal.image' docker-compose.yml)
           if [[ "$actual" != "$expected" ]]; then
             echo "::error::docker-compose.yml image tag drift: expected '${expected}', found '${actual}'"

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -14,7 +14,7 @@ on:
 permissions: {}
 
 env:
-  IMAGE_NAME: ghcr.io/samfolo/tribal
+  IMAGE_NAME: ghcr.io/tribal-memory/tribal
 
 jobs:
   shellcheck:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -293,7 +293,7 @@ jobs:
       - uses: actions/checkout@v6
         with:
           persist-credentials: true
-          repository: "samfolo/homebrew-tap"
+          repository: "tribal-memory/homebrew-tap"
           token: ${{ secrets.HOMEBREW_TAP_TOKEN }}
       # So we have access to the formula
       - name: Fetch homebrew formulae

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5155,7 +5155,7 @@ dependencies = [
 
 [[package]]
 name = "tribal-common"
-version = "0.1.1"
+version = "0.2.0"
 dependencies = [
  "dashmap",
  "rand 0.10.1",
@@ -5166,7 +5166,7 @@ dependencies = [
 
 [[package]]
 name = "tribal-config"
-version = "0.1.1"
+version = "0.2.0"
 dependencies = [
  "dirs",
  "figment",
@@ -5181,7 +5181,7 @@ dependencies = [
 
 [[package]]
 name = "tribal-db"
-version = "0.1.1"
+version = "0.2.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -5200,7 +5200,7 @@ dependencies = [
 
 [[package]]
 name = "tribal-domain"
-version = "0.1.1"
+version = "0.2.0"
 dependencies = [
  "chrono",
  "schemars 0.8.22",
@@ -5214,7 +5214,7 @@ dependencies = [
 
 [[package]]
 name = "tribal-e2e"
-version = "0.1.1"
+version = "0.2.0"
 dependencies = [
  "chrono",
  "dashmap",
@@ -5240,7 +5240,7 @@ dependencies = [
 
 [[package]]
 name = "tribal-inference"
-version = "0.1.1"
+version = "0.2.0"
 dependencies = [
  "async-trait",
  "reqwest 0.13.2",
@@ -5256,7 +5256,7 @@ dependencies = [
 
 [[package]]
 name = "tribal-mcp"
-version = "0.1.1"
+version = "0.2.0"
 dependencies = [
  "axum",
  "chrono",
@@ -5289,7 +5289,7 @@ dependencies = [
 
 [[package]]
 name = "tribal-telemetry"
-version = "0.1.1"
+version = "0.2.0"
 dependencies = [
  "opentelemetry",
  "opentelemetry-otlp",
@@ -5310,7 +5310,7 @@ dependencies = [
 
 [[package]]
 name = "tribal-test-utils"
-version = "0.1.1"
+version = "0.2.0"
 dependencies = [
  "anstream 1.0.0",
  "async-trait",
@@ -5334,7 +5334,7 @@ dependencies = [
 
 [[package]]
 name = "tribal-ui"
-version = "0.1.1"
+version = "0.2.0"
 dependencies = [
  "anstream 1.0.0",
  "anstyle",
@@ -5349,7 +5349,7 @@ dependencies = [
 
 [[package]]
 name = "tribal-worker"
-version = "0.1.1"
+version = "0.2.0"
 dependencies = [
  "chrono",
  "dashmap",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5105,7 +5105,7 @@ dependencies = [
 
 [[package]]
 name = "tribal"
-version = "0.1.1"
+version = "0.2.0"
 dependencies = [
  "anstream 1.0.0",
  "axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ members = [
 
 [workspace.package]
 edition = "2024"
-version = "0.1.1"
+version = "0.2.0"
 license = "Elastic-2.0"
 rust-version = "1.93"
 publish = false

--- a/crates/tribal-server/Cargo.toml
+++ b/crates/tribal-server/Cargo.toml
@@ -5,8 +5,8 @@ version.workspace = true
 rust-version.workspace = true
 publish.workspace = true
 license.workspace = true
-repository = "https://github.com/samfolo/tribal"
-homepage = "https://github.com/samfolo/tribal"
+repository = "https://github.com/tribal-memory/tribal"
+homepage = "https://github.com/tribal-memory/tribal"
 description = "Capture tribal knowledge. Give it to your agents."
 
 [package.metadata.dist]

--- a/crates/tribal-server/src/commands/bootstrap/output/action_list.rs
+++ b/crates/tribal-server/src/commands/bootstrap/output/action_list.rs
@@ -284,6 +284,6 @@ fn push_wire_up_step(steps: &mut Vec<ActionStep>) {
 fn push_skills_step(steps: &mut Vec<ActionStep>) {
     steps.push(ActionStep::new(
         "(Optional) Install Tribal skills into your agent:",
-        vec![BodyLine::new("npx skills add samfolo/tribal-skills")],
+        vec![BodyLine::new("npx skills add tribal-memory/skills")],
     ));
 }

--- a/crates/tribal-server/src/commands/bootstrap/snapshots/stderr-http-credentials-failed.txt
+++ b/crates/tribal-server/src/commands/bootstrap/snapshots/stderr-http-credentials-failed.txt
@@ -38,4 +38,4 @@ Next steps:
    For Codex / Gemini CLI / OpenCode, see the installation skill.
 
 7. (Optional) Install Tribal skills into your agent:
-   npx skills add samfolo/tribal-skills
+   npx skills add tribal-memory/skills

--- a/crates/tribal-server/src/commands/bootstrap/snapshots/stderr-http-flags-file-exists.txt
+++ b/crates/tribal-server/src/commands/bootstrap/snapshots/stderr-http-flags-file-exists.txt
@@ -48,4 +48,4 @@ Next steps:
    For Codex / Gemini CLI / OpenCode, see the installation skill.
 
 8. (Optional) Install Tribal skills into your agent:
-   npx skills add samfolo/tribal-skills
+   npx skills add tribal-memory/skills

--- a/crates/tribal-server/src/commands/bootstrap/snapshots/stderr-http-flags-first-run.txt
+++ b/crates/tribal-server/src/commands/bootstrap/snapshots/stderr-http-flags-first-run.txt
@@ -41,4 +41,4 @@ Next steps:
    For Codex / Gemini CLI / OpenCode, see the installation skill.
 
 8. (Optional) Install Tribal skills into your agent:
-   npx skills add samfolo/tribal-skills
+   npx skills add tribal-memory/skills

--- a/crates/tribal-server/src/commands/bootstrap/snapshots/stderr-http-no-flags-file-exists.txt
+++ b/crates/tribal-server/src/commands/bootstrap/snapshots/stderr-http-no-flags-file-exists.txt
@@ -40,4 +40,4 @@ Next steps:
    For Codex / Gemini CLI / OpenCode, see the installation skill.
 
 7. (Optional) Install Tribal skills into your agent:
-   npx skills add samfolo/tribal-skills
+   npx skills add tribal-memory/skills

--- a/crates/tribal-server/src/commands/bootstrap/snapshots/stderr-http-no-flags-first-run.txt
+++ b/crates/tribal-server/src/commands/bootstrap/snapshots/stderr-http-no-flags-first-run.txt
@@ -38,4 +38,4 @@ Next steps:
    For Codex / Gemini CLI / OpenCode, see the installation skill.
 
 7. (Optional) Install Tribal skills into your agent:
-   npx skills add samfolo/tribal-skills
+   npx skills add tribal-memory/skills

--- a/crates/tribal-server/src/commands/bootstrap/snapshots/stderr-stdio-credentials-failed.txt
+++ b/crates/tribal-server/src/commands/bootstrap/snapshots/stderr-stdio-credentials-failed.txt
@@ -17,7 +17,7 @@ Next steps:
    For Codex / Gemini CLI / OpenCode, see the installation skill.
 
 4. (Optional) Install Tribal skills into your agent:
-   npx skills add samfolo/tribal-skills
+   npx skills add tribal-memory/skills
 
 Bearer token (credentials.json was NOT written — copy this manually):
 

--- a/crates/tribal-server/src/commands/bootstrap/snapshots/stderr-stdio-flags-file-exists.txt
+++ b/crates/tribal-server/src/commands/bootstrap/snapshots/stderr-stdio-flags-file-exists.txt
@@ -27,7 +27,7 @@ Next steps:
    For Codex / Gemini CLI / OpenCode, see the installation skill.
 
 5. (Optional) Install Tribal skills into your agent:
-   npx skills add samfolo/tribal-skills
+   npx skills add tribal-memory/skills
 
 Bearer token (also saved to /home/sam/.config/tribal/credentials.json):
 

--- a/crates/tribal-server/src/commands/bootstrap/snapshots/stderr-stdio-flags-first-run.txt
+++ b/crates/tribal-server/src/commands/bootstrap/snapshots/stderr-stdio-flags-first-run.txt
@@ -20,7 +20,7 @@ Next steps:
    For Codex / Gemini CLI / OpenCode, see the installation skill.
 
 5. (Optional) Install Tribal skills into your agent:
-   npx skills add samfolo/tribal-skills
+   npx skills add tribal-memory/skills
 
 Bearer token (also saved to /home/sam/.config/tribal/credentials.json):
 

--- a/crates/tribal-server/src/commands/bootstrap/snapshots/stderr-stdio-no-flags-file-exists.txt
+++ b/crates/tribal-server/src/commands/bootstrap/snapshots/stderr-stdio-no-flags-file-exists.txt
@@ -19,7 +19,7 @@ Next steps:
    For Codex / Gemini CLI / OpenCode, see the installation skill.
 
 4. (Optional) Install Tribal skills into your agent:
-   npx skills add samfolo/tribal-skills
+   npx skills add tribal-memory/skills
 
 Bearer token (also saved to /home/sam/.config/tribal/credentials.json):
 

--- a/crates/tribal-server/src/commands/bootstrap/snapshots/stderr-stdio-no-flags-first-run.txt
+++ b/crates/tribal-server/src/commands/bootstrap/snapshots/stderr-stdio-no-flags-first-run.txt
@@ -17,7 +17,7 @@ Next steps:
    For Codex / Gemini CLI / OpenCode, see the installation skill.
 
 4. (Optional) Install Tribal skills into your agent:
-   npx skills add samfolo/tribal-skills
+   npx skills add tribal-memory/skills
 
 Bearer token (also saved to /home/sam/.config/tribal/credentials.json):
 

--- a/dist-workspace.toml
+++ b/dist-workspace.toml
@@ -10,7 +10,7 @@ ci = "github"
 # The installers to generate for each app
 installers = ["shell", "homebrew"]
 # A GitHub repo to push Homebrew formulas to
-tap = "samfolo/homebrew-tap"
+tap = "tribal-memory/homebrew-tap"
 # Target platforms to build apps for (Rust target-triple syntax)
 targets = ["aarch64-apple-darwin", "aarch64-unknown-linux-gnu", "x86_64-apple-darwin", "x86_64-unknown-linux-gnu", "x86_64-unknown-linux-musl"]
 # Path that installers should place binaries in

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -19,7 +19,7 @@ services:
         max-file: "3"
 
   tribal:
-    image: ghcr.io/samfolo/tribal:0.1.1
+    image: ghcr.io/tribal-memory/tribal:0.1.1
     depends_on:
       postgres:
         condition: service_healthy

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -19,7 +19,7 @@ services:
         max-file: "3"
 
   tribal:
-    image: ghcr.io/tribal-memory/tribal:0.1.1
+    image: ghcr.io/tribal-memory/tribal:0.2.0
     depends_on:
       postgres:
         condition: service_healthy

--- a/scripts/tribal-entrypoint
+++ b/scripts/tribal-entrypoint
@@ -64,11 +64,11 @@ Provider configuration is your responsibility:
     (OPENAI_API_KEY, ANTHROPIC_API_KEY, ...).
 
 To install Tribal's skills into your agent:
-  npx skills add samfolo/tribal-skills
+  npx skills add tribal-memory/skills
 
 To remove Tribal entirely:
   docker compose down -v
-  npx skills remove samfolo/tribal-skills
+  npx skills remove installing-tribal using-tribal
 ================================================================
 EOF
 }


### PR DESCRIPTION
## Summary

Prepares a release under the `tribal-memory` org.

**Owner-namespace migration** (`samfolo/*` → `tribal-memory/*`):
- `Cargo.toml`: `repository` + `homepage` → `tribal-memory/tribal`
- bootstrap `action_list` + 10 stderr snapshots: skills install line → `tribal-memory/skills`; remove line corrected to skill names (`installing-tribal using-tribal`)
- `dist-workspace.toml`: Homebrew tap → `tribal-memory/homebrew-tap`
- `docker-compose.yml`, `ci.yml`, `docker.yml`: GHCR namespace → `ghcr.io/tribal-memory/tribal`
- `release.yml`: cargo-dist tap checkout → `tribal-memory/homebrew-tap`

**Version bump to 0.2.0** (minor; Onboarding MVP milestone):
- workspace version, `Cargo.lock` tribal entry, and `docker-compose.yml` image pin in lockstep (keeps the `ci.yml` compose-pin check green)
- MSRV (`rust-version`) left at 1.93

The Homebrew formula and the `release.yml` tap value are cargo-dist generated; the next release regenerates the formula with `tribal-memory` URLs from `Cargo.toml` + `dist-workspace.toml`. GHCR images publish to the new namespace on release via the updated `IMAGE_NAME`.

README migration + install-block split + CONTRIBUTING ride on the separate `docs/readme-rewrite` branch (merges last, with `Closes #162`).

## Release flow after merge

1. Merge this PR.
2. Tag `v0.2.0` and push the tag — fires `release.yml` (cargo-dist) and the `docker.yml` publish job.
3. Release regenerates the Homebrew formula under `tribal-memory/homebrew-tap` and publishes `ghcr.io/tribal-memory/tribal:0.2.0`.

## Test plan

- [ ] CI green (snapshot tests confirm regenerated bootstrap stderr; compose-pin check passes at 0.2.0)
- [ ] Tag push produces a clean release; formula + GHCR image land under tribal-memory