### PR TITLE
[REFACTOR] Use index-based knowledge-item targeting for the triage inference call

### DIFF
--- a/crates/tribal-e2e/tests/e2e/cross_batch_relations.rs
+++ b/crates/tribal-e2e/tests/e2e/cross_batch_relations.rs
@@ -90,8 +90,9 @@ async fn test_cross_batch_relations() {
             m.on_content_repeat_last(
                 "storage costs",
                 &[novel()
+                    // The seeded decision is the sole search hit, at index 0.
                     .similar_item(SimilarItemSpec {
-                        item_id: decision_id,
+                        context_index: 0,
                         suggested_relation: "supports",
                         justification: "Storage savings validate the event sourcing decision",
                     })

--- a/crates/tribal-e2e/tests/e2e/duplicate_batch.rs
+++ b/crates/tribal-e2e/tests/e2e/duplicate_batch.rs
@@ -46,8 +46,6 @@ async fn test_duplicate_only_batch() {
     })
     .await;
 
-    let existing_id = harness.label("notification_item");
-
     // -- Mount mocks ----------------------------------------------------------
 
     // Extraction produces a single candidate that restates the existing knowledge.
@@ -68,10 +66,11 @@ async fn test_duplicate_only_batch() {
         })
         .await;
 
-    // Triage classifies the candidate as a duplicate of the existing item.
+    // Triage classifies the candidate as a duplicate of the existing item,
+    // the sole search hit, at index 0.
     harness
         .mount_triage(|m| {
-            m.respond(duplicate(existing_id).build());
+            m.respond(duplicate(0).build());
         })
         .await;
 

--- a/crates/tribal-e2e/tests/harness/fixtures/triage.rs
+++ b/crates/tribal-e2e/tests/harness/fixtures/triage.rs
@@ -4,9 +4,10 @@ use serde_json::{Value, json};
 // Spec types
 // ---------------------------------------------------------------------------
 
-/// Specifies a similar item classification in a triage response.
+/// Specifies a similar item classification in a triage response, referencing
+/// the similar item by its zero-based index in the prompt's numbered list.
 pub struct SimilarItemSpec<'a> {
-    pub item_id: &'a str,
+    pub context_index: u32,
     pub suggested_relation: &'a str,
     pub justification: &'a str,
 }
@@ -20,17 +21,18 @@ pub struct SimilarItemSpec<'a> {
 pub fn novel() -> TriageFixtureBuilder {
     TriageFixtureBuilder {
         decision: "created".to_owned(),
-        matched_item_id: None,
+        matched_index: None,
         similar_items: Vec::new(),
     }
 }
 
-/// Creates a Duplicate triage fixture builder referencing an existing item.
+/// Creates a Duplicate triage fixture builder referencing the similar item
+/// at the given zero-based context index.
 #[must_use]
