### PR TITLE
[REFACTOR] Parameterise Docker provider config for cloud models (0.2.1)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,1 +1,34 @@
+# Local development: sqlx tooling reads this (`cargo sqlx prepare`,
+# `sqlx migrate`, builds without SQLX_OFFLINE). The Docker Compose
+# stack sets its own database URL and ignores this line.
 DATABASE_URL=postgres://tribal:tribal@localhost:5432/tribal_dev
+
+# API keys for cloud providers. Blank is fine for local Ollama; the
+# standard names are picked up across all stages (embedding + inference).
+OPENAI_API_KEY=
+ANTHROPIC_API_KEY=
+
+# --- Cloud provider override (Docker Compose, optional) ---
+# The compose stack defaults to a local Ollama on the host. To run the
+# pipeline on OpenAI instead, uncomment below and set OPENAI_API_KEY
+# above. Stages are independent (you can mix, e.g. Ollama embedding +
+# cloud inference); base_url must be set too, or requests route to the
+# local Ollama. Embedding is currently fixed at 768 dims, which
+# text-embedding-3-small fits (Tribal requests 768 via the dimensions
+# parameter).
+#
+# TRIBAL_EMBEDDING__PROVIDER=openai
+# TRIBAL_EMBEDDING__MODEL=text-embedding-3-small
+# TRIBAL_EMBEDDING__BASE_URL=https://api.openai.com
+# TRIBAL_INFERENCE__EXTRACTION__PROVIDER=openai
+# TRIBAL_INFERENCE__EXTRACTION__MODEL=gpt-5.4-mini
+# TRIBAL_INFERENCE__EXTRACTION__BASE_URL=https://api.openai.com
+# TRIBAL_INFERENCE__TRIAGE__PROVIDER=openai
+# TRIBAL_INFERENCE__TRIAGE__MODEL=gpt-5.4-mini
+# TRIBAL_INFERENCE__TRIAGE__BASE_URL=https://api.openai.com
+# TRIBAL_INFERENCE__RELATION__PROVIDER=openai
+# TRIBAL_INFERENCE__RELATION__MODEL=gpt-5.4-mini
+# TRIBAL_INFERENCE__RELATION__BASE_URL=https://api.openai.com
+#
+# Anthropic is available for the inference stages (it has no embedding
+# API), e.g. TRIBAL_INFERENCE__EXTRACTION__BASE_URL=https://api.anthropic.com

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5105,7 +5105,7 @@ dependencies = [
 
 [[package]]
 name = "tribal"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "anstream 1.0.0",
  "axum",
@@ -5155,7 +5155,7 @@ dependencies = [
 
 [[package]]
 name = "tribal-common"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "dashmap",
  "rand 0.10.1",
@@ -5166,7 +5166,7 @@ dependencies = [
 
 [[package]]
 name = "tribal-config"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "dirs",
  "figment",
@@ -5181,7 +5181,7 @@ dependencies = [
 
 [[package]]
 name = "tribal-db"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "async-trait",
  "chrono",
@@ -5200,7 +5200,7 @@ dependencies = [
 
 [[package]]
 name = "tribal-domain"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "chrono",
  "schemars 0.8.22",
@@ -5214,7 +5214,7 @@ dependencies = [
 
 [[package]]
 name = "tribal-e2e"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "chrono",
  "dashmap",
@@ -5240,7 +5240,7 @@ dependencies = [
 
 [[package]]
 name = "tribal-inference"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "async-trait",
  "reqwest 0.13.2",
@@ -5256,7 +5256,7 @@ dependencies = [
 
 [[package]]
 name = "tribal-mcp"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "axum",
  "chrono",
@@ -5289,7 +5289,7 @@ dependencies = [
 
 [[package]]
 name = "tribal-telemetry"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "opentelemetry",
  "opentelemetry-otlp",
@@ -5310,7 +5310,7 @@ dependencies = [
 
 [[package]]
 name = "tribal-test-utils"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "anstream 1.0.0",
  "async-trait",
@@ -5334,7 +5334,7 @@ dependencies = [
 
 [[package]]
 name = "tribal-ui"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "anstream 1.0.0",
  "anstyle",
@@ -5349,7 +5349,7 @@ dependencies = [
 
 [[package]]
 name = "tribal-worker"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "chrono",
  "dashmap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ members = [
 
 [workspace.package]
 edition = "2024"
-version = "0.2.0"
+version = "0.2.1"
 license = "Elastic-2.0"
 rust-version = "1.93"
 publish = false

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -19,7 +19,7 @@ services:
         max-file: "3"
 
   tribal:
-    image: ghcr.io/tribal-memory/tribal:0.2.0
+    image: ghcr.io/tribal-memory/tribal:0.2.1
     depends_on:
       postgres:
         condition: service_healthy
@@ -37,15 +37,32 @@ services:
       # XDG_CONFIG_HOME parent).
       XDG_CONFIG_HOME: "/var/lib/tribal"
       TRIBAL_CONFIG_PATH: "/var/lib/tribal/tribal/tribal.yaml"
-      # Ollama base URL — the binary default resolves to the container's
-      # own loopback (no Ollama there). Redirect to host.docker.internal
-      # so the container reaches Ollama on the host. extra_hosts (below)
-      # makes the name resolvable on Linux Docker (macOS / Windows Docker
-      # Desktop resolve it natively).
-      TRIBAL_EMBEDDING__BASE_URL: "http://host.docker.internal:11434"
-      TRIBAL_INFERENCE__EXTRACTION__BASE_URL: "http://host.docker.internal:11434"
-      TRIBAL_INFERENCE__TRIAGE__BASE_URL: "http://host.docker.internal:11434"
-      TRIBAL_INFERENCE__RELATION__BASE_URL: "http://host.docker.internal:11434"
+      # Provider selection. Defaults target a local Ollama on the host.
+      # Every field is exposed as a host-overridable variable: Compose only
+      # forwards variables it names here, so each needs a default to stay
+      # overridable from .env. To use a cloud provider, set these in .env
+      # (see .env.example for a ready-to-paste OpenAI block).
+      #
+      # base_url is pinned to host.docker.internal rather than the binary's
+      # localhost default so the container reaches Ollama on the host;
+      # extra_hosts (below) makes the name resolvable on Linux Docker
+      # (macOS / Windows Docker Desktop resolve it natively). Switching a
+      # stage to a cloud provider means overriding its base_url too (for
+      # example https://api.openai.com or https://api.anthropic.com),
+      # otherwise requests route to the local Ollama address. Model
+      # defaults mirror the binary's.
+      TRIBAL_EMBEDDING__PROVIDER: "${TRIBAL_EMBEDDING__PROVIDER:-ollama}"
+      TRIBAL_EMBEDDING__MODEL: "${TRIBAL_EMBEDDING__MODEL:-nomic-embed-text:v1.5}"
+      TRIBAL_EMBEDDING__BASE_URL: "${TRIBAL_EMBEDDING__BASE_URL:-http://host.docker.internal:11434}"
+      TRIBAL_INFERENCE__EXTRACTION__PROVIDER: "${TRIBAL_INFERENCE__EXTRACTION__PROVIDER:-ollama}"
+      TRIBAL_INFERENCE__EXTRACTION__MODEL: "${TRIBAL_INFERENCE__EXTRACTION__MODEL:-llama3.1:70b}"
+      TRIBAL_INFERENCE__EXTRACTION__BASE_URL: "${TRIBAL_INFERENCE__EXTRACTION__BASE_URL:-http://host.docker.internal:11434}"
+      TRIBAL_INFERENCE__TRIAGE__PROVIDER: "${TRIBAL_INFERENCE__TRIAGE__PROVIDER:-ollama}"
+      TRIBAL_INFERENCE__TRIAGE__MODEL: "${TRIBAL_INFERENCE__TRIAGE__MODEL:-llama3.1:8b}"
+      TRIBAL_INFERENCE__TRIAGE__BASE_URL: "${TRIBAL_INFERENCE__TRIAGE__BASE_URL:-http://host.docker.internal:11434}"
+      TRIBAL_INFERENCE__RELATION__PROVIDER: "${TRIBAL_INFERENCE__RELATION__PROVIDER:-ollama}"
+      TRIBAL_INFERENCE__RELATION__MODEL: "${TRIBAL_INFERENCE__RELATION__MODEL:-llama3.1:8b}"
+      TRIBAL_INFERENCE__RELATION__BASE_URL: "${TRIBAL_INFERENCE__RELATION__BASE_URL:-http://host.docker.internal:11434}"
       TRIBAL_PROJECT_NAME: ${TRIBAL_PROJECT_NAME:-tribal-docker-local}
       TRIBAL_PROJECT_REMOTE: ${TRIBAL_PROJECT_REMOTE:-https://example.com/local/tribal-docker.git}
       # Provider env vars passed through from the host shell. Optional;

--- a/scripts/tribal-entrypoint
+++ b/scripts/tribal-entrypoint
@@ -57,11 +57,12 @@ This compose flow uses a placeholder git remote
 against your real repo, ask your agent (after wiring) to run:
   tribal project register --remote <your-repo-url>
 
-Provider configuration is your responsibility:
-  - Ollama: ensure it's running and reachable (default
-    http://host.docker.internal:11434 from the container).
-  - Cloud providers: pass your API keys via the compose env
-    (OPENAI_API_KEY, ANTHROPIC_API_KEY, ...).
+Provider configuration is your responsibility. The defaults
+target a local Ollama on the host
+(http://host.docker.internal:11434); ensure it is running with
+the required models pulled. To use a cloud provider instead, set
+its provider, model, and base_url (plus API key) in .env before
+'docker compose up'. See .env.example for a ready-to-paste block.
 
 To install Tribal's skills into your agent:
   npx skills add tribal-memory/skills


### PR DESCRIPTION
## Summary
- Parameterise every embedding and inference provider field in `docker-compose.yml` as `${VAR:-default}`, so a host `.env` can select a cloud provider (OpenAI/Anthropic) via Compose interpolation. The previous hard-coded Ollama `base_url` env vars overrode config and made the Docker path Ollama-only.
- Document the cloud override in `.env.example`; update the entrypoint onboarding text to match.
- Bump the workspace version and the compose image tag to 0.2.1.

## Why
The M8.6 smoke surfaced that the Docker path was effectively Ollama-locked: the compose pinned `TRIBAL_*__BASE_URL` to the local Ollama address (which beats the config file), with no flag to override it, so cloud providers were unreachable short of a hand-written override file.

## Release sequencing
Tagging `v0.2.1` publishes `ghcr.io/tribal-memory/tribal:0.2.1`, which the compose now pins (the CI guard requires the tag to match the workspace version). The `installing-tribal` skill (in `tribal-memory/skills`) is updated to fetch the compose from the latest release; that skill change should be pushed **only after** this release is live, or users would pull the older Ollama-locked compose.

## Test plan
- [ ] `docker compose up` with no `.env` overrides runs on local Ollama (defaults resolve).
- [ ] A `.env` with the OpenAI block routes embedding and inference to OpenAI.
- [ ] `tribal check` reports healthy; a first ingest succeeds against the configured provider.