### PR TITLE
[CHORE] Cut 0.2.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ## [Unreleased]
 
+## [0.2.3] - 2026-05-27
+
+### Fixed
+
+- Triage now references similar items by position index rather than by their identifier, resolving them server-side. This removes a failure mode in which weaker models that could not reproduce a knowledge-item identifier failed triage and exhausted retries. An unresolvable reference is handled gracefully: an out-of-range duplicate match is treated as a novel item rather than failing the job.
+
 ## [0.2.2] - 2026-05-26
 
 ### Added
@@ -30,6 +36,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 - Docker Compose provider configuration through `.env`, letting the containerised path target a cloud provider (OpenAI, Anthropic) instead of only a local Ollama.
 
-[Unreleased]: https://github.com/tribal-memory/tribal/compare/v0.2.2...HEAD
+[Unreleased]: https://github.com/tribal-memory/tribal/compare/v0.2.3...HEAD
+[0.2.3]: https://github.com/tribal-memory/tribal/compare/v0.2.2...v0.2.3
 [0.2.2]: https://github.com/tribal-memory/tribal/compare/v0.2.1...v0.2.2
 [0.2.1]: https://github.com/tribal-memory/tribal/releases/tag/v0.2.1

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5105,7 +5105,7 @@ dependencies = [
 
 [[package]]
 name = "tribal"
-version = "0.2.2"
+version = "0.2.3"
 dependencies = [
  "anstream 1.0.0",
  "axum",
@@ -5155,7 +5155,7 @@ dependencies = [
 
 [[package]]
 name = "tribal-common"
-version = "0.2.2"
+version = "0.2.3"
 dependencies = [
  "dashmap",
  "rand 0.10.1",
@@ -5166,7 +5166,7 @@ dependencies = [
 
 [[package]]
 name = "tribal-config"
-version = "0.2.2"
+version = "0.2.3"
 dependencies = [
  "dirs",
  "figment",
@@ -5181,7 +5181,7 @@ dependencies = [
 
 [[package]]
 name = "tribal-db"
-version = "0.2.2"
+version = "0.2.3"
 dependencies = [
  "async-trait",
  "chrono",
@@ -5200,7 +5200,7 @@ dependencies = [
 
 [[package]]
 name = "tribal-domain"
-version = "0.2.2"
+version = "0.2.3"
 dependencies = [
  "chrono",
  "schemars 0.8.22",
@@ -5214,7 +5214,7 @@ dependencies = [
 
 [[package]]
 name = "tribal-e2e"
-version = "0.2.2"
+version = "0.2.3"
 dependencies = [
  "chrono",
  "dashmap",
@@ -5240,7 +5240,7 @@ dependencies = [
 
 [[package]]
 name = "tribal-inference"
-version = "0.2.2"
+version = "0.2.3"
 dependencies = [
  "async-trait",
  "reqwest 0.13.2",
@@ -5256,7 +5256,7 @@ dependencies = [
 
 [[package]]
 name = "tribal-mcp"
-version = "0.2.2"
+version = "0.2.3"
 dependencies = [
  "axum",
  "chrono",
@@ -5289,7 +5289,7 @@ dependencies = [
 
 [[package]]
 name = "tribal-telemetry"
-version = "0.2.2"
+version = "0.2.3"
 dependencies = [
  "opentelemetry",
  "opentelemetry-otlp",
@@ -5310,7 +5310,7 @@ dependencies = [
 
 [[package]]
 name = "tribal-test-utils"
-version = "0.2.2"
+version = "0.2.3"
 dependencies = [
  "anstream 1.0.0",
  "async-trait",
@@ -5334,7 +5334,7 @@ dependencies = [
 
 [[package]]
 name = "tribal-ui"
-version = "0.2.2"
+version = "0.2.3"
 dependencies = [
  "anstream 1.0.0",
  "anstyle",
@@ -5349,7 +5349,7 @@ dependencies = [
 
 [[package]]
 name = "tribal-worker"
-version = "0.2.2"
+version = "0.2.3"
 dependencies = [
  "chrono",
  "dashmap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ members = [
 
 [workspace.package]
 edition = "2024"
-version = "0.2.2"
+version = "0.2.3"
 license = "Elastic-2.0"
 rust-version = "1.93"
 publish = false

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -19,7 +19,7 @@ services:
         max-file: "3"
 
   tribal:
-    image: ghcr.io/tribal-memory/tribal:0.2.2
+    image: ghcr.io/tribal-memory/tribal:0.2.3
     depends_on:
       postgres:
         condition: service_healthy


### PR DESCRIPTION
## Summary

Cuts **0.2.3**, carrying the triage index-based targeting change (#170).

- `CHANGELOG.md`: `0.2.3` entry (the triage fix) plus updated compare links.
- Workspace version `0.2.2` -> `0.2.3` (`Cargo.toml` + `Cargo.lock`, 12 crates, no dependency churn).
- `docker-compose.yml` pinned image tag bumped to `0.2.3` to match the release.

## Release sequence (after merge)

Merge, then tag that commit `v0.2.3` and push the tag. `release.yml` publishes the binaries / installer / Homebrew formula with the `0.2.3` changelog section as the release body; `docker.yml` validates the tag matches the workspace version and publishes `ghcr.io/tribal-memory/tribal:0.2.3`. This is the release the skills install from, so it unblocks verifying tribal-memory/cortex#33 end-to-end with a reasoning model.