-pub fn duplicate(matched_item_id: &str) -> TriageFixtureBuilder {
+pub fn duplicate(matched_index: u32) -> TriageFixtureBuilder {
     TriageFixtureBuilder {
         decision: "duplicate".to_owned(),
-        matched_item_id: Some(matched_item_id.to_owned()),
+        matched_index: Some(matched_index),
         similar_items: Vec::new(),
     }
 }
@@ -43,7 +45,7 @@ pub fn duplicate(matched_item_id: &str) -> TriageFixtureBuilder {
 /// `crates/tribal-worker/src/parsing/triage.rs`.
 pub struct TriageFixtureBuilder {
     decision: String,
-    matched_item_id: Option<String>,
+    matched_index: Option<u32>,
     similar_items: Vec<Value>,
 }
 
@@ -52,7 +54,7 @@ impl TriageFixtureBuilder {
     #[must_use]
     pub fn similar_item(mut self, item: SimilarItemSpec<'_>) -> Self {
         self.similar_items.push(json!({
-            "item_id": item.item_id,
+            "item": { "kind": "context_index", "context_index": item.context_index },
             "suggested_relation": item.suggested_relation,
             "justification": item.justification,
         }));
@@ -63,8 +65,8 @@ impl TriageFixtureBuilder {
     #[must_use]
     pub fn build(self) -> Value {
         let mut outcome = json!({ "decision": self.decision });
-        if let Some(id) = &self.matched_item_id {
-            outcome["matched_item_id"] = json!(id);
+        if let Some(index) = self.matched_index {
+            outcome["matched_item"] = json!({ "kind": "context_index", "context_index": index });
         }
 
         json!({

--- a/crates/tribal-worker/src/parsing.rs
+++ b/crates/tribal-worker/src/parsing.rs
@@ -9,5 +9,6 @@ pub(crate) use extraction::{ExtractionOutput, parse_extraction_response};
 pub(crate) use relation::IngestionRelationKind;
 pub(crate) use relation::{RelationEdge, RelationOutput, RelationTarget, parse_relation_response};
 pub(crate) use triage::{
-    SimilarItemClassification, TriageClassification, TriageDecision, parse_triage_response,
+    SimilarItemClassification, TriageClassification, TriageDecision, TriageItemReference,
+    parse_triage_response,
 };

--- a/crates/tribal-worker/src/parsing/triage.rs
+++ b/crates/tribal-worker/src/parsing/triage.rs
@@ -1,7 +1,7 @@
 //! Triage response parsing and LLM response types.
 
 use serde::Deserialize;
-use tribal_domain::{KnowledgeItemId, RelationSuggestion};
+use tribal_domain::RelationSuggestion;
 use tribal_inference::CompletionResponse;
 
 use crate::error::StageError;
@@ -61,6 +61,36 @@ impl TriageClassification {
     }
 }
 
+/// A reference to one of the similar items provided to triage.
+///
+/// Triage's index space contains *only* the similar items returned by
+/// semantic search, numbered by their zero-based position in the prompt's
+/// numbered list. (This differs from the relation stage's unified space,
+/// which also numbers the batch's extraction candidates — hence a
+/// triage-local type.) The worker resolves the index to a knowledge item
+/// against the search results before persisting; an out-of-range index is
+/// a handled outcome, never a parse failure.
+///
+/// Modelled as a typed structure rather than a bare integer or string, so an
+/// ill-formed reference is unrepresentable at the schema boundary.
+/// `#[serde(tag = "kind")]` (internally tagged) gives explicit discrimination
+/// and room to add further reference kinds without a wire break.
+#[derive(Debug, Clone, PartialEq, Eq, Deserialize, schemars::JsonSchema)]
+#[serde(tag = "kind")]
+#[schemars(description = "A reference to one of the provided similar items by its context index.")]
+pub(crate) enum TriageItemReference {
+    /// A similar item, identified by its zero-based position in the
+    /// numbered similar-items list.
+    ///
+    /// Wire format: `{"kind": "context_index", "context_index": 0}`.
+    #[serde(rename = "context_index")]
+    #[schemars(
+        description = "A similar item, referenced by its zero-based index in the \
+        numbered similar-items list shown in the prompt."
+    )]
+    ContextIndex { context_index: u32 },
+}
+
 /// The triage decision for a candidate.
 ///
 /// Uses expressive Rust names (`Novel`/`Duplicate`) with serde renames
@@ -89,12 +119,12 @@ pub(crate) enum TriageDecision {
         'contradicts' — a contradiction is always novel."
     )]
     Duplicate {
-        /// The existing item the candidate matches.
+        /// The similar item the candidate duplicates, referenced by index.
         #[schemars(
-            description = "The identifier of the existing item this candidate duplicates. \
-            Must reference an item from the similar items provided."
+            description = "The similar item this candidate duplicates, referenced by its \
+            context index in the provided similar items."
         )]
-        matched_item_id: KnowledgeItemId,
+        matched_item: TriageItemReference,
     },
 }
 
@@ -105,9 +135,12 @@ pub(crate) enum TriageDecision {
     the candidate."
 )]
 pub(crate) struct SimilarItemClassification {
-    /// The existing item that was compared against.
-    #[schemars(description = "The identifier of the existing item being assessed.")]
-    pub item_id: KnowledgeItemId,
+    /// The similar item that was compared against, referenced by index.
+    #[schemars(
+        description = "The similar item being assessed, referenced by its context index \
+        in the provided similar items."
+    )]
+    pub item: TriageItemReference,
     /// The agent's suggested relation classification.
     #[schemars(
         description = "The relationship between the existing item and the candidate. \
@@ -189,13 +222,63 @@ mod tests {
         let json = r#"{
             "outcome": {
                 "decision": "duplicate",
-                "matched_item_id": "ki_550e8400-e29b-41d4-a716-446655440000"
+                "matched_item": { "kind": "context_index", "context_index": 0 }
             },
             "similar_item_decisions": []
         }"#;
         let response = mock_response(json);
         let result = parse_triage_response(&response);
         assert!(result.is_ok());
+    }
+
+    #[test]
+    fn test_parse_duplicate_with_context_index() {
+        let json = r#"{
+            "outcome": {
+                "decision": "duplicate",
+                "matched_item": { "kind": "context_index", "context_index": 2 }
+            },
+            "similar_item_decisions": []
+        }"#;
+        let response = mock_response(json);
+        let classification = parse_triage_response(&response).unwrap();
+        assert!(matches!(
+            classification.outcome,
+            TriageDecision::Duplicate {
+                matched_item: TriageItemReference::ContextIndex { context_index: 2 }
+            }
+        ));
+    }
+
+    #[test]
+    fn test_parse_duplicate_rejects_placeholder_string() {
+        // A bare string (a UUID or a hallucinated placeholder like
+        // "existing-item-1") is not admissible: the schema accepts only the
+        // typed context-index reference.
+        let json = r#"{
+            "outcome": { "decision": "duplicate", "matched_item": "existing-item-1" },
+            "similar_item_decisions": []
+        }"#;
+        let response = mock_response(json);
+        assert!(parse_triage_response(&response).is_err());
+    }
+
+    #[test]
+    fn test_parse_rejects_placeholder_string_in_similar_item_decision() {
+        // The per-item reference is the same typed field, so a placeholder
+        // string is inadmissible there too.
+        let json = r#"{
+            "outcome": { "decision": "created" },
+            "similar_item_decisions": [
+                {
+                    "item": "existing-item-1",
+                    "suggested_relation": "supports",
+                    "justification": "placeholder reference"
+                }
+            ]
+        }"#;
+        let response = mock_response(json);
+        assert!(parse_triage_response(&response).is_err());
     }
 
     #[test]
@@ -230,7 +313,7 @@ mod tests {
             "outcome": { "decision": "created" },
             "similar_item_decisions": [
                 {
-                    "item_id": "ki_550e8400-e29b-41d4-a716-446655440000",
+                    "item": { "kind": "context_index", "context_index": 0 },
                     "suggested_relation": "supports",
                     "justification": "Both describe Rust memory safety"
                 }
@@ -241,19 +324,23 @@ mod tests {
         assert!(result.is_ok());
         let classification = result.unwrap();
         assert_eq!(classification.similar_item_decisions.len(), 1);
+        assert!(matches!(
+            classification.similar_item_decisions[0].item,
+            TriageItemReference::ContextIndex { context_index: 0 }
+        ));
     }
 
     // -- reconcile --------------------------------------------------------
 
     fn classification_with_decisions(
         decision: &str,
-        matched_item_id: Option<&str>,
+        matched_index: Option<u32>,
         relations: &[&str],
     ) -> TriageClassification {
-        let outcome_json = match (decision, matched_item_id) {
-            ("duplicate", Some(id)) => {
-                format!(r#"{{"decision": "duplicate", "matched_item_id": "{id}"}}"#)
-            }
+        let outcome_json = match (decision, matched_index) {
+            ("duplicate", Some(index)) => format!(
+                r#"{{"decision": "duplicate", "matched_item": {{"kind": "context_index", "context_index": {index}}}}}"#
+            ),
             _ => r#"{"decision": "created"}"#.to_owned(),
         };
 
@@ -261,9 +348,9 @@ mod tests {
             .iter()
             .enumerate()
             .map(|(i, rel)| SimilarItemClassification {
-                item_id: format!("ki_{i:0>8}-0000-0000-0000-000000000000")
-                    .parse()
-                    .unwrap(),
+                item: TriageItemReference::ContextIndex {
+                    context_index: u32::try_from(i).unwrap(),
+                },
                 suggested_relation: rel.parse().unwrap(),
                 justification: "test".to_owned(),
             })
@@ -277,11 +364,7 @@ mod tests {
 
     #[test]
     fn test_reconcile_overrides_duplicate_with_contradiction() {
-        let mut c = classification_with_decisions(
-            "duplicate",
-            Some("ki_00000000-0000-0000-0000-000000000000"),
-            &["contradicts"],
-        );
+        let mut c = classification_with_decisions("duplicate", Some(0), &["contradicts"]);
         c.reconcile();
         assert!(matches!(c.outcome, TriageDecision::Novel));
     }
@@ -290,7 +373,7 @@ mod tests {
     fn test_reconcile_overrides_when_any_decision_contradicts() {
         let mut c = classification_with_decisions(
             "duplicate",
-            Some("ki_00000000-0000-0000-0000-000000000000"),
+            Some(0),
             &["supports", "unrelated", "contradicts"],
         );
         c.reconcile();
@@ -299,11 +382,7 @@ mod tests {
 
     #[test]
     fn test_reconcile_preserves_duplicate_without_contradiction() {
-        let mut c = classification_with_decisions(
-            "duplicate",
-            Some("ki_00000000-0000-0000-0000-000000000000"),
-            &["supports", "unrelated"],
-        );
+        let mut c = classification_with_decisions("duplicate", Some(0), &["supports", "unrelated"]);
         c.reconcile();
         assert!(matches!(c.outcome, TriageDecision::Duplicate { .. }));
     }

--- a/crates/tribal-worker/src/prompt/snapshots/triage/user.md
+++ b/crates/tribal-worker/src/prompt/snapshots/triage/user.md
@@ -17,21 +17,21 @@ The billing service rate limiter threshold was raised from 100 to 500 requests p
 
 ## Existing Items from Semantic Search
 
-### ki_b2c3d4e5-f6a7-8901-bcde-f01234567890 (fact, similarity: 0.89 — very high)
+### Item 0 (fact, similarity: 0.89 — very high)
 Tags: <tags-validation00>billing, api rate limiting</tags-validation00>
 
 <content-validation00>
 The billing service rate limiter uses a sliding window of 60 seconds with a threshold of 100 requests per client.
 </content-validation00>
 
-### ki_a1b2c3d4-e5f6-7890-abcd-ef0123456789 (fact, similarity: 0.54 — moderate)
+### Item 1 (fact, similarity: 0.54 — moderate)
 Tags: <tags-validation00>authentication</tags-validation00>
 
 <content-validation00>
 The authentication service caches tokens in Redis with a 15-minute TTL to reduce database load during peak hours.
 </content-validation00>
 
-### ki_c3d4e5f6-a7b8-9012-cdef-012345678901 (fact, similarity: 0.21 — low)
+### Item 2 (fact, similarity: 0.21 — low)
 Tags: <tags-validation00>ci pipeline</tags-validation00>
 
 <content-validation00>

--- a/crates/tribal-worker/src/prompt/triage.rs
+++ b/crates/tribal-worker/src/prompt/triage.rs
@@ -27,6 +27,10 @@ use crate::{
 #[derive(Debug, Clone, Serialize)]
 pub(crate) struct SimilarItemContext {
     /// The existing knowledge item identifier.
+    ///
+    /// Not serialised, so the model never sees a real identifier. The worker
+    /// keeps it only to check this list stays aligned with `search_results`.
+    #[serde(skip)]
     pub item_id: KnowledgeItemId,
     /// Classification of the existing item.
     pub kind: KnowledgeKind,
@@ -261,6 +265,25 @@ mod tests {
             request.messages[0].content.contains("high"),
             "should contain label: {}",
             request.messages[0].content,
+        );
+    }
+
+    #[test]
+    fn test_item_id_excluded_from_serialised_context() {
+        // The prompt context is built by serialising SimilarItemContext, so a
+        // real identifier must not appear in its serialised form.
+        let similar = SimilarItemContext {
+            item_id: KnowledgeItemId::new(),
+            kind: KnowledgeKind::Fact,
+            content: "existing item".to_owned(),
+            similarity_score: 0.72,
+            similarity_label: SimilarityBand::from(0.72).to_string(),
+            tags: vec![],
+        };
+        let json = serde_json::to_string(&similar).unwrap();
+        assert!(
+            !json.contains("item_id") && !json.contains("ki_"),
+            "item_id must not reach the prompt context: {json}",
         );
     }
 

--- a/crates/tribal-worker/src/prompt/triage.rs
+++ b/crates/tribal-worker/src/prompt/triage.rs
@@ -222,6 +222,37 @@ mod tests {
     }
 
     #[test]
+    fn test_triage_schema_references_items_by_index_not_identifier() {
+        let request = assemble_triage_prompt(
+            "system",
+            "{{ candidate.content }}",
+            &test_candidate(),
+            &[],
+            &[],
+            &StageParameters::default(),
+        )
+        .expect("assemble triage prompt");
+
+        // The model-facing schema references similar items by typed context
+        // index (context_index / matched_item) and exposes no real
+        // knowledge-item identifier (matched_item_id / item_id / ki_).
+        assert!(
+            matches!(
+                request.response_format,
+                Some(ResponseFormat::JsonSchema { schema }) if {
+                    let s = schema.to_string();
+                    s.contains("context_index")
+                        && s.contains("matched_item")
+                        && !s.contains("matched_item_id")
+                        && !s.contains("item_id")
+                        && !s.contains("ki_")
+                }
+            ),
+            "triage schema must reference items by context index, not identifier",
+        );
+    }
+
+    #[test]
     fn test_candidate_content_rendered_in_user_message() {
         let result = assemble_triage_prompt(
             "system",

--- a/crates/tribal-worker/src/stages/triage.rs
+++ b/crates/tribal-worker/src/stages/triage.rs
@@ -1,6 +1,6 @@
 //! Triage stage: similarity search and LLM-based relevance scoring.
 
-use std::{collections::HashMap, sync::Arc, time::Instant};
+use std::{sync::Arc, time::Instant};
 
 use tokio::sync::Semaphore;
 use tracing::Instrument;
@@ -10,8 +10,8 @@ use tribal_db::{
     PgTriageResultRepository, SemanticSearchParams, SemanticSearchResult, TriageResultRepository,
 };
 use tribal_domain::{
-    Candidate, Confidence, EmbeddingPurpose, Job, JobId, SourceType, StageParameters,
-    TagRegistryEntry, Task, span_attrs,
+    Candidate, Confidence, EmbeddingPurpose, Job, JobId, KnowledgeItemId, SourceType,
+    StageParameters, TagRegistryEntry, Task, span_attrs,
 };
 use tribal_inference::{
     EmbeddingRequest, EmbeddingResponse, InferenceProvider, ProviderKey, Usage,
@@ -22,7 +22,8 @@ use crate::{
     common::{EXPECT_BATCH_INDEX, PARSE_PREVIEW_LENGTH},
     error::{SEMAPHORE_CLOSED, STAGE_TRIAGE, StageError},
     parsing::{
-        SimilarItemClassification, TriageClassification, TriageDecision, parse_triage_response,
+        SimilarItemClassification, TriageClassification, TriageDecision, TriageItemReference,
+        parse_triage_response,
     },
     prompt::{SimilarItemContext, assemble_triage_prompt},
     tag_resolution::{self, ResolvedTags},
@@ -189,6 +190,23 @@ impl Worker {
                 .map(SimilarItemContext::from)
                 .collect();
 
+            // The model addresses similar items by position; the rendered
+            // list and the search results it resolves against must agree
+            // index-for-index. Length first, since zip would otherwise hide a
+            // divergence where one list is a prefix of the other.
+            debug_assert_eq!(
+                similar_items.len(),
+                search_results.len(),
+                "similar_items and search_results differ in length",
+            );
+            for (i, (rendered, result)) in similar_items.iter().zip(&search_results).enumerate() {
+                debug_assert_eq!(
+                    rendered.item_id,
+                    result.item.id(),
+                    "similar_items[{i}] diverged from search_results — positional alignment broken",
+                );
+            }
+
             let (mut classification, completion_response) = self
                 .classify_candidate(
                     &ctx,
@@ -202,11 +220,22 @@ impl Worker {
 
             classification.reconcile();
 
+            // Resolve the duplicate's context index to a concrete item once,
+            // before tag resolution: an out-of-range index downgrades to Novel
+            // here so the candidate still resolves its tags below and commits
+            // as a novel item, rather than panicking at commit time.
+            let resolved_outcome = resolve_triage_outcome(
+                &classification.outcome,
+                &search_results,
+                ctx.job.id(),
+                ctx.batch_index,
+            );
+
             let embedding_usage = embedding_response.usage;
             let embedding_vector = embedding_response.vector;
 
-            let (resolved_tags, tag_usages) = match &classification.outcome {
-                TriageDecision::Novel => {
+            let (resolved_tags, tag_usages) = match &resolved_outcome {
+                ResolvedTriageOutcome::Novel => {
                     let (resolved, usages) = tag_resolution::resolve_tags(
                         self.pool(),
                         ctx.candidate.suggested_tags(),
@@ -221,12 +250,13 @@ impl Worker {
                     .await?;
                     (Some(resolved), usages)
                 }
-                TriageDecision::Duplicate { .. } => (None, vec![]),
+                ResolvedTriageOutcome::Duplicate { .. } => (None, vec![]),
             };
 
             let commit = self.build_triage_commit(
                 &ctx,
-                &classification,
+                &resolved_outcome,
+                &classification.similar_item_decisions,
                 &search_results,
                 embedding_vector,
                 resolved_tags,
@@ -500,12 +530,17 @@ impl Worker {
         Ok((classification, response))
     }
 
-    /// Builds the `StageCommit::Triage` variant from the classification
-    /// result, resolved tags, and embedding vector.
+    /// Builds the `StageCommit::Triage` variant from the resolved outcome,
+    /// the per-similar-item decisions, the resolved tags, and the embedding
+    /// vector.
+    ///
+    /// The `outcome` is already resolved: a `Duplicate` bears its concrete
+    /// `KnowledgeItemId`, so no index resolution happens here.
     fn build_triage_commit(
         &self,
         ctx: &TriageContext<'_>,
-        classification: &TriageClassification,
+        outcome: &ResolvedTriageOutcome,
+        similar_item_decisions: &[SimilarItemClassification],
         search_results: &[SemanticSearchResult],
         embedding_vector: Vec<f32>,
         resolved_tags: Option<ResolvedTags>,
@@ -513,12 +548,12 @@ impl Worker {
         let similar_item_decisions = build_similar_item_decisions(
             ctx.job.id(),
             ctx.batch_index,
-            &classification.similar_item_decisions,
+            similar_item_decisions,
             search_results,
         );
 
-        let decision = match &classification.outcome {
-            TriageDecision::Novel => {
+        let decision = match outcome {
+            ResolvedTriageOutcome::Novel => {
                 let tag_data =
                     resolved_tags.expect("resolved tags required for Novel classification");
 
@@ -555,7 +590,7 @@ impl Worker {
                     resolved_tags: tag_data.resolved,
                 }
             }
-            TriageDecision::Duplicate { matched_item_id } => {
+            ResolvedTriageOutcome::Duplicate { matched_item_id } => {
                 let observation = NewItemObservation::builder()
                     .knowledge_item_id(*matched_item_id)
                     .principal_id(ctx.job.principal_id())
@@ -578,28 +613,87 @@ impl Worker {
 // Helpers
 // ---------------------------------------------------------------------------
 
-/// Builds `NewTriageSimilarItemDecision` records by joining classifications
-/// with search results to retrieve similarity scores.
+/// The triage outcome with its duplicate match resolved to a concrete
+/// knowledge item.
+///
+/// A `Duplicate` here already bears its resolved [`KnowledgeItemId`], so the
+/// id is consumed directly without re-resolving an index. A duplicate whose
+/// index matched no search result is represented as `Novel` (see
+/// [`resolve_triage_outcome`]).
+enum ResolvedTriageOutcome {
+    /// The candidate is novel — a new knowledge item will be created.
+    Novel,
+    /// The candidate duplicates an existing, already-resolved item.
+    Duplicate { matched_item_id: KnowledgeItemId },
+}
+
+/// Resolves a similar-item reference to its entry in the search results,
+/// returning `None` if the index is out of range.
+fn lookup_similar_item<'a>(
+    reference: &TriageItemReference,
+    search_results: &'a [SemanticSearchResult],
+) -> Option<&'a SemanticSearchResult> {
+    let TriageItemReference::ContextIndex { context_index } = reference;
+    search_results.get(*context_index as usize)
+}
+
+/// Resolves a parsed [`TriageDecision`] into a [`ResolvedTriageOutcome`].
+///
+/// A `Duplicate` whose context index addresses a real search result is
+/// resolved to that item's [`KnowledgeItemId`]. A `Duplicate` whose index is
+/// out of range is downgraded to `Novel` with a warning — the candidate is
+/// still ingested, just as a new item rather than an observation.
+fn resolve_triage_outcome(
+    outcome: &TriageDecision,
+    search_results: &[SemanticSearchResult],
+    job_id: JobId,
+    batch_index: u32,
+) -> ResolvedTriageOutcome {
+    match outcome {
+        TriageDecision::Novel => ResolvedTriageOutcome::Novel,
+        TriageDecision::Duplicate { matched_item } => {
+            if let Some(result) = lookup_similar_item(matched_item, search_results) {
+                ResolvedTriageOutcome::Duplicate {
+                    matched_item_id: result.item.id(),
+                }
+            } else {
+                tracing::warn!(
+                    item = ?matched_item,
+                    search_result_count = search_results.len(),
+                    %job_id,
+                    %batch_index,
+                    "downgrading duplicate to novel — matched context index out of range",
+                );
+                ResolvedTriageOutcome::Novel
+            }
+        }
+    }
+}
+
+/// Builds `NewTriageSimilarItemDecision` records by resolving each
+/// classification's context index against the positionally-aligned search
+/// results, taking the similarity score from the same entry.
+///
+/// An out-of-range index is dropped with a warning rather than failing the
+/// stage. Each index addresses a position in both the rendered similar-items
+/// list and `search_results`, an alignment guarded at the call site that
+/// builds those lists.
 fn build_similar_item_decisions(
     job_id: JobId,
     batch_index: u32,
     classifications: &[SimilarItemClassification],
     search_results: &[SemanticSearchResult],
 ) -> Vec<NewTriageSimilarItemDecision> {
-    let similarity_by_id: HashMap<_, _> = search_results
-        .iter()
-        .map(|r| (r.item.id(), r.similarity))
-        .collect();
-
     classifications
         .iter()
         .filter_map(|c| {
-            let Some(&similarity) = similarity_by_id.get(&c.item_id) else {
+            let Some(result) = lookup_similar_item(&c.item, search_results) else {
                 tracing::warn!(
-                    matched_item_id = %c.item_id,
+                    item = ?c.item,
+                    search_result_count = search_results.len(),
                     %job_id,
                     %batch_index,
-                    "dropping similar-item classification for item not in search results",
+                    "dropping similar-item classification for index not in search results",
                 );
                 return None;
             };
@@ -607,13 +701,13 @@ fn build_similar_item_decisions(
             // Similarity scores persist as REAL (f32), so narrowing here
             // matches the storage precision and loses nothing.
             #[allow(clippy::cast_possible_truncation)]
-            let similarity_score = similarity as f32;
+            let similarity_score = result.similarity as f32;
 
             Some(
                 NewTriageSimilarItemDecision::builder()
                     .job_id(job_id)
                     .batch_index(batch_index)
-                    .matched_item_id(c.item_id)
+                    .matched_item_id(result.item.id())
                     .similarity_score(similarity_score)
                     .suggested_relation(c.suggested_relation)
                     .justification_text(c.justification.clone())
@@ -642,4 +736,90 @@ fn triage_sqlx_error(context: &str, source: sqlx::Error) -> StageError {
             source,
         },
     )
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use tribal_domain::RelationSuggestion;
+    use tribal_test_utils::a_knowledge_item;
+
+    use super::*;
+
+    #[test]
+    fn test_resolve_triage_outcome_downgrades_out_of_range_duplicate() {
+        // A duplicate referencing an index with no backing search result
+        // downgrades to Novel rather than failing the stage.
+        let search_results: Vec<SemanticSearchResult> = vec![];
+        let outcome = TriageDecision::Duplicate {
+            matched_item: TriageItemReference::ContextIndex { context_index: 0 },
+        };
+        let resolved = resolve_triage_outcome(&outcome, &search_results, JobId::new(), 0);
+        assert!(matches!(resolved, ResolvedTriageOutcome::Novel));
+    }
+
+    #[test]
+    fn test_resolve_triage_outcome_passes_novel_through() {
+        let search_results: Vec<SemanticSearchResult> = vec![];
+        let resolved =
+            resolve_triage_outcome(&TriageDecision::Novel, &search_results, JobId::new(), 0);
+        assert!(matches!(resolved, ResolvedTriageOutcome::Novel));
+    }
+
+    #[test]
+    fn test_build_similar_item_decisions_resolves_by_index_and_drops_out_of_range() {
+        // Indices deliberately diverge from classification order, and one is
+        // out of range. This fails for any implementation that maps by
+        // position rather than by the context index value.
+        let item_a = a_knowledge_item().build();
+        let item_b = a_knowledge_item().build();
+        let item_c = a_knowledge_item().build();
+        let id_a = item_a.id();
+        let id_c = item_c.id();
+        let search_results = vec![
+            SemanticSearchResult {
+                item: item_a,
+                similarity: 0.5,
+            },
+            SemanticSearchResult {
+                item: item_b,
+                similarity: 0.25,
+            },
+            SemanticSearchResult {
+                item: item_c,
+                similarity: 0.75,
+            },
+        ];
+
+        let classifications = vec![
+            SimilarItemClassification {
+                item: TriageItemReference::ContextIndex { context_index: 2 },
+                suggested_relation: RelationSuggestion::Supports,
+                justification: "resolves to item_c".to_owned(),
+            },
+            SimilarItemClassification {
+                item: TriageItemReference::ContextIndex { context_index: 99 },
+                suggested_relation: RelationSuggestion::Contradicts,
+                justification: "out of range — dropped".to_owned(),
+            },
+            SimilarItemClassification {
+                item: TriageItemReference::ContextIndex { context_index: 0 },
+                suggested_relation: RelationSuggestion::Unrelated,
+                justification: "resolves to item_a".to_owned(),
+            },
+        ];
+
+        let rows = build_similar_item_decisions(JobId::new(), 0, &classifications, &search_results);
+
+        // Out-of-range dropped; survivors keep classification order and each
+        // resolves by index value to the right item and that entry's similarity.
+        assert_eq!(rows.len(), 2);
+        assert_eq!(rows[0].matched_item_id, id_c);
+        assert!((rows[0].similarity_score - 0.75).abs() < f32::EPSILON);
+        assert_eq!(rows[1].matched_item_id, id_a);
+        assert!((rows[1].similarity_score - 0.5).abs() < f32::EPSILON);
+    }
 }

--- a/crates/tribal-worker/src/stages/triage.rs
+++ b/crates/tribal-worker/src/stages/triage.rs
@@ -770,6 +770,33 @@ mod tests {
     }
 
     #[test]
+    fn test_resolve_triage_outcome_resolves_in_range_duplicate() {
+        // A duplicate referencing an in-range, non-zero index resolves to that
+        // entry's item id.
+        let item_a = a_knowledge_item().build();
+        let item_b = a_knowledge_item().build();
+        let id_b = item_b.id();
+        let search_results = vec![
+            SemanticSearchResult {
+                item: item_a,
+                similarity: 0.9,
+            },
+            SemanticSearchResult {
+                item: item_b,
+                similarity: 0.5,
+            },
+        ];
+        let outcome = TriageDecision::Duplicate {
+            matched_item: TriageItemReference::ContextIndex { context_index: 1 },
+        };
+        let resolved = resolve_triage_outcome(&outcome, &search_results, JobId::new(), 0);
+        assert!(matches!(
+            resolved,
+            ResolvedTriageOutcome::Duplicate { matched_item_id } if matched_item_id == id_b
+        ));
+    }
+
+    #[test]
     fn test_build_similar_item_decisions_resolves_by_index_and_drops_out_of_range() {
         // Indices deliberately diverge from classification order, and one is
         // out of range. This fails for any implementation that maps by

--- a/crates/tribal-worker/tests/worker/common.rs
+++ b/crates/tribal-worker/tests/worker/common.rs
@@ -16,9 +16,9 @@ pub(super) use tribal_db::{
     TagRegistryRepository, TaskRepository, TokenUsageRepository, TriageResultRepository,
 };
 pub(super) use tribal_domain::{
-    EmbeddingPurpose, JobOutcome, JobStatus, KnowledgeItemId, KnowledgeKind, PipelineStage,
-    PrincipalId, ProjectId, PromptVersionId, RelationBatchId, SourceType, TaskErrorKind,
-    TaskStatus, TaskType, TriageOutcome,
+    EmbeddingPurpose, JobOutcome, JobStatus, KnowledgeKind, PipelineStage, PrincipalId, ProjectId,
+    PromptVersionId, RelationBatchId, SourceType, TaskErrorKind, TaskStatus, TaskType,
+    TriageOutcome,
 };
 pub(super) use tribal_inference::{
     EmbeddingProvider, InferenceProvider, ProviderKey, ProviderLimits, ProviderRegistry,

--- a/crates/tribal-worker/tests/worker/fixtures.rs
+++ b/crates/tribal-worker/tests/worker/fixtures.rs
@@ -1,7 +1,5 @@
 //! Response JSON fixtures shared across worker integration tests.
 
-use super::common::*;
-
 /// Builds an extraction-output JSON string from candidates and hints.
 pub(super) fn extraction_response_json(
     candidates: &[tribal_domain::Candidate],
@@ -23,13 +21,13 @@ pub(super) fn triage_novel_response_json() -> String {
     .to_string()
 }
 
-/// Builds a triage Duplicate response JSON string for the given
-/// matched item.
-pub(super) fn triage_duplicate_response_json(matched_item_id: KnowledgeItemId) -> String {
+/// Builds a triage Duplicate response JSON string referencing the similar
+/// item at the given zero-based context index.
+pub(super) fn triage_duplicate_response_json(matched_index: u32) -> String {
     serde_json::json!({
         "outcome": {
             "decision": "duplicate",
-            "matched_item_id": matched_item_id.to_string(),
+            "matched_item": { "kind": "context_index", "context_index": matched_index },
         },
         "similar_item_decisions": [],
     })

--- a/crates/tribal-worker/tests/worker/token_usage.rs
+++ b/crates/tribal-worker/tests/worker/token_usage.rs
@@ -453,7 +453,8 @@ async fn test_triage_duplicate_records_token_usage() {
     let inference: Arc<dyn InferenceProvider> = Arc::new(
         MockInferenceProvider::builder()
             .on_complete(
-                a_completion_response(triage_duplicate_response_json(ki_id)),
+                // The seeded item is the sole search hit, so it is at index 0.
+                a_completion_response(triage_duplicate_response_json(0)),
                 None,
             )
             .on_exhaust(ExhaustBehaviour::RepeatLast)

--- a/crates/tribal-worker/tests/worker/triage.rs
+++ b/crates/tribal-worker/tests/worker/triage.rs
@@ -217,7 +217,8 @@ async fn test_triage_duplicate_path() {
     let inference: Arc<dyn InferenceProvider> = Arc::new(
         MockInferenceProvider::builder()
             .on_complete(
-                a_completion_response(triage_duplicate_response_json(ki_id)),
+                // The seeded item is the sole search hit, so it is at index 0.
+                a_completion_response(triage_duplicate_response_json(0)),
                 None,
             )
             .on_exhaust(ExhaustBehaviour::RepeatLast)
@@ -266,6 +267,143 @@ async fn test_triage_duplicate_path() {
         .await
         .expect("find observations");
     assert_eq!(observations.len(), 1, "should have one observation");
+
+    teardown(ctx).await;
+}
+
+/// Verifies the downgrade path end-to-end: a duplicate whose matched index
+/// is out of range commits as a novel item with its tags resolved — no panic,
+/// parse failure, dead-letter, or observation against the seeded item. Locks
+/// the resolve-before-tag-resolution ordering in `run_triage`.
+#[tokio::test]
+async fn test_triage_duplicate_out_of_range_downgrades_to_novel() {
+    let _guard = serial_lock().await;
+    let ctx = test_context().await;
+    let pool = ctx.create_pool().await.expect("create pool");
+
+    // Seed an existing item so semantic search returns one hit at index 0;
+    // the model references an out-of-range index instead.
+    let mut conn = raw_conn(ctx).await;
+    let seed_result = Seed::new()
+        .define_project("proj", "git@github.com:test/triage-downgrade.git")
+        .define_principal("user", "user:triage-downgrade")
+        .define_prompt_version("system-pv", a_new_prompt_version().build())
+        .define_prompt_version(
+            "user-pv",
+            a_new_prompt_version()
+                .role(tribal_domain::PromptRole::User)
+                .content_hash("c".repeat(64))
+                .content("test user prompt content".to_owned())
+                .build(),
+        )
+        .set_embedding_model("mock-model", 768)
+        .as_principal("user")
+        .for_project("proj", |store| {
+            store.add_item("existing", item(KnowledgeKind::Fact, "existing knowledge"));
+        })
+        .execute(&mut conn)
+        .await;
+
+    let principal_id = seed_result.principal_id("user");
+    let project_id = seed_result.project_id("proj");
+    let existing_id = seed_result.item_id("existing");
+    let system_pv_id = seed_result.prompt_version_id("system-pv");
+    let user_pv_id = seed_result.prompt_version_id("user-pv");
+
+    let seeded_embedding = PgEmbeddingRepository
+        .find_by_knowledge_item_id(&mut conn, existing_id, "mock-model")
+        .await
+        .expect("find seeded embedding")
+        .expect("seeded embedding should exist");
+    let embedding_vector = seeded_embedding.embedding().to_vec();
+
+    let candidates = vec![
+        a_candidate()
+            .content("novel content after downgrade".to_owned())
+            .suggested_tags(vec!["rust".to_owned()])
+            .build(),
+    ];
+
+    let (job_id, task_id) = seed_triage_job(
+        &mut conn,
+        principal_id,
+        project_id,
+        system_pv_id,
+        user_pv_id,
+        &candidates,
+    )
+    .await;
+    drop(conn);
+
+    let embedding: Arc<dyn EmbeddingProvider> = Arc::new(
+        MockEmbeddingProvider::builder()
+            .on_embed(an_embedding_response(embedding_vector), None)
+            .on_exhaust(ExhaustBehaviour::RepeatLast)
+            .build(),
+    );
+
+    let inference: Arc<dyn InferenceProvider> = Arc::new(
+        MockInferenceProvider::builder()
+            .on_complete(
+                // Index 99 is out of range — only the seeded item (index 0)
+                // was retrieved — so the duplicate downgrades to novel.
+                a_completion_response(triage_duplicate_response_json(99)),
+                None,
+            )
+            .on_exhaust(ExhaustBehaviour::RepeatLast)
+            .build(),
+    );
+
+    let token = CancellationToken::new();
+    let worker = build_test_worker(
+        pool.clone(),
+        token.clone(),
+        test_config(),
+        Some(inference),
+        Some(embedding),
+    );
+    let handle = {
+        let w = Arc::clone(&worker);
+        tokio::spawn(async move { w.run().await })
+    };
+
+    let task = poll_task_status(&pool, task_id, TaskStatus::Completed, POLL_SETTLE).await;
+    token.cancel();
+    let _ = handle.await;
+
+    // The task completes — no parse failure, dead-letter, or panic. Because
+    // the candidate carries suggested tags, completing proves the downgraded
+    // candidate ran the novel commit path (resolving tags) without hitting
+    // the `resolved_tags` panic.
+    assert_eq!(task.status(), TaskStatus::Completed);
+
+    let mut conn = raw_conn(ctx).await;
+    let triage_result = PgTriageResultRepository
+        .find_by_job_id_and_batch_index(&mut conn, job_id, SEED_TRIAGE_BATCH_INDEX)
+        .await
+        .expect("find triage result")
+        .expect("triage result should exist");
+
+    // The outcome is Created against a new item, not the seeded one — the
+    // duplicate downgraded rather than recording an observation.
+    assert!(
+        matches!(
+            triage_result.outcome(),
+            TriageOutcome::Created { item_id } if *item_id != existing_id
+        ),
+        "expected Created with a new item, got {:?}",
+        triage_result.outcome(),
+    );
+
+    // No observation was recorded against the seeded item.
+    let observations = PgItemObservationRepository
+        .find_by_knowledge_item_id(&mut conn, existing_id)
+        .await
+        .expect("find observations");
+    assert!(
+        observations.is_empty(),
+        "downgrade must not observe the seeded item",
+    );
 
     teardown(ctx).await;
 }

--- a/prompts/triage/user.tera
+++ b/prompts/triage/user.tera
@@ -19,7 +19,7 @@ Tags: <item-tags-{{ nonce }}>{% for tag in candidate.suggested_tags %}{{ tag }}{
 ## Existing Items from Semantic Search
 {%- for item in similar_items %}
 
-### {{ item.item_id }} ({{ item.kind }}, similarity: {{ item.similarity_score | round(precision=4) }} — {{ item.similarity_label }})
+### Item {{ loop.index0 }} ({{ item.kind }}, similarity: {{ item.similarity_score | round(precision=4) }} — {{ item.similarity_label }})
 Tags: <tags-{{ nonce }}>{% for tag in item.tags %}{{ tag }}{% if not loop.last %}, {% endif %}{% endfor %}</tags-{{ nonce }}>
 
 <content-{{ nonce }}>


### PR DESCRIPTION
## Summary

Replaces the real `KnowledgeItemId` UUIDs in the triage inference call with typed zero-based context indices, mirroring the relation stage. Weaker models could not reliably echo a `ki_<uuid>` and returned placeholders that failed `KnowledgeItemId` parsing, dead-lettering whole triage batches. The model now references similar items only by index, and the worker owns the index→ID mapping.

- New triage-local `TriageItemReference` (`{"kind":"context_index","context_index":N}`) replaces the `KnowledgeItemId` fields on the duplicate match and each per-similar-item assessment; the schema carries no identifier-typed field.
- The triage user prompt renders similar items by zero-based index; the regenerated snapshot carries no `ki_` heading.
- The worker resolves each index against `search_results` before commit, via a shared `lookup_similar_item` helper. An out-of-range duplicate match downgrades to `Novel` (resolving tags, committing as a novel item); an out-of-range per-item assessment is dropped with a warning. Neither is a parse failure or panic.
- The prompt context DTO no longer serialises the item identifier, so a real id cannot reach the model-facing prompt.
- A `debug_assert_eq!` guards that the rendered similar-items list and `search_results` stay positionally aligned.
- No database change: resolved `KnowledgeItemId`s are persisted as before.

Closes tribal-memory/cortex#33.

## Test plan

- [x] `cargo +nightly fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo test -p tribal-worker` — parse/prompt/stage unit tests + worker integration (incl. out-of-range duplicate downgrade and per-item drop)
- [x] `cargo test -p tribal-e2e` — full suite (duplicate_batch, cross_batch_relations, transports)
- [ ] Manual/eval (not CI): a weaker cloud model completes triage on a candidate with similar items, including one it judges a duplicate, without a parse failure