### PR TITLE
[CHORE] add CHANGELOG and bump version to 0.2.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,35 @@
+# Changelog
+
+All notable changes to this project are documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and this project aims to follow [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.2.2] - 2026-05-26
+
+### Added
+
+- Support for reasoning and adaptive-sampling models. Tribal resolves, per provider and model, which request fields a target accepts and shapes each request to match: OpenAI reasoning models (the o-series and the GPT-5 reasoning line) send the output cap as `max_completion_tokens` and have caller sampling parameters dropped, while Anthropic adaptive models (Opus 4.7) have `temperature` dropped but keep their required `max_tokens`. Both `tribal check --providers` and ingest now succeed for these models. An unrecognised model keeps sending every parameter, so ordinary models are unaffected.
+- Per-stage `temperature` and `max_tokens` from configuration now reach the model. Previously they were silently dropped and only recorded in the system fingerprint.
+- Configuration validation for sampling parameters: when set, `temperature` must be within `[0.0, 2.0]` and `max_tokens` at least 1. Model IDs may no longer be empty or whitespace-only.
+
+### Changed
+
+- Sampling parameters are now optional in configuration. An unset `temperature` or `max_tokens` means "use the provider default" rather than a built-in number, and the four built-in per-stage sampling defaults have been removed.
+- The system fingerprint records the effective post-reconcile sampling parameters, so it reflects what is actually sent. Fingerprints change for any model whose request shape the capability layer adjusts.
+- Rewrote the README around the shipped onboarding surface (`tribal bootstrap`, `tribal check`, `tribal mcp-config`, Docker Compose, and the skills), and added `CONTRIBUTING.md`.
+
+### Fixed
+
+- Reasoning models are no longer rejected by the provider readiness probe (`tribal check --providers`), which previously forced `temperature` and `max_tokens` values these models reject.
+
+## [0.2.1] - 2026-05-25
+
+### Added
+
+- Docker Compose provider configuration through `.env`, letting the containerised path target a cloud provider (OpenAI, Anthropic) instead of only a local Ollama.
+
+[Unreleased]: https://github.com/tribal-memory/tribal/compare/v0.2.2...HEAD
+[0.2.2]: https://github.com/tribal-memory/tribal/compare/v0.2.1...v0.2.2
+[0.2.1]: https://github.com/tribal-memory/tribal/releases/tag/v0.2.1

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -35,3 +35,16 @@ just serve          # run the MCP server (stdio transport)
 ```
 
 Run `just --list` for the complete set.
+
+## Releasing
+
+Releases are tag-driven. Pushing a `vX.Y.Z` tag builds the binaries, installers, and Homebrew formula (via cargo-dist) and publishes the Docker image. The GitHub Release body is taken from the matching `CHANGELOG.md` section, so the changelog *is* the release notes.
+
+To cut a release:
+
+1. Update `CHANGELOG.md`: rename `## [Unreleased]` to `## [X.Y.Z] - YYYY-MM-DD`, curate the entries for readers (group under Added / Changed / Fixed / Removed, drop internal churn), add a fresh empty `## [Unreleased]`, and update the compare links at the bottom. `git log vPREV..HEAD` is a useful starting point, since commits follow Conventional Commits.
+2. Bump `workspace.package.version` in `Cargo.toml`, then run `cargo update --workspace` to sync `Cargo.lock`.
+3. Bump the pinned image tag in `docker-compose.yml` to the same version. The README and the installation skill fetch the compose file from the release tag, so it must reference the image that tag publishes.
+4. Land the above on `main`, then tag that commit `vX.Y.Z` and push the tag.
+
+The Docker workflow refuses to publish if the tag does not match `workspace.package.version`, so steps 2 and 4 must agree.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5105,7 +5105,7 @@ dependencies = [
 
 [[package]]
 name = "tribal"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "anstream 1.0.0",
  "axum",
@@ -5155,7 +5155,7 @@ dependencies = [
 
 [[package]]
 name = "tribal-common"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "dashmap",
  "rand 0.10.1",
@@ -5166,7 +5166,7 @@ dependencies = [
 
 [[package]]
 name = "tribal-config"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "dirs",
  "figment",
@@ -5181,7 +5181,7 @@ dependencies = [
 
 [[package]]
 name = "tribal-db"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "async-trait",
  "chrono",
@@ -5200,7 +5200,7 @@ dependencies = [
 
 [[package]]
 name = "tribal-domain"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "chrono",
  "schemars 0.8.22",
@@ -5214,7 +5214,7 @@ dependencies = [
 
 [[package]]
 name = "tribal-e2e"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "chrono",
  "dashmap",
@@ -5240,7 +5240,7 @@ dependencies = [
 
 [[package]]
 name = "tribal-inference"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "async-trait",
  "reqwest 0.13.2",
@@ -5256,7 +5256,7 @@ dependencies = [
 
 [[package]]
 name = "tribal-mcp"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "axum",
  "chrono",
@@ -5289,7 +5289,7 @@ dependencies = [
 
 [[package]]
 name = "tribal-telemetry"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "opentelemetry",
  "opentelemetry-otlp",
@@ -5310,7 +5310,7 @@ dependencies = [
 
 [[package]]
 name = "tribal-test-utils"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "anstream 1.0.0",
  "async-trait",
@@ -5334,7 +5334,7 @@ dependencies = [
 
 [[package]]
 name = "tribal-ui"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "anstream 1.0.0",
  "anstyle",
@@ -5349,7 +5349,7 @@ dependencies = [
 
 [[package]]
 name = "tribal-worker"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "chrono",
  "dashmap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ members = [
 
 [workspace.package]
 edition = "2024"
-version = "0.2.1"
+version = "0.2.2"
 license = "Elastic-2.0"
 rust-version = "1.93"
 publish = false

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -19,7 +19,7 @@ services:
         max-file: "3"
 
   tribal:
-    image: ghcr.io/tribal-memory/tribal:0.2.1
+    image: ghcr.io/tribal-memory/tribal:0.2.2
     depends_on:
       postgres:
         condition: service_healthy


### PR DESCRIPTION
## Summary

- Start `CHANGELOG.md` in [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) format: a full `0.2.2` entry (the #168 capability layer) plus a terse `0.2.1` entry.
- Bump the workspace version `0.2.1` -> `0.2.2` (`Cargo.toml` + `Cargo.lock` via `cargo update --workspace`, 12 crates, no dependency churn) and the pinned `docker-compose.yml` image tag to match.
- Add a **Releasing** runbook to `CONTRIBUTING.md`. cargo-dist already uses the matching `CHANGELOG.md` section as the GitHub Release body, so the changelog *is* the release notes.

## Release sequence (after this merges)

1. Merge to `main`, then tag that commit `v0.2.2` and push the tag.
2. `release.yml` publishes binaries / shell installer / Homebrew formula; `docker.yml` validates the tag matches the workspace version and publishes `ghcr.io/tribal-memory/tribal:0.2.2`.
3. **Verify a reasoning-model ingest end-to-end against the published image before flipping the skills** to recommend reasoning models. The skills still conservatively say reasoning models are unsupported, so nothing is mis-advertised in the meantime.

## Notes

- No stray `0.2.1` references remain in tracked source / config.
- Merging puts `docker-compose.yml` at `:0.2.2` on `main` before the image exists; the image publishes on the `v0.2.2` tag, and the README / skill fetch the compose from the release tag (not `main`), so tag promptly after merge.