### PR TITLE
[REFACTOR] Transform response schemas into per-provider dialects and enforce strict structured output

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,20 @@
 version = 4
 
 [[package]]
+name = "ahash"
+version = "0.8.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a15f179cd60c4584b8a8c596927aadc462e27f2ca70c04e0071964a73ba7a75"
+dependencies = [
+ "cfg-if",
+ "getrandom 0.3.4",
+ "once_cell",
+ "serde",
+ "version_check",
+ "zerocopy",
+]
+
+[[package]]
 name = "aho-corasick"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -297,6 +311,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2af50177e190e07a26ab74f8b1efbfe2ef87da2116221318cb1c2e82baf7de06"
 
 [[package]]
+name = "bit-set"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08807e080ed7f9d5433fa9b275196cfc35414f66a0c79d864dc51a0d825231a3"
+dependencies = [
+ "bit-vec",
+]
+
+[[package]]
+name = "bit-vec"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e764a1d40d510daf35e07be9eb06e75770908c27d411ee6c92109c9840eaaf7"
+
+[[package]]
 name = "bitflags"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -395,6 +424,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "borrow-or-share"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc0b364ead1874514c8c2855ab558056ebfeb775653e7ae45ff72f28f8f3166c"
+
+[[package]]
 name = "bstr"
 version = "1.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -410,6 +445,12 @@ name = "bumpalo"
 version = "3.19.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5dd9dc738b7a8311c7ade152424974d8115f2cdad61e8dab8dac9f2362298510"
+
+[[package]]
+name = "bytecount"
+version = "0.6.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "175812e0be2bccb6abe50bb8d566126198344f707e304f45c648fd8f2cc0365e"
 
 [[package]]
 name = "bytemuck"
@@ -836,6 +877,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "data-encoding"
+version = "2.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4ae5f15dda3c708c0ade84bfee31ccab44a3da4f88015ed22f63732abe300c8"
+
+[[package]]
 name = "deadpool"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -969,6 +1016,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "email_address"
+version = "0.2.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e079f19b08ca6239f47f8ba8509c11cf3ea30095831f7fed61441475edd8c449"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "equivalent"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -981,7 +1037,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1014,6 +1070,17 @@ dependencies = [
  "concurrent-queue",
  "parking",
  "pin-project-lite",
+]
+
+[[package]]
+name = "fancy-regex"
+version = "0.18.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1e1dacd0d2082dfcf1351c4bdd566bbe89a2b263235a2b50058f1e130a47277"
+dependencies = [
+ "bit-set",
+ "regex-automata",
+ "regex-syntax",
 ]
 
 [[package]]
@@ -1077,6 +1144,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
 
 [[package]]
+name = "fluent-uri"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc74ac4d8359ae70623506d512209619e5cf8f347124910440dbc221714b328e"
+dependencies = [
+ "borrow-or-share",
+ "ref-cast",
+ "serde",
+]
+
+[[package]]
 name = "flume"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1112,6 +1190,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cb4cb245038516f5f85277875cdaa4f7d2c9a0fa0468de06ed190163b1581fcf"
 dependencies = [
  "percent-encoding",
+]
+
+[[package]]
+name = "fraction"
+version = "0.15.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e076045bb43dac435333ed5f04caf35c7463631d0dae2deb2638d94dd0a5b872"
+dependencies = [
+ "lazy_static",
+ "num",
 ]
 
 [[package]]
@@ -2406,7 +2494,7 @@ dependencies = [
  "portable-atomic",
  "portable-atomic-util",
  "serde_core",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2475,6 +2563,35 @@ checksum = "8c942ebf8e95485ca0d52d97da7c5a2c387d0e7f0ba4c35e93bfcaee045955b3"
 dependencies = [
  "once_cell",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "jsonschema"
+version = "0.46.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a5fe5206f06e589caf25e79fc05ccdf91fca745685fe9fe1a13bbdfb479a631"
+dependencies = [
+ "ahash",
+ "bytecount",
+ "data-encoding",
+ "email_address",
+ "fancy-regex",
+ "fraction",
+ "getrandom 0.3.4",
+ "idna",
+ "itoa",
+ "num-cmp",
+ "num-traits",
+ "percent-encoding",
+ "referencing",
+ "regex",
+ "regex-syntax",
+ "reqwest 0.13.2",
+ "rustls",
+ "serde",
+ "serde_json",
+ "unicode-general-category",
+ "uuid-simd",
 ]
 
 [[package]]
@@ -2636,6 +2753,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "micromap"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2a86d3146ed3995b5913c414f6664344b9617457320782e64f0bb44afd49d74"
+
+[[package]]
 name = "mime"
 version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2772,6 +2895,12 @@ dependencies = [
  "smallvec",
  "zeroize",
 ]
+
+[[package]]
+name = "num-cmp"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63335b2e2c34fae2fb0aa2cecfd9f0832a1e24b3b32ecec612c3426d46dc8aaa"
 
 [[package]]
 name = "num-complex"
@@ -2957,6 +3086,12 @@ name = "option-ext"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
+
+[[package]]
+name = "outref"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a80800c0488c3a21695ea981a54918fbb37abf04f4d0720c453632255e2ff0e"
 
 [[package]]
 name = "parking"
@@ -3426,7 +3561,7 @@ dependencies = [
  "once_cell",
  "socket2",
  "tracing",
- "windows-sys 0.52.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -3579,6 +3714,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "referencing"
+version = "0.46.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69e4e17ef386c5383591d07623d3de49cbc601156e7582973e6db98d66a57de2"
+dependencies = [
+ "ahash",
+ "fluent-uri",
+ "getrandom 0.3.4",
+ "hashbrown 0.16.1",
+ "itoa",
+ "micromap",
+ "parking_lot",
+ "percent-encoding",
+ "serde_json",
+]
+
+[[package]]
 name = "regex"
 version = "1.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3649,7 +3801,10 @@ checksum = "ab3f43e3283ab1488b624b44b0e988d0acea0b3214e694730a055cb6b2efa801"
 dependencies = [
  "base64 0.22.1",
  "bytes",
+ "futures-channel",
  "futures-core",
+ "futures-util",
+ "h2",
  "http",
  "http-body",
  "http-body-util",
@@ -3785,7 +3940,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.11.0",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3844,7 +3999,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4645,7 +4800,7 @@ dependencies = [
  "getrandom 0.4.1",
  "once_cell",
  "rustix 1.1.3",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5353,6 +5508,7 @@ version = "0.2.3"
 dependencies = [
  "chrono",
  "dashmap",
+ "jsonschema",
  "schemars 0.8.22",
  "serde",
  "serde_json",
@@ -5437,6 +5593,12 @@ name = "unicode-bom"
 version = "2.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7eec5d1121208364f6793f7d2e222bf75a915c19557537745b195b253dd64217"
+
+[[package]]
+name = "unicode-general-category"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b993bddc193ae5bd0d623b49ec06ac3e9312875fdae725a975c51db1cc1677f"
 
 [[package]]
 name = "unicode-ident"
@@ -5566,6 +5728,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "uuid-simd"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23b082222b4f6619906941c17eb2297fff4c2fb96cb60164170522942a200bd8"
+dependencies = [
+ "outref",
+ "vsimd",
+]
+
+[[package]]
 name = "valuable"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5582,6 +5754,12 @@ name = "version_check"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
+
+[[package]]
+name = "vsimd"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c3082ca00d5a5ef149bb8b555a72ae84c9c59f7250f013ac822ac2e49b19c64"
 
 [[package]]
 name = "walkdir"
@@ -5804,7 +5982,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -100,6 +100,9 @@ tera = "1"
 # JSON Schema generation
 schemars = { version = "0.8", features = ["uuid1"] }
 
+# JSON Schema validation
+jsonschema = "0.46"
+
 # MCP server
 rmcp = { version = "1", features = ["macros", "server", "client", "transport-io", "transport-async-rw", "transport-streamable-http-server"] }
 

--- a/crates/tribal-inference/src/anthropic/inference.rs
+++ b/crates/tribal-inference/src/anthropic/inference.rs
@@ -13,7 +13,7 @@ use tribal_domain::{ProviderKind, span_attrs};
 
 use crate::{
     CompletionRequest, CompletionResponse, CompletionUsage, InferenceError, InferenceProvider,
-    Message, ProviderIdentity, ResponseFormat, Role,
+    Message, ProviderIdentity, ResponseFormat, Role, apply_dialect,
     capabilities::{reconcile_temperature, resolve},
     error::{map_body_read_error, map_http_error, map_json_parse_error, map_send_error},
     http::{INFERENCE_PROBE_INPUT, PROBE_MAX_TOKENS, normalise_base_url, record_completion_usage},
@@ -329,7 +329,7 @@ fn map_response_format(format: &ResponseFormat) -> Option<AnthropicOutputConfig>
         }
         ResponseFormat::JsonSchema { schema } => Some(AnthropicOutputConfig {
             format: AnthropicOutputFormat::JsonSchema {
-                schema: schema.clone(),
+                schema: apply_dialect(ProviderKind::Anthropic, schema.clone()),
             },
         }),
     }
@@ -697,8 +697,19 @@ mod tests {
     #[tokio::test]
     async fn test_chat_sends_output_config_for_json_schema() {
         let server = MockServer::start().await;
-        let schema =
-            serde_json::json!({"type": "object", "properties": {"name": {"type": "string"}}});
+        let schema = serde_json::json!({
+            "type": "object",
+            "properties": {"name": {"type": "string"}},
+            "required": ["name"],
+        });
+        // The subset dialect closes objects (`additionalProperties: false`) but
+        // leaves optionals omitted from `required` and sends no strict flag.
+        let expected_schema = serde_json::json!({
+            "type": "object",
+            "properties": {"name": {"type": "string"}},
+            "required": ["name"],
+            "additionalProperties": false,
+        });
 
         Mock::given(method("POST"))
             .and(path(MESSAGES_PATH))
@@ -709,7 +720,7 @@ mod tests {
                 "output_config": {
                     "format": {
                         "type": "json_schema",
-                        "schema": schema.clone(),
+                        "schema": expected_schema,
                     },
                 },
             })))

--- a/crates/tribal-inference/src/capabilities.rs
+++ b/crates/tribal-inference/src/capabilities.rs
@@ -1,12 +1,17 @@
 //! Per-model request-field admissibility for inference providers.
 //!
 //! [`resolve`] maps a `(ProviderKind, model)` target to the
-//! [`ModelCapabilities`] describing how the endpoint handles two request
+//! [`ModelCapabilities`] describing how the endpoint handles three request
 //! axes that vary by model: whether it honours caller-supplied sampling
-//! parameters, and which field carries the maximum-output-token cap. It is
-//! the single source of capability truth — every site that shapes a request
-//! for the wire or records its effective shape reads this one resolver, so
-//! they agree by construction (ingest and the readiness probe included).
+//! parameters, which field carries the maximum-output-token cap, and how it
+//! enforces a caller-supplied JSON Schema on its output. It is the single
+//! source of capability truth — every site that shapes a request for the wire
+//! or records its effective shape reads this one resolver, so they agree by
+//! construction (ingest and the readiness probe included).
+//!
+//! The schema-dialect transform that rewrites a schema into a provider's
+//! accepted shape is a separate mechanism, keyed on the transport rather than
+//! the model class, and is not represented here.
 //!
 //! The layer governs only what varies by model class. Provider-protocol-fixed
 //! shaping (a provider's always-required or fixed-name fields) stays in each
@@ -108,6 +113,29 @@ pub enum MaxOutputTokensParam {
     MaxCompletionTokens,
 }
 
+/// How a target enforces a caller-supplied JSON Schema on its output.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum StructuredOutputMode {
+    /// Decoding is constrained to the schema; the request marks it `strict`.
+    Strict,
+    /// The schema is advisory guidance; the request does not mark it `strict`.
+    Advisory,
+}
+
+impl StructuredOutputMode {
+    /// Whether a schema sent to this target must be marked `strict`.
+    ///
+    /// The single source for the mode→strict mapping, so every site that
+    /// applies it agrees without re-deriving it.
+    #[must_use]
+    pub fn requires_strict(self) -> bool {
+        match self {
+            Self::Strict => true,
+            Self::Advisory => false,
+        }
+    }
+}
+
 // ---------------------------------------------------------------------------
 // ModelCapabilities
 // ---------------------------------------------------------------------------
@@ -123,14 +151,19 @@ pub struct ModelCapabilities {
 
     /// Which field name carries the output-token cap.
     pub max_output_tokens_param: MaxOutputTokensParam,
+
+    /// How the target enforces a caller-supplied JSON Schema on its output.
+    pub structured_output_mode: StructuredOutputMode,
 }
 
 impl ModelCapabilities {
     /// The default-send posture for an unrecognised target: honour caller
-    /// sampling parameters and use the conventional `max_tokens` field name.
+    /// sampling parameters, use the conventional `max_tokens` field name, and
+    /// request strict schema enforcement.
     pub const SEND_ALL: Self = Self {
         sampling: SamplingControl::Configurable,
         max_output_tokens_param: MaxOutputTokensParam::MaxTokens,
+        structured_output_mode: StructuredOutputMode::Strict,
     };
 
     /// Reasoning models served over the Chat Completions API: adaptive
@@ -138,6 +171,7 @@ impl ModelCapabilities {
     const OPENAI_REASONING: Self = Self {
         sampling: SamplingControl::Adaptive,
         max_output_tokens_param: MaxOutputTokensParam::MaxCompletionTokens,
+        structured_output_mode: StructuredOutputMode::Strict,
     };
 
     /// Adaptive-sampling models that retain the conventional `max_tokens`
@@ -145,6 +179,7 @@ impl ModelCapabilities {
     const ANTHROPIC_ADAPTIVE: Self = Self {
         sampling: SamplingControl::Adaptive,
         max_output_tokens_param: MaxOutputTokensParam::MaxTokens,
+        structured_output_mode: StructuredOutputMode::Strict,
     };
 }
 
@@ -227,6 +262,11 @@ mod tests {
                 MaxOutputTokensParam::MaxCompletionTokens,
                 "{model} should use max_completion_tokens",
             );
+            assert_eq!(
+                caps.structured_output_mode,
+                StructuredOutputMode::Strict,
+                "{model} should request strict schema enforcement",
+            );
         }
     }
 
@@ -234,6 +274,18 @@ mod tests {
     fn test_ordinary_openai_model_sends_all() {
         let caps = resolve(ProviderKind::OpenAi, "gpt-4o-mini");
         assert_eq!(caps, ModelCapabilities::SEND_ALL);
+    }
+
+    #[test]
+    fn test_unrecognised_openai_target_requests_strict() {
+        // An unrecognised OpenAI target resolves strict-by-default: a 400 from a
+        // surface that cannot honour it surfaces at the probe, which is
+        // preferable to silent advisory drift.
+        assert!(
+            resolve(ProviderKind::OpenAi, "gpt-4o-mini")
+                .structured_output_mode
+                .requires_strict()
+        );
     }
 
     #[test]
@@ -299,6 +351,12 @@ mod tests {
     fn test_sampling_control_accepts_overrides() {
         assert!(SamplingControl::Configurable.accepts_overrides());
         assert!(!SamplingControl::Adaptive.accepts_overrides());
+    }
+
+    #[test]
+    fn test_structured_output_mode_requires_strict() {
+        assert!(StructuredOutputMode::Strict.requires_strict());
+        assert!(!StructuredOutputMode::Advisory.requires_strict());
     }
 
     #[test]

--- a/crates/tribal-inference/src/lib.rs
+++ b/crates/tribal-inference/src/lib.rs
@@ -13,13 +13,16 @@ mod provider;
 mod registry;
 mod request;
 mod response;
+mod schema_dialect;
 mod usage;
 mod validation;
 
 pub use anthropic::AnthropicInferenceProvider;
 #[cfg(feature = "test-helpers")]
 pub use anthropic::MESSAGES_PATH as ANTHROPIC_MESSAGES_PATH;
-pub use capabilities::{MaxOutputTokensParam, ModelCapabilities, SamplingControl, resolve};
+pub use capabilities::{
+    MaxOutputTokensParam, ModelCapabilities, SamplingControl, StructuredOutputMode, resolve,
+};
 pub use error::InferenceError;
 #[cfg(feature = "test-helpers")]
 pub use http::{EMBEDDING_PROBE_INPUT, INFERENCE_PROBE_INPUT};
@@ -37,4 +40,5 @@ pub use registry::{
 };
 pub use request::{CompletionRequest, EmbeddingRequest, Message, ResponseFormat, Role};
 pub use response::{CompletionResponse, EmbeddingResponse};
+pub use schema_dialect::apply_dialect;
 pub use usage::{CompletionUsage, EmbeddingUsage, Usage};

--- a/crates/tribal-inference/src/lib.rs
+++ b/crates/tribal-inference/src/lib.rs
@@ -41,4 +41,6 @@ pub use registry::{
 pub use request::{CompletionRequest, EmbeddingRequest, Message, ResponseFormat, Role};
 pub use response::{CompletionResponse, EmbeddingResponse};
 pub use schema_dialect::apply_dialect;
+#[cfg(feature = "test-helpers")]
+pub use schema_dialect::assert_dialect_invariants;
 pub use usage::{CompletionUsage, EmbeddingUsage, Usage};

--- a/crates/tribal-inference/src/ollama/inference.rs
+++ b/crates/tribal-inference/src/ollama/inference.rs
@@ -8,11 +8,11 @@ use std::time::Instant;
 
 use async_trait::async_trait;
 use tracing::Instrument;
-use tribal_domain::span_attrs;
+use tribal_domain::{ProviderKind, span_attrs};
 
 use crate::{
     CompletionRequest, CompletionResponse, CompletionUsage, InferenceError, InferenceProvider,
-    Message, ProviderIdentity, ResponseFormat, Role,
+    Message, ProviderIdentity, ResponseFormat, Role, apply_dialect,
     error::{map_body_read_error, map_http_error, map_json_parse_error, map_send_error},
     http::{INFERENCE_PROBE_INPUT, PROBE_MAX_TOKENS, normalise_base_url, record_completion_usage},
 };
@@ -312,7 +312,9 @@ fn build_request<'a>(model: &'a str, request: &'a CompletionRequest) -> OllamaCh
 fn map_response_format(format: &ResponseFormat) -> serde_json::Value {
     match format {
         ResponseFormat::Json => serde_json::Value::String("json".to_owned()),
-        ResponseFormat::JsonSchema { schema } => schema.clone(),
+        ResponseFormat::JsonSchema { schema } => {
+            apply_dialect(ProviderKind::Ollama, schema.clone())
+        }
     }
 }
 

--- a/crates/tribal-inference/src/openai/inference.rs
+++ b/crates/tribal-inference/src/openai/inference.rs
@@ -13,8 +13,8 @@ use tribal_domain::{ProviderKind, span_attrs};
 
 use crate::{
     CompletionRequest, CompletionResponse, CompletionUsage, InferenceError, InferenceProvider,
-    Message, ProviderIdentity, ResponseFormat, Role,
-    capabilities::{MaxOutputTokensParam, reconcile_temperature, resolve},
+    Message, ProviderIdentity, ResponseFormat, Role, apply_dialect,
+    capabilities::{MaxOutputTokensParam, StructuredOutputMode, reconcile_temperature, resolve},
     error::{map_body_read_error, map_http_error, map_json_parse_error, map_send_error},
     http::{INFERENCE_PROBE_INPUT, PROBE_MAX_TOKENS, normalise_base_url, record_completion_usage},
 };
@@ -304,10 +304,12 @@ fn build_request<'a>(model: &'a str, request: &'a CompletionRequest) -> OpenAiCh
         });
     }
 
-    let response_format = request.response_format.as_ref().map(map_response_format);
-
     // -- Capability reconciliation --
     let caps = resolve(ProviderKind::OpenAi, model);
+    let response_format = request
+        .response_format
+        .as_ref()
+        .map(|format| map_response_format(format, caps.structured_output_mode));
     let temperature = reconcile_temperature(caps.sampling, request.temperature, model);
     let (max_tokens, max_completion_tokens) = match caps.max_output_tokens_param {
         MaxOutputTokensParam::MaxTokens => (request.max_tokens, None),
@@ -329,14 +331,21 @@ fn build_request<'a>(model: &'a str, request: &'a CompletionRequest) -> OpenAiCh
     }
 }
 
-fn map_response_format(format: &ResponseFormat) -> serde_json::Value {
+/// Maps a [`ResponseFormat`] to the `OpenAI` `response_format` envelope. A
+/// schema is normalised into the strict dialect and marked `strict` per the
+/// resolved structured-output mode.
+fn map_response_format(
+    format: &ResponseFormat,
+    structured_output_mode: StructuredOutputMode,
+) -> serde_json::Value {
     match format {
         ResponseFormat::Json => serde_json::json!({"type": "json_object"}),
         ResponseFormat::JsonSchema { schema } => serde_json::json!({
             "type": "json_schema",
             "json_schema": {
                 "name": "response",
-                "schema": schema,
+                "schema": apply_dialect(ProviderKind::OpenAi, schema.clone()),
+                "strict": structured_output_mode.requires_strict(),
             },
         }),
     }
@@ -552,8 +561,19 @@ mod tests {
     #[tokio::test]
     async fn test_chat_sends_response_format_json_schema() {
         let server = MockServer::start().await;
-        let schema =
-            serde_json::json!({"type": "object", "properties": {"name": {"type": "string"}}});
+        let schema = serde_json::json!({
+            "type": "object",
+            "properties": {"name": {"type": "string"}},
+            "required": ["name"],
+        });
+        // The wire schema is the strict-dialect normalisation: closed object,
+        // and the envelope carries `strict: true` (gpt-4o-mini resolves strict).
+        let expected_schema = serde_json::json!({
+            "type": "object",
+            "properties": {"name": {"type": "string"}},
+            "required": ["name"],
+            "additionalProperties": false,
+        });
 
         Mock::given(method("POST"))
             .and(path(CHAT_PATH))
@@ -564,7 +584,8 @@ mod tests {
                     "type": "json_schema",
                     "json_schema": {
                         "name": "response",
-                        "schema": schema.clone(),
+                        "schema": expected_schema,
+                        "strict": true,
                     },
                 },
             })))
@@ -585,6 +606,36 @@ mod tests {
             response_format: Some(ResponseFormat::JsonSchema { schema }),
         };
         let _ = provider.complete(request).await.unwrap();
+    }
+
+    #[test]
+    fn test_map_response_format_strict_marks_schema_strict() {
+        let schema = serde_json::json!({
+            "type": "object",
+            "properties": {"name": {"type": "string"}},
+            "required": ["name"],
+        });
+        let result = map_response_format(
+            &ResponseFormat::JsonSchema { schema },
+            StructuredOutputMode::Strict,
+        );
+        assert_eq!(result["json_schema"]["strict"], serde_json::json!(true));
+    }
+
+    #[test]
+    fn test_map_response_format_advisory_does_not_mark_schema_strict() {
+        // The advisory branch is unreachable through `resolve` today; a
+        // constructed mode is the only coverage of the non-strict envelope.
+        let schema = serde_json::json!({
+            "type": "object",
+            "properties": {"name": {"type": "string"}},
+            "required": ["name"],
+        });
+        let result = map_response_format(
+            &ResponseFormat::JsonSchema { schema },
+            StructuredOutputMode::Advisory,
+        );
+        assert_eq!(result["json_schema"]["strict"], serde_json::json!(false));
     }
 
     #[tokio::test]

--- a/crates/tribal-inference/src/schema_dialect.rs
+++ b/crates/tribal-inference/src/schema_dialect.rs
@@ -55,6 +55,8 @@ const TYPE_KEY: &str = "type";
 const ENUM_KEY: &str = "enum";
 const CONST_KEY: &str = "const";
 const PROPERTIES_KEY: &str = "properties";
+const DEFINITIONS_KEY: &str = "definitions";
+const ITEMS_KEY: &str = "items";
 const REQUIRED_KEY: &str = "required";
 const ADDITIONAL_PROPERTIES_KEY: &str = "additionalProperties";
 const DESCRIPTION_KEY: &str = "description";
@@ -77,6 +79,9 @@ const FORBIDDEN_VALIDATION_KEYWORDS: &[&str] = &[
     "minLength",
     "maxLength",
     "pattern",
+    "minItems",
+    "maxItems",
+    "uniqueItems",
 ];
 
 // ---------------------------------------------------------------------------
@@ -129,7 +134,7 @@ fn apply_anthropic_subset(mut schema: Value) -> Value {
 /// decode never consumes, so stripping it removes a provider-acceptance
 /// assumption at no functional cost.
 fn strip_unsupported_keywords(root: &mut Value) {
-    walk_objects_mut(root, &mut |map| {
+    walk_schema_maps_mut(root, &mut |map| {
         map.remove(SCHEMA_KEY);
         map.remove(DEFAULT_KEY);
         for keyword in FORBIDDEN_VALIDATION_KEYWORDS {
@@ -152,7 +157,7 @@ fn strip_unsupported_keywords(root: &mut Value) {
 /// the sibling annotations, removing the single-element `allOf`-with-`$ref` that
 /// both subsets reject.
 fn unwrap_described_refs(root: &mut Value) {
-    walk_objects_mut(root, &mut |map| {
+    walk_schema_maps_mut(root, &mut |map| {
         let inner = match map.get(ALL_OF_KEY) {
             Some(Value::Array(items)) if items.len() == 1 => items[0].as_object().cloned(),
             _ => None,
@@ -171,7 +176,7 @@ fn unwrap_described_refs(root: &mut Value) {
 /// Reduces every `$ref` node to a bare reference. The strict subset rejects
 /// sibling keywords (such as `description`) alongside `$ref`.
 fn strip_ref_siblings(root: &mut Value) {
-    walk_objects_mut(root, &mut |map| {
+    walk_schema_maps_mut(root, &mut |map| {
         if let Some(reference) = map.get(REF_KEY).cloned() {
             map.clear();
             map.insert(REF_KEY.to_owned(), reference);
@@ -183,8 +188,14 @@ fn strip_ref_siblings(root: &mut Value) {
 /// accepts. String (unit-variant) enums collapse to a single `enum`; internally
 /// tagged enums become `anyOf` of branches with a `const` discriminator, or, for
 /// a single variant, the sole branch inlined.
+///
+/// `const`-based branch distinguishability is guaranteed only for internally
+/// tagged `oneOf` (object branches sharing a discriminator). An externally or
+/// adjacently tagged enum — none of the current response types produce one —
+/// would trip the debug assertion and fall back to a bare `oneOf`→`anyOf`
+/// rename, which is a known gap rather than a supported shape.
 fn rewrite_enums(root: &mut Value) {
-    walk_objects_mut_with_value(root, &mut |value| {
+    walk_schema_nodes_mut(root, &mut |value| {
         let Some(branches) = value
             .as_object()
             .and_then(|map| map.get(ONE_OF_KEY))
@@ -275,9 +286,10 @@ fn rewrite_tagged_enum(value: &mut Value, mut branches: Vec<Value>) {
     }
 }
 
-/// Expresses each single-value string `enum` property — the internally tagged
-/// discriminator — as a `const`, which a strict `anyOf` requires for its
-/// branches to be distinguishable.
+/// Rewrites every single-value `enum` property to the equivalent `const`. In an
+/// internally tagged enum branch this is the discriminator, and a strict `anyOf`
+/// requires a `const` for its branches to be distinguishable; any other
+/// single-value `enum` is identical as a `const`, so pinning it is harmless.
 fn pin_discriminator_consts(properties: &mut Map<String, Value>) {
     for property in properties.values_mut() {
         let Some(map) = property.as_object_mut() else {
@@ -298,7 +310,7 @@ fn pin_discriminator_consts(properties: &mut Map<String, Value>) {
 /// was optional (absent from the original `required`) as nullable. Arrays are
 /// required but not made nullable: an empty array satisfies the field.
 fn force_required_and_nullable(root: &mut Value) {
-    walk_objects_mut(root, &mut |map| {
+    walk_schema_maps_mut(root, &mut |map| {
         let Some(properties) = map.get(PROPERTIES_KEY).and_then(Value::as_object) else {
             return;
         };
@@ -334,9 +346,9 @@ fn force_required_and_nullable(root: &mut Value) {
 ///
 /// Arrays are left unchanged (required-but-empty satisfies the field). A `$ref`
 /// or `const` cannot carry an inline null, so it is wrapped in an `anyOf` with a
-/// null branch; an `enum` widens both its type union and its value set; a plain
-/// typed leaf gains `null` in its type union. Idempotent for an already-nullable
-/// scalar.
+/// null branch; an inline `anyOf` gains a null branch directly; an `enum` widens
+/// both its type union and its value set; a plain typed leaf gains `null` in its
+/// type union. Idempotent for an already-nullable scalar or `anyOf`.
 fn make_nullable(schema: &mut Value) {
     let Some(map) = schema.as_object() else {
         return;
@@ -355,6 +367,16 @@ fn make_nullable(schema: &mut Value) {
     let Some(map) = schema.as_object_mut() else {
         return;
     };
+    // An inline `anyOf` gains a null branch rather than a type union.
+    if let Some(Value::Array(branches)) = map.get_mut(ANY_OF_KEY) {
+        let has_null = branches
+            .iter()
+            .any(|branch| branch.get(TYPE_KEY).and_then(Value::as_str) == Some(NULL_TYPE));
+        if !has_null {
+            branches.push(null_schema());
+        }
+        return;
+    }
     // An enum constrains the value set, so `null` must join both the type union
     // and the enum.
     if let Some(Value::Array(values)) = map.get_mut(ENUM_KEY)
@@ -374,15 +396,20 @@ fn make_nullable(schema: &mut Value) {
     }
 }
 
+/// A schema matching only JSON null.
+fn null_schema() -> Value {
+    let mut map = Map::new();
+    map.insert(TYPE_KEY.to_owned(), Value::String(NULL_TYPE.to_owned()));
+    Value::Object(map)
+}
+
 /// Wraps a schema in `anyOf: [<schema>, { "type": "null" }]`, the nullable form
 /// for a node that cannot carry an inline null type (a `$ref` or a `const`).
 fn anyof_with_null(schema: Value) -> Value {
-    let mut null_branch = Map::new();
-    null_branch.insert(TYPE_KEY.to_owned(), Value::String(NULL_TYPE.to_owned()));
     let mut wrapper = Map::new();
     wrapper.insert(
         ANY_OF_KEY.to_owned(),
-        Value::Array(vec![schema, Value::Object(null_branch)]),
+        Value::Array(vec![schema, null_schema()]),
     );
     Value::Object(wrapper)
 }
@@ -390,7 +417,7 @@ fn anyof_with_null(schema: Value) -> Value {
 /// Sets `additionalProperties: false` on every object schema that does not
 /// already constrain it. Both subsets require closed objects.
 fn close_all_objects(root: &mut Value) {
-    walk_objects_mut(root, &mut |map| {
+    walk_schema_maps_mut(root, &mut |map| {
         if is_object_schema(map) && !map.contains_key(ADDITIONAL_PROPERTIES_KEY) {
             map.insert(ADDITIONAL_PROPERTIES_KEY.to_owned(), Value::Bool(false));
         }
@@ -420,52 +447,104 @@ fn is_object_branch(branch: &Value) -> bool {
     branch.get(PROPERTIES_KEY).is_some()
 }
 
-/// Visits every object node in `root`, depth-first, applying `visit` to its map.
-fn walk_objects_mut(root: &mut Value, visit: &mut impl FnMut(&mut Map<String, Value>)) {
-    walk_objects_mut_with_value(root, &mut |value| {
+/// Visits every schema node in `root`, depth-first, applying `visit` to its map.
+fn walk_schema_maps_mut(root: &mut Value, visit: &mut impl FnMut(&mut Map<String, Value>)) {
+    walk_schema_nodes_mut(root, &mut |value| {
         if let Some(map) = value.as_object_mut() {
             visit(map);
         }
     });
 }
 
-/// Visits every object node in `root`, depth-first, applying `visit` to the
+/// Visits every schema node in `root`, depth-first, applying `visit` to the
 /// owning [`Value`] so a node can be replaced wholesale.
-fn walk_objects_mut_with_value(root: &mut Value, visit: &mut impl FnMut(&mut Value)) {
-    match root {
-        Value::Object(map) => {
-            for child in map.values_mut() {
-                walk_objects_mut_with_value(child, visit);
+///
+/// Recursion follows only schema-bearing positions — `properties` and
+/// `definitions` *values*, `items`, `additionalProperties`, and the
+/// `anyOf`/`oneOf`/`allOf` branches — never the container maps that hold named
+/// properties or definitions, nor data positions such as `enum`/`const`/`default`
+/// values. A field whose name collides with a schema keyword is therefore left
+/// alone.
+fn walk_schema_nodes_mut(root: &mut Value, visit: &mut impl FnMut(&mut Value)) {
+    if let Value::Object(map) = root {
+        if let Some(Value::Object(properties)) = map.get_mut(PROPERTIES_KEY) {
+            for child in properties.values_mut() {
+                walk_schema_nodes_mut(child, visit);
             }
         }
-        Value::Array(items) => {
-            for item in items {
-                walk_objects_mut_with_value(item, visit);
+        if let Some(Value::Object(definitions)) = map.get_mut(DEFINITIONS_KEY) {
+            for child in definitions.values_mut() {
+                walk_schema_nodes_mut(child, visit);
             }
-            return;
         }
-        _ => return,
+        if let Some(items) = map.get_mut(ITEMS_KEY) {
+            match items {
+                Value::Object(_) => walk_schema_nodes_mut(items, visit),
+                Value::Array(elements) => {
+                    for element in elements.iter_mut() {
+                        walk_schema_nodes_mut(element, visit);
+                    }
+                }
+                _ => {}
+            }
+        }
+        if let Some(additional) = map.get_mut(ADDITIONAL_PROPERTIES_KEY)
+            && additional.is_object()
+        {
+            walk_schema_nodes_mut(additional, visit);
+        }
+        for combinator in [ANY_OF_KEY, ONE_OF_KEY, ALL_OF_KEY] {
+            if let Some(Value::Array(branches)) = map.get_mut(combinator) {
+                for branch in branches.iter_mut() {
+                    walk_schema_nodes_mut(branch, visit);
+                }
+            }
+        }
     }
     visit(root);
 }
 
-/// Visits every object node in `root`, depth-first (read-only).
+/// Visits every schema node in `root`, depth-first (read-only), following the
+/// same schema-bearing positions as [`walk_schema_nodes_mut`].
 #[cfg(any(test, feature = "test-helpers"))]
-fn for_each_object(root: &Value, visit: &mut impl FnMut(&Map<String, Value>)) {
-    match root {
-        Value::Object(map) => {
-            for child in map.values() {
-                for_each_object(child, visit);
-            }
-            visit(map);
+fn for_each_schema_node(root: &Value, visit: &mut impl FnMut(&Map<String, Value>)) {
+    let Some(map) = root.as_object() else {
+        return;
+    };
+    if let Some(Value::Object(properties)) = map.get(PROPERTIES_KEY) {
+        for child in properties.values() {
+            for_each_schema_node(child, visit);
         }
-        Value::Array(items) => {
-            for item in items {
-                for_each_object(item, visit);
-            }
-        }
-        _ => {}
     }
+    if let Some(Value::Object(definitions)) = map.get(DEFINITIONS_KEY) {
+        for child in definitions.values() {
+            for_each_schema_node(child, visit);
+        }
+    }
+    if let Some(items) = map.get(ITEMS_KEY) {
+        match items {
+            Value::Object(_) => for_each_schema_node(items, visit),
+            Value::Array(elements) => {
+                for element in elements {
+                    for_each_schema_node(element, visit);
+                }
+            }
+            _ => {}
+        }
+    }
+    if let Some(additional) = map.get(ADDITIONAL_PROPERTIES_KEY)
+        && additional.is_object()
+    {
+        for_each_schema_node(additional, visit);
+    }
+    for combinator in [ANY_OF_KEY, ONE_OF_KEY, ALL_OF_KEY] {
+        if let Some(Value::Array(branches)) = map.get(combinator) {
+            for branch in branches {
+                for_each_schema_node(branch, visit);
+            }
+        }
+    }
+    visit(map);
 }
 
 /// Asserts that an internally tagged enum's branches are distinguishable by
@@ -505,23 +584,28 @@ fn branch_const_signature(branch: &Value) -> Vec<(String, Value)> {
 #[cfg(any(test, feature = "test-helpers"))]
 const FORBIDDEN_COMBINATORS: &[&str] = &[ONE_OF_KEY, ALL_OF_KEY, "if", "then", "else", "not"];
 
-/// Asserts a transformed schema satisfies its provider subset's invariants: no
+/// Asserts a transformed schema satisfies the dialect's output invariants: no
 /// forbidden combinator or leaf keyword survives, the meta and `default`
 /// keywords are stripped, numeric leaves carry no `format`, and every object is
-/// closed. `strict` adds the OpenAI-only requirement that every object lists all
-/// its properties as required.
+/// closed. `strict` adds the OpenAI-only requirements that every object lists
+/// all its properties as required and that the root is not an `anyOf`.
 ///
-/// This is the single source of subset-invariant truth — reused by the dialect's
-/// own tests and by cross-crate snapshot tests — and it checks against the same
-/// keyword lists the transform strips by, so the assertion cannot drift from the
-/// transform.
+/// These are the transform's *output* invariants, which are a conservative
+/// subset of what each provider accepts (for instance it forbids `allOf`, which
+/// `Anthropic` in fact permits). The leaf-keyword check shares
+/// `FORBIDDEN_VALIDATION_KEYWORDS` with the transform, keeping that portion
+/// coupled to what the transform strips.
 ///
 /// # Panics
 ///
-/// Panics if `schema` violates any invariant of the selected subset.
+/// Panics if `schema` violates any of those invariants.
 #[cfg(any(test, feature = "test-helpers"))]
 pub fn assert_dialect_invariants(schema: &Value, strict: bool) {
-    for_each_object(schema, &mut |map| {
+    assert!(
+        !(strict && schema.get(ANY_OF_KEY).is_some()),
+        "strict subset forbids an anyOf at the schema root"
+    );
+    for_each_schema_node(schema, &mut |map| {
         for combinator in FORBIDDEN_COMBINATORS {
             assert!(
                 !map.contains_key(*combinator),
@@ -823,6 +907,82 @@ mod tests {
         assert_eq!(
             result["properties"]["kind"]["enum"],
             json!(["a", "b", null])
+        );
+    }
+
+    #[test]
+    fn test_field_named_like_keyword_is_not_stripped() {
+        // The traversal visits schema nodes, not the property container, so a
+        // field whose name collides with a stripped keyword survives intact.
+        let schema = json!({
+            "type": "object",
+            "properties": {
+                "default": { "type": "string" },
+                "minimum": { "type": "string" },
+            },
+            "required": ["default", "minimum"],
+        });
+        let result = apply_openai(schema);
+        assert!(
+            result["properties"].get("default").is_some(),
+            "field named `default` was stripped"
+        );
+        assert!(
+            result["properties"].get("minimum").is_some(),
+            "field named `minimum` was stripped"
+        );
+        assert_eq!(result["required"], json!(["default", "minimum"]));
+    }
+
+    #[test]
+    fn test_openai_makes_optional_inline_anyof_nullable() {
+        let schema = json!({
+            "type": "object",
+            "properties": {
+                "choice": { "anyOf": [{ "type": "string" }, { "type": "integer" }] },
+            },
+            "required": [],
+        });
+        let result = apply_openai(schema);
+        assert_eq!(result["required"], json!(["choice"]));
+        let branches = result["properties"]["choice"]["anyOf"]
+            .as_array()
+            .expect("inline anyOf");
+        assert!(
+            branches
+                .iter()
+                .any(|branch| branch["type"] == json!("null")),
+            "optional inline anyOf gained a null branch"
+        );
+    }
+
+    #[test]
+    fn test_strips_array_constraint_keywords() {
+        let schema = json!({
+            "type": "object",
+            "properties": {
+                "tags": {
+                    "type": "array",
+                    "items": { "type": "string" },
+                    "maxItems": 5,
+                    "uniqueItems": true,
+                },
+            },
+            "required": ["tags"],
+        });
+        let result = apply_openai(schema);
+        assert!(result["properties"]["tags"].get("maxItems").is_none());
+        assert!(result["properties"]["tags"].get("uniqueItems").is_none());
+    }
+
+    #[test]
+    #[should_panic(expected = "anyOf at the schema root")]
+    fn test_strict_invariants_reject_root_anyof() {
+        assert_dialect_invariants(
+            &json!({
+                "anyOf": [{ "type": "object", "properties": {}, "additionalProperties": false }]
+            }),
+            true,
         );
     }
 

--- a/crates/tribal-inference/src/schema_dialect.rs
+++ b/crates/tribal-inference/src/schema_dialect.rs
@@ -1,0 +1,928 @@
+//! Per-provider JSON Schema dialect transforms.
+//!
+//! [`apply_dialect`] rewrites the canonical `schemars` schema (a draft-07
+//! document) into the dialect a provider's structured-output endpoint accepts.
+//! The canonical schema is emitted once by the worker and carried opaquely to
+//! the wire; each transport normalises it on the way out, so the response Rust
+//! types are never reshaped to satisfy a provider's subset.
+//!
+//! The dispatch is keyed on [`ProviderKind`] because dialect admissibility is a
+//! property of the serving endpoint, not the model weights. A new provider is
+//! accommodated by adding one arm to [`apply_dialect`]; existing call sites are
+//! unchanged.
+//!
+//! Three policies:
+//!
+//! - **`OpenAI`**: every object closed (`additionalProperties: false`) and
+//!   all-required, optionals expressed as a nullable type union, internally
+//!   tagged enums rewritten from `oneOf` to `anyOf` with a `const` discriminator,
+//!   string enums collapsed to a single `enum`, `$ref` reduced to a bare
+//!   reference (the subset rejects sibling keywords on `$ref`), and the
+//!   validation leaf keywords the subset rejects stripped.
+//! - **`Anthropic`**: every object closed and `oneOf`/`allOf`-with-`$ref`
+//!   rewritten away, but optionals left omitted from `required` (the subset
+//!   accepts optional-by-omission) and `$ref` annotations retained. Enforcement
+//!   is grammar-based, so no per-request flag is sent.
+//! - **`Ollama`**: identity. The local llama.cpp path accepts the canonical
+//!   schema unchanged.
+//!
+//! # Provenance
+//!
+//! These dialects encode each provider's accepted *subset* of JSON Schema,
+//! which is vendor policy rather than a JSON Schema specification concept — so
+//! no schema library canonicalises it, and the keyword lists below are
+//! maintained by hand against the providers' own structured-output docs:
+//!
+//! - `OpenAI`: <https://platform.openai.com/docs/guides/structured-outputs>
+//! - `Anthropic`: <https://platform.claude.com/docs/en/build-with-claude/structured-outputs>
+//!
+//! A subset can drift as a provider extends support; the documented live probe
+//! and issue reports are the safety net for that drift.
+
+use serde_json::{Map, Value, json};
+use tribal_domain::ProviderKind;
+
+// ---------------------------------------------------------------------------
+// Schema keywords
+// ---------------------------------------------------------------------------
+
+const SCHEMA_KEY: &str = "$schema";
+const REF_KEY: &str = "$ref";
+const ALL_OF_KEY: &str = "allOf";
+const ANY_OF_KEY: &str = "anyOf";
+const ONE_OF_KEY: &str = "oneOf";
+const TYPE_KEY: &str = "type";
+const ENUM_KEY: &str = "enum";
+const CONST_KEY: &str = "const";
+const PROPERTIES_KEY: &str = "properties";
+const REQUIRED_KEY: &str = "required";
+const ADDITIONAL_PROPERTIES_KEY: &str = "additionalProperties";
+const DESCRIPTION_KEY: &str = "description";
+const DEFAULT_KEY: &str = "default";
+const FORMAT_KEY: &str = "format";
+const NULL_TYPE: &str = "null";
+const OBJECT_TYPE: &str = "object";
+const ARRAY_TYPE: &str = "array";
+const STRING_TYPE: &str = "string";
+
+/// Validation leaf keywords that both transforming subsets reject and that
+/// `schemars` may emit on number, integer, and string leaves. Sourced from the
+/// provider subsets cited in the module-level Provenance note.
+const FORBIDDEN_VALIDATION_KEYWORDS: &[&str] = &[
+    "minimum",
+    "maximum",
+    "exclusiveMinimum",
+    "exclusiveMaximum",
+    "multipleOf",
+    "minLength",
+    "maxLength",
+    "pattern",
+];
+
+// ---------------------------------------------------------------------------
+// Dispatch
+// ---------------------------------------------------------------------------
+
+/// Rewrites a canonical `schemars` schema into the dialect `provider`'s
+/// structured-output endpoint accepts.
+///
+/// `Ollama` accepts the canonical schema unchanged; the cloud providers each
+/// have their own transform. A provider that shares a policy reuses the same
+/// transform function.
+#[must_use]
+pub fn apply_dialect(provider: ProviderKind, schema: Value) -> Value {
+    match provider {
+        ProviderKind::Ollama => schema,
+        ProviderKind::Anthropic => apply_anthropic_subset(schema),
+        ProviderKind::OpenAi => apply_openai_strict(schema),
+    }
+}
+
+/// Normalises a schema into the `OpenAI` strict structured-output subset. See
+/// the module-level Provenance note for the subset reference.
+fn apply_openai_strict(mut schema: Value) -> Value {
+    strip_unsupported_keywords(&mut schema, true);
+    unwrap_described_refs(&mut schema);
+    strip_ref_siblings(&mut schema);
+    rewrite_enums(&mut schema);
+    force_required_and_nullable(&mut schema);
+    close_all_objects(&mut schema);
+    debug_assert_dialect_invariants(&schema, true);
+    schema
+}
+
+/// Normalises a schema into the `Anthropic` structured-output subset. See the
+/// module-level Provenance note for the subset reference.
+fn apply_anthropic_subset(mut schema: Value) -> Value {
+    strip_unsupported_keywords(&mut schema, false);
+    unwrap_described_refs(&mut schema);
+    rewrite_enums(&mut schema);
+    close_all_objects(&mut schema);
+    debug_assert_dialect_invariants(&schema, false);
+    schema
+}
+
+// ---------------------------------------------------------------------------
+// Transform passes
+// ---------------------------------------------------------------------------
+
+/// Removes the meta declaration and the validation leaf keywords the subsets
+/// reject. `remove_default` also drops `default`, which the strict subset
+/// rejects; the looser subset accepts it, so it is retained there.
+fn strip_unsupported_keywords(root: &mut Value, remove_default: bool) {
+    walk_objects_mut(root, &mut |map| {
+        map.remove(SCHEMA_KEY);
+        for keyword in FORBIDDEN_VALIDATION_KEYWORDS {
+            map.remove(*keyword);
+        }
+        // `format` is rejected on numeric leaves (e.g. `uint32`); string
+        // formats stay, so the removal is scoped by type.
+        let is_numeric = matches!(
+            map.get(TYPE_KEY).and_then(Value::as_str),
+            Some("integer" | "number")
+        );
+        if is_numeric {
+            map.remove(FORMAT_KEY);
+        }
+        if remove_default {
+            map.remove(DEFAULT_KEY);
+        }
+    });
+}
+
+/// Collapses the draft-07 described-reference form
+/// `{ "description": .., "allOf": [ { "$ref": .. } ] }` into a `$ref` carrying
+/// the sibling annotations, removing the single-element `allOf`-with-`$ref` that
+/// both subsets reject.
+fn unwrap_described_refs(root: &mut Value) {
+    walk_objects_mut(root, &mut |map| {
+        let inner = match map.get(ALL_OF_KEY) {
+            Some(Value::Array(items)) if items.len() == 1 => items[0].as_object().cloned(),
+            _ => None,
+        };
+        let Some(inner) = inner else { return };
+        if !inner.contains_key(REF_KEY) {
+            return;
+        }
+        map.remove(ALL_OF_KEY);
+        for (key, value) in inner {
+            map.entry(key).or_insert(value);
+        }
+    });
+}
+
+/// Reduces every `$ref` node to a bare reference. The strict subset rejects
+/// sibling keywords (such as `description`) alongside `$ref`.
+fn strip_ref_siblings(root: &mut Value) {
+    walk_objects_mut(root, &mut |map| {
+        if let Some(reference) = map.get(REF_KEY).cloned() {
+            map.clear();
+            map.insert(REF_KEY.to_owned(), reference);
+        }
+    });
+}
+
+/// Rewrites the `oneOf` forms `schemars` emits for enums, which neither subset
+/// accepts. String (unit-variant) enums collapse to a single `enum`; internally
+/// tagged enums become `anyOf` of branches with a `const` discriminator, or, for
+/// a single variant, the sole branch inlined.
+fn rewrite_enums(root: &mut Value) {
+    walk_objects_mut_with_value(root, &mut |value| {
+        let Some(branches) = value
+            .as_object()
+            .and_then(|map| map.get(ONE_OF_KEY))
+            .and_then(Value::as_array)
+            .cloned()
+        else {
+            return;
+        };
+
+        if branches.is_empty() {
+            return;
+        }
+
+        if branches.iter().all(is_string_enum_branch) {
+            if let Some(map) = value.as_object_mut() {
+                collapse_string_enum(map, &branches);
+            }
+        } else if branches.iter().all(is_object_branch) {
+            rewrite_tagged_enum(value, branches);
+        } else {
+            debug_assert!(false, "unexpected oneOf branch shape");
+            if let Some(map) = value.as_object_mut()
+                && let Some(one_of) = map.remove(ONE_OF_KEY)
+            {
+                map.insert(ANY_OF_KEY.to_owned(), one_of);
+            }
+        }
+    });
+}
+
+/// Collapses a `oneOf` of single-value string-`enum` branches into one
+/// `{ "type": "string", "enum": [..] }`, preserving the node's own annotations.
+/// Per-branch descriptions are dropped: neither subset attaches descriptions to
+/// individual enum values.
+fn collapse_string_enum(map: &mut Map<String, Value>, branches: &[Value]) {
+    let mut values: Vec<Value> = Vec::new();
+    let mut value_type: Option<Value> = None;
+    for branch in branches {
+        let Some(branch) = branch.as_object() else {
+            continue;
+        };
+        if value_type.is_none() {
+            value_type = branch.get(TYPE_KEY).cloned();
+        }
+        if let Some(Value::Array(enum_values)) = branch.get(ENUM_KEY) {
+            for value in enum_values {
+                if !values.contains(value) {
+                    values.push(value.clone());
+                }
+            }
+        }
+    }
+    map.remove(ONE_OF_KEY);
+    map.insert(
+        TYPE_KEY.to_owned(),
+        value_type.unwrap_or_else(|| json!(STRING_TYPE)),
+    );
+    map.insert(ENUM_KEY.to_owned(), Value::Array(values));
+}
+
+/// Rewrites an internally tagged enum. Each branch's single-value discriminator
+/// is pinned to a `const`; a single branch is inlined in place (carrying the
+/// node's description), multiple branches become an `anyOf`.
+fn rewrite_tagged_enum(value: &mut Value, mut branches: Vec<Value>) {
+    for branch in &mut branches {
+        if let Some(map) = branch.as_object_mut()
+            && let Some(properties) = map.get_mut(PROPERTIES_KEY)
+            && let Some(properties) = properties.as_object_mut()
+        {
+            pin_discriminator_consts(properties);
+        }
+    }
+
+    if branches.len() == 1 {
+        let description = value.get(DESCRIPTION_KEY).cloned();
+        let Some(mut branch) = branches.into_iter().next() else {
+            return;
+        };
+        if let (Some(map), Some(description)) = (branch.as_object_mut(), description) {
+            map.insert(DESCRIPTION_KEY.to_owned(), description);
+        }
+        *value = branch;
+    } else if let Some(map) = value.as_object_mut() {
+        #[cfg(debug_assertions)]
+        debug_assert_distinct_branches(&branches);
+        map.remove(ONE_OF_KEY);
+        map.insert(ANY_OF_KEY.to_owned(), Value::Array(branches));
+    }
+}
+
+/// Expresses each single-value string `enum` property — the internally tagged
+/// discriminator — as a `const`, which a strict `anyOf` requires for its
+/// branches to be distinguishable.
+fn pin_discriminator_consts(properties: &mut Map<String, Value>) {
+    for property in properties.values_mut() {
+        let Some(map) = property.as_object_mut() else {
+            continue;
+        };
+        let single_value = match map.get(ENUM_KEY) {
+            Some(Value::Array(values)) if values.len() == 1 => values.first().cloned(),
+            _ => None,
+        };
+        if let Some(value) = single_value {
+            map.remove(ENUM_KEY);
+            map.insert(CONST_KEY.to_owned(), value);
+        }
+    }
+}
+
+/// Marks every property of every object required, expressing each property that
+/// was optional (absent from the original `required`) as nullable. Arrays are
+/// required but not made nullable: an empty array satisfies the field.
+fn force_required_and_nullable(root: &mut Value) {
+    walk_objects_mut(root, &mut |map| {
+        let Some(properties) = map.get(PROPERTIES_KEY).and_then(Value::as_object) else {
+            return;
+        };
+        let keys: Vec<String> = properties.keys().cloned().collect();
+        let originally_required: Vec<String> = map
+            .get(REQUIRED_KEY)
+            .and_then(Value::as_array)
+            .map(|required| {
+                required
+                    .iter()
+                    .filter_map(|value| value.as_str().map(str::to_owned))
+                    .collect()
+            })
+            .unwrap_or_default();
+
+        if let Some(properties) = map.get_mut(PROPERTIES_KEY).and_then(Value::as_object_mut) {
+            for (key, schema) in properties.iter_mut() {
+                if !originally_required.contains(key) {
+                    make_nullable(schema);
+                }
+            }
+        }
+
+        map.insert(
+            REQUIRED_KEY.to_owned(),
+            Value::Array(keys.into_iter().map(Value::String).collect()),
+        );
+    });
+}
+
+/// Adds `null` to a property's type union. Idempotent for an already-nullable
+/// scalar; a no-op for arrays (required-but-empty satisfies the field).
+fn make_nullable(schema: &mut Value) {
+    let Some(map) = schema.as_object_mut() else {
+        return;
+    };
+    if map.get(TYPE_KEY).and_then(Value::as_str) == Some(ARRAY_TYPE) {
+        return;
+    }
+    if map.contains_key(REF_KEY) {
+        // No optional `$ref` field exists in the pipeline response types; a
+        // nullable reference would need an `anyOf` with a null branch.
+        debug_assert!(
+            false,
+            "optional $ref field is not expected under the strict subset"
+        );
+        return;
+    }
+    match map.get(TYPE_KEY).cloned() {
+        Some(Value::String(scalar)) => {
+            map.insert(TYPE_KEY.to_owned(), json!([scalar, NULL_TYPE]));
+        }
+        Some(Value::Array(mut types)) if !types.iter().any(|ty| ty.as_str() == Some(NULL_TYPE)) => {
+            types.push(json!(NULL_TYPE));
+            map.insert(TYPE_KEY.to_owned(), Value::Array(types));
+        }
+        _ => {}
+    }
+}
+
+/// Sets `additionalProperties: false` on every object schema that does not
+/// already constrain it. Both subsets require closed objects.
+fn close_all_objects(root: &mut Value) {
+    walk_objects_mut(root, &mut |map| {
+        if is_object_schema(map) && !map.contains_key(ADDITIONAL_PROPERTIES_KEY) {
+            map.insert(ADDITIONAL_PROPERTIES_KEY.to_owned(), Value::Bool(false));
+        }
+    });
+}
+
+// ---------------------------------------------------------------------------
+// Predicates and traversal
+// ---------------------------------------------------------------------------
+
+/// Whether a schema node describes an object instance, which both subsets
+/// require to be closed.
+fn is_object_schema(map: &Map<String, Value>) -> bool {
+    map.get(TYPE_KEY).and_then(Value::as_str) == Some(OBJECT_TYPE)
+        || map.contains_key(PROPERTIES_KEY)
+}
+
+/// A `oneOf` branch produced by a unit (string) enum variant: a string schema
+/// constrained by `enum`, carrying no `properties`.
+fn is_string_enum_branch(branch: &Value) -> bool {
+    branch.is_object() && branch.get(ENUM_KEY).is_some() && branch.get(PROPERTIES_KEY).is_none()
+}
+
+/// A `oneOf` branch produced by an internally tagged enum variant: an object
+/// schema with `properties`.
+fn is_object_branch(branch: &Value) -> bool {
+    branch.get(PROPERTIES_KEY).is_some()
+}
+
+/// Visits every object node in `root`, depth-first, applying `visit` to its map.
+fn walk_objects_mut(root: &mut Value, visit: &mut impl FnMut(&mut Map<String, Value>)) {
+    walk_objects_mut_with_value(root, &mut |value| {
+        if let Some(map) = value.as_object_mut() {
+            visit(map);
+        }
+    });
+}
+
+/// Visits every object node in `root`, depth-first, applying `visit` to the
+/// owning [`Value`] so a node can be replaced wholesale.
+fn walk_objects_mut_with_value(root: &mut Value, visit: &mut impl FnMut(&mut Value)) {
+    match root {
+        Value::Object(map) => {
+            for child in map.values_mut() {
+                walk_objects_mut_with_value(child, visit);
+            }
+        }
+        Value::Array(items) => {
+            for item in items {
+                walk_objects_mut_with_value(item, visit);
+            }
+            return;
+        }
+        _ => return,
+    }
+    visit(root);
+}
+
+/// Visits every object node in `root`, depth-first (read-only).
+fn for_each_object(root: &Value, visit: &mut impl FnMut(&Map<String, Value>)) {
+    match root {
+        Value::Object(map) => {
+            for child in map.values() {
+                for_each_object(child, visit);
+            }
+            visit(map);
+        }
+        Value::Array(items) => {
+            for item in items {
+                for_each_object(item, visit);
+            }
+        }
+        _ => {}
+    }
+}
+
+/// Asserts that an internally tagged enum's branches are distinguishable by
+/// their `const` discriminators. Distinct variant tags hold by construction for
+/// a serde internally tagged enum; a collision would make the `anyOf` ambiguous
+/// to a strict validator, so it fails loudly in debug.
+#[cfg(debug_assertions)]
+fn debug_assert_distinct_branches(branches: &[Value]) {
+    let signatures: Vec<Vec<(String, Value)>> =
+        branches.iter().map(branch_const_signature).collect();
+    for (index, signature) in signatures.iter().enumerate() {
+        for other in &signatures[index + 1..] {
+            debug_assert_ne!(signature, other, "anyOf branches share a discriminator");
+        }
+    }
+}
+
+/// The sorted `(property, const)` pairs that distinguish a tagged-enum branch.
+#[cfg(debug_assertions)]
+fn branch_const_signature(branch: &Value) -> Vec<(String, Value)> {
+    let Some(properties) = branch.get(PROPERTIES_KEY).and_then(Value::as_object) else {
+        return Vec::new();
+    };
+    let mut signature: Vec<(String, Value)> = properties
+        .iter()
+        .filter_map(|(key, schema)| {
+            schema
+                .get(CONST_KEY)
+                .map(|value| (key.clone(), value.clone()))
+        })
+        .collect();
+    signature.sort_by(|left, right| left.0.cmp(&right.0));
+    signature
+}
+
+/// Asserts the transformed schema satisfies the subset's structural invariants:
+/// no combinator both subsets reject survives, and every object is closed (and,
+/// under `strict`, all-required).
+///
+/// This is the dialect's postcondition over the complex recursive rewrites,
+/// holding for every transformed schema rather than only the pipeline response
+/// types. A violation is a bug in a transform pass, not a runtime condition, so
+/// it fails loudly in debug and is inert in release. Keyword stripping is a
+/// flat removal with its own unit coverage, so it is not re-asserted here.
+fn debug_assert_dialect_invariants(root: &Value, strict: bool) {
+    for_each_object(root, &mut |map| {
+        debug_assert!(
+            !map.contains_key(ONE_OF_KEY),
+            "oneOf survived the dialect transform"
+        );
+        debug_assert!(
+            !map.contains_key(ALL_OF_KEY),
+            "allOf survived the dialect transform"
+        );
+        debug_assert!(
+            !(is_object_schema(map)
+                && map.get(ADDITIONAL_PROPERTIES_KEY) != Some(&Value::Bool(false))),
+            "object left open by the dialect transform"
+        );
+        if strict {
+            debug_assert!(
+                all_properties_required(map),
+                "object left with an optional property under the strict transform"
+            );
+        }
+    });
+}
+
+/// Whether every property of an object node appears in its `required` list. A
+/// node without `properties` is vacuously satisfied.
+fn all_properties_required(map: &Map<String, Value>) -> bool {
+    let Some(properties) = map.get(PROPERTIES_KEY).and_then(Value::as_object) else {
+        return true;
+    };
+    let required: Vec<&str> = map
+        .get(REQUIRED_KEY)
+        .and_then(Value::as_array)
+        .map(|values| values.iter().filter_map(Value::as_str).collect())
+        .unwrap_or_default();
+    properties
+        .keys()
+        .all(|key| required.contains(&key.as_str()))
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn apply_openai(schema: Value) -> Value {
+        apply_dialect(ProviderKind::OpenAi, schema)
+    }
+
+    fn apply_anthropic(schema: Value) -> Value {
+        apply_dialect(ProviderKind::Anthropic, schema)
+    }
+
+    #[test]
+    fn test_ollama_dialect_is_identity() {
+        let schema = json!({
+            "type": "object",
+            "properties": { "name": { "type": "string" } },
+            "oneOf": [{ "enum": ["a"], "type": "string" }],
+        });
+        assert_eq!(apply_dialect(ProviderKind::Ollama, schema.clone()), schema);
+    }
+
+    #[test]
+    fn test_openai_collapses_string_enum_oneof() {
+        let schema = json!({
+            "oneOf": [
+                { "description": "first", "enum": ["fact"], "type": "string" },
+                { "description": "second", "enum": ["heuristic"], "type": "string" },
+            ],
+        });
+        let result = apply_openai(schema);
+        assert_eq!(
+            result,
+            json!({ "type": "string", "enum": ["fact", "heuristic"] })
+        );
+    }
+
+    #[test]
+    fn test_openai_rewrites_tagged_enum_to_anyof_with_const() {
+        let schema = json!({
+            "description": "decision",
+            "oneOf": [
+                {
+                    "type": "object",
+                    "properties": { "decision": { "enum": ["created"], "type": "string" } },
+                    "required": ["decision"],
+                },
+                {
+                    "type": "object",
+                    "properties": {
+                        "decision": { "enum": ["duplicate"], "type": "string" },
+                        "matched": { "type": "string" },
+                    },
+                    "required": ["decision", "matched"],
+                },
+            ],
+        });
+        let result = apply_openai(schema);
+
+        assert!(result.get("oneOf").is_none());
+        let branches = result["anyOf"].as_array().expect("anyOf branches");
+        assert_eq!(branches.len(), 2);
+        assert_eq!(
+            branches[0]["properties"]["decision"]["const"],
+            json!("created")
+        );
+        assert_eq!(
+            branches[1]["properties"]["decision"]["const"],
+            json!("duplicate")
+        );
+        // Branches are closed and all-required after the strict passes.
+        assert_eq!(branches[0]["additionalProperties"], json!(false));
+        assert_eq!(branches[1]["required"], json!(["decision", "matched"]));
+    }
+
+    #[test]
+    fn test_openai_inlines_single_variant_enum() {
+        let schema = json!({
+            "description": "reference",
+            "oneOf": [{
+                "type": "object",
+                "properties": {
+                    "context_index": { "type": "integer", "format": "uint32", "minimum": 0.0 },
+                    "kind": { "enum": ["context_index"], "type": "string" },
+                },
+                "required": ["context_index", "kind"],
+            }],
+        });
+        let result = apply_openai(schema);
+
+        assert!(result.get("oneOf").is_none());
+        assert!(result.get("anyOf").is_none());
+        assert_eq!(result["type"], json!("object"));
+        assert_eq!(result["description"], json!("reference"));
+        assert_eq!(
+            result["properties"]["kind"]["const"],
+            json!("context_index")
+        );
+        // The numeric leaf keywords the subset rejects are stripped.
+        assert!(
+            result["properties"]["context_index"]
+                .get("format")
+                .is_none()
+        );
+        assert!(
+            result["properties"]["context_index"]
+                .get("minimum")
+                .is_none()
+        );
+        assert_eq!(result["additionalProperties"], json!(false));
+    }
+
+    #[test]
+    fn test_openai_unwraps_described_ref_and_strips_siblings() {
+        let schema = json!({
+            "type": "object",
+            "properties": {
+                "outcome": {
+                    "description": "the decision",
+                    "allOf": [{ "$ref": "#/definitions/Decision" }],
+                },
+            },
+            "required": ["outcome"],
+        });
+        let result = apply_openai(schema);
+        assert_eq!(
+            result["properties"]["outcome"],
+            json!({ "$ref": "#/definitions/Decision" })
+        );
+    }
+
+    #[test]
+    fn test_anthropic_keeps_ref_description() {
+        let schema = json!({
+            "type": "object",
+            "properties": {
+                "outcome": {
+                    "description": "the decision",
+                    "allOf": [{ "$ref": "#/definitions/Decision" }],
+                },
+            },
+            "required": ["outcome"],
+        });
+        let result = apply_anthropic(schema);
+        let outcome = &result["properties"]["outcome"];
+        assert_eq!(outcome["$ref"], json!("#/definitions/Decision"));
+        assert_eq!(outcome["description"], json!("the decision"));
+        assert!(outcome.get("allOf").is_none());
+    }
+
+    #[test]
+    fn test_openai_forces_required_with_nullable_optionals() {
+        let schema = json!({
+            "type": "object",
+            "properties": {
+                "content": { "type": "string" },
+                "justification": { "type": ["string", "null"] },
+                "hints": { "type": "array", "items": { "type": "string" } },
+            },
+            "required": ["content"],
+        });
+        let result = apply_openai(schema);
+
+        let required = result["required"].as_array().expect("required");
+        assert!(
+            ["content", "justification", "hints"]
+                .iter()
+                .all(|key| required.iter().any(|value| value == key))
+        );
+        // The already-nullable optional gains no duplicate null.
+        assert_eq!(
+            result["properties"]["justification"]["type"],
+            json!(["string", "null"])
+        );
+        // The plain optional scalar becomes a nullable union.
+        // The optional array is required but not made nullable.
+        assert_eq!(result["properties"]["hints"]["type"], json!("array"));
+    }
+
+    #[test]
+    fn test_openai_makes_plain_optional_scalar_nullable() {
+        let schema = json!({
+            "type": "object",
+            "properties": { "note": { "type": "string" } },
+            "required": [],
+        });
+        let result = apply_openai(schema);
+        assert_eq!(
+            result["properties"]["note"]["type"],
+            json!(["string", "null"])
+        );
+        assert_eq!(result["required"], json!(["note"]));
+    }
+
+    #[test]
+    fn test_anthropic_leaves_optionals_omitted_from_required() {
+        let schema = json!({
+            "type": "object",
+            "properties": {
+                "content": { "type": "string" },
+                "note": { "type": ["string", "null"] },
+            },
+            "required": ["content"],
+        });
+        let result = apply_anthropic(schema);
+        assert_eq!(result["required"], json!(["content"]));
+        assert_eq!(result["additionalProperties"], json!(false));
+        // The optional scalar is untouched (not forced nullable, already is).
+        assert_eq!(
+            result["properties"]["note"]["type"],
+            json!(["string", "null"])
+        );
+    }
+
+    #[test]
+    fn test_anthropic_collapses_string_enum_and_closes_objects() {
+        let schema = json!({
+            "type": "object",
+            "properties": {
+                "kind": {
+                    "oneOf": [
+                        { "enum": ["fact"], "type": "string" },
+                        { "enum": ["heuristic"], "type": "string" },
+                    ],
+                },
+            },
+            "required": ["kind"],
+        });
+        let result = apply_anthropic(schema);
+        assert_eq!(
+            result["properties"]["kind"],
+            json!({ "type": "string", "enum": ["fact", "heuristic"] })
+        );
+        assert_eq!(result["additionalProperties"], json!(false));
+    }
+
+    #[test]
+    fn test_strips_schema_meta_keyword() {
+        let schema = json!({
+            "$schema": "http://json-schema.org/draft-07/schema#",
+            "type": "object",
+            "properties": { "name": { "type": "string" } },
+            "required": ["name"],
+        });
+        assert!(apply_openai(schema.clone()).get("$schema").is_none());
+        assert!(apply_anthropic(schema).get("$schema").is_none());
+    }
+
+    #[test]
+    fn test_openai_strips_default_anthropic_keeps_it() {
+        let schema = json!({
+            "type": "object",
+            "properties": {
+                "hints": { "type": "array", "items": { "type": "string" }, "default": [] },
+            },
+            "required": [],
+        });
+        assert!(
+            apply_openai(schema.clone())["properties"]["hints"]
+                .get("default")
+                .is_none()
+        );
+        assert_eq!(
+            apply_anthropic(schema)["properties"]["hints"]["default"],
+            json!([])
+        );
+    }
+
+    #[test]
+    fn test_walks_into_definitions() {
+        let schema = json!({
+            "type": "object",
+            "properties": { "ref": { "$ref": "#/definitions/Inner" } },
+            "required": ["ref"],
+            "definitions": {
+                "Inner": {
+                    "type": "object",
+                    "properties": { "n": { "type": "integer", "format": "uint32", "minimum": 0.0 } },
+                    "required": ["n"],
+                },
+            },
+        });
+        let result = apply_openai(schema);
+        let inner = &result["definitions"]["Inner"];
+        assert_eq!(inner["additionalProperties"], json!(false));
+        assert!(inner["properties"]["n"].get("format").is_none());
+        assert!(inner["properties"]["n"].get("minimum").is_none());
+    }
+
+    #[test]
+    fn test_openai_collapses_single_variant_string_enum() {
+        // A unit enum with one variant still emits a one-branch `oneOf`.
+        let schema = json!({
+            "oneOf": [{ "description": "only", "enum": ["derived_from"], "type": "string" }],
+        });
+        assert_eq!(
+            apply_openai(schema),
+            json!({ "type": "string", "enum": ["derived_from"] })
+        );
+    }
+
+    #[test]
+    fn test_openai_rewrites_enum_nested_in_tagged_branch() {
+        // A tagged-enum branch may itself contain a string-enum field; the
+        // depth-first walk rewrites the inner `oneOf` before the outer one.
+        let schema = json!({
+            "oneOf": [{
+                "type": "object",
+                "properties": {
+                    "kind": { "enum": ["a"], "type": "string" },
+                    "relation": {
+                        "oneOf": [
+                            { "enum": ["supports"], "type": "string" },
+                            { "enum": ["contradicts"], "type": "string" },
+                        ],
+                    },
+                },
+                "required": ["kind", "relation"],
+            }],
+        });
+        let result = apply_openai(schema);
+        assert!(result.get("oneOf").is_none());
+        assert_eq!(result["properties"]["kind"]["const"], json!("a"));
+        assert_eq!(
+            result["properties"]["relation"],
+            json!({ "type": "string", "enum": ["supports", "contradicts"] })
+        );
+    }
+
+    /// A composite resembling the real draft-07 output: definitions, a described
+    /// `$ref`, a tagged enum, a string enum, an optional array, and a numeric
+    /// leaf.
+    fn representative_schema() -> Value {
+        json!({
+            "$schema": "http://json-schema.org/draft-07/schema#",
+            "type": "object",
+            "title": "Output",
+            "properties": {
+                "outcome": {
+                    "description": "the decision",
+                    "allOf": [{ "$ref": "#/definitions/Decision" }],
+                },
+                "hints": { "type": "array", "items": { "type": "string" }, "default": [] },
+                "note": { "type": ["string", "null"], "default": null },
+            },
+            "required": ["outcome"],
+            "definitions": {
+                "Decision": {
+                    "description": "decision",
+                    "oneOf": [
+                        {
+                            "type": "object",
+                            "properties": { "decision": { "enum": ["created"], "type": "string" } },
+                            "required": ["decision"],
+                        },
+                        {
+                            "type": "object",
+                            "properties": {
+                                "decision": { "enum": ["duplicate"], "type": "string" },
+                                "index": { "type": "integer", "format": "uint32", "minimum": 0.0 },
+                            },
+                            "required": ["decision", "index"],
+                        },
+                    ],
+                },
+                "Kind": {
+                    "oneOf": [
+                        { "enum": ["fact"], "type": "string" },
+                        { "enum": ["heuristic"], "type": "string" },
+                    ],
+                },
+            },
+        })
+    }
+
+    #[test]
+    fn test_openai_dialect_is_idempotent() {
+        let once = apply_openai(representative_schema());
+        let twice = apply_openai(once.clone());
+        assert_eq!(once, twice);
+    }
+
+    #[test]
+    fn test_anthropic_dialect_is_idempotent() {
+        let once = apply_anthropic(representative_schema());
+        let twice = apply_anthropic(once.clone());
+        assert_eq!(once, twice);
+    }
+
+    #[test]
+    fn test_openai_leaves_no_combinators_on_composite() {
+        let result = apply_openai(representative_schema());
+        for_each_object(&result, &mut |map| {
+            assert!(!map.contains_key(ONE_OF_KEY), "oneOf survived");
+            assert!(!map.contains_key(ALL_OF_KEY), "allOf survived");
+        });
+    }
+}

--- a/crates/tribal-inference/src/schema_dialect.rs
+++ b/crates/tribal-inference/src/schema_dialect.rs
@@ -101,24 +101,22 @@ pub fn apply_dialect(provider: ProviderKind, schema: Value) -> Value {
 /// Normalises a schema into the `OpenAI` strict structured-output subset. See
 /// the module-level Provenance note for the subset reference.
 fn apply_openai_strict(mut schema: Value) -> Value {
-    strip_unsupported_keywords(&mut schema, true);
+    strip_unsupported_keywords(&mut schema);
     unwrap_described_refs(&mut schema);
     strip_ref_siblings(&mut schema);
     rewrite_enums(&mut schema);
     force_required_and_nullable(&mut schema);
     close_all_objects(&mut schema);
-    debug_assert_dialect_invariants(&schema, true);
     schema
 }
 
 /// Normalises a schema into the `Anthropic` structured-output subset. See the
 /// module-level Provenance note for the subset reference.
 fn apply_anthropic_subset(mut schema: Value) -> Value {
-    strip_unsupported_keywords(&mut schema, false);
+    strip_unsupported_keywords(&mut schema);
     unwrap_described_refs(&mut schema);
     rewrite_enums(&mut schema);
     close_all_objects(&mut schema);
-    debug_assert_dialect_invariants(&schema, false);
     schema
 }
 
@@ -126,26 +124,25 @@ fn apply_anthropic_subset(mut schema: Value) -> Value {
 // Transform passes
 // ---------------------------------------------------------------------------
 
-/// Removes the meta declaration and the validation leaf keywords the subsets
-/// reject. `remove_default` also drops `default`, which the strict subset
-/// rejects; the looser subset accepts it, so it is retained there.
-fn strip_unsupported_keywords(root: &mut Value, remove_default: bool) {
+/// Removes the meta declaration and the keywords neither subset needs. `default`
+/// is dropped for both subsets: it is advisory metadata a grammar-constrained
+/// decode never consumes, so stripping it removes a provider-acceptance
+/// assumption at no functional cost.
+fn strip_unsupported_keywords(root: &mut Value) {
     walk_objects_mut(root, &mut |map| {
         map.remove(SCHEMA_KEY);
+        map.remove(DEFAULT_KEY);
         for keyword in FORBIDDEN_VALIDATION_KEYWORDS {
             map.remove(*keyword);
         }
         // `format` is rejected on numeric leaves (e.g. `uint32`); string
-        // formats stay, so the removal is scoped by type.
+        // formats are accepted, so the removal is scoped by type.
         let is_numeric = matches!(
             map.get(TYPE_KEY).and_then(Value::as_str),
             Some("integer" | "number")
         );
         if is_numeric {
             map.remove(FORMAT_KEY);
-        }
-        if remove_default {
-            map.remove(DEFAULT_KEY);
         }
     });
 }
@@ -332,23 +329,38 @@ fn force_required_and_nullable(root: &mut Value) {
     });
 }
 
-/// Adds `null` to a property's type union. Idempotent for an already-nullable
-/// scalar; a no-op for arrays (required-but-empty satisfies the field).
+/// Widens a property schema to also accept `null`, expressing the original
+/// field's optionality under the all-required strict subset.
+///
+/// Arrays are left unchanged (required-but-empty satisfies the field). A `$ref`
+/// or `const` cannot carry an inline null, so it is wrapped in an `anyOf` with a
+/// null branch; an `enum` widens both its type union and its value set; a plain
+/// typed leaf gains `null` in its type union. Idempotent for an already-nullable
+/// scalar.
 fn make_nullable(schema: &mut Value) {
-    let Some(map) = schema.as_object_mut() else {
+    let Some(map) = schema.as_object() else {
         return;
     };
     if map.get(TYPE_KEY).and_then(Value::as_str) == Some(ARRAY_TYPE) {
         return;
     }
-    if map.contains_key(REF_KEY) {
-        // No optional `$ref` field exists in the pipeline response types; a
-        // nullable reference would need an `anyOf` with a null branch.
-        debug_assert!(
-            false,
-            "optional $ref field is not expected under the strict subset"
-        );
+    // A reference or a const value has no place for an inline null, so wrap the
+    // whole node in an `anyOf` with a null branch.
+    if map.contains_key(REF_KEY) || map.contains_key(CONST_KEY) {
+        let original = schema.take();
+        *schema = anyof_with_null(original);
         return;
+    }
+
+    let Some(map) = schema.as_object_mut() else {
+        return;
+    };
+    // An enum constrains the value set, so `null` must join both the type union
+    // and the enum.
+    if let Some(Value::Array(values)) = map.get_mut(ENUM_KEY)
+        && !values.iter().any(Value::is_null)
+    {
+        values.push(Value::Null);
     }
     match map.get(TYPE_KEY).cloned() {
         Some(Value::String(scalar)) => {
@@ -360,6 +372,19 @@ fn make_nullable(schema: &mut Value) {
         }
         _ => {}
     }
+}
+
+/// Wraps a schema in `anyOf: [<schema>, { "type": "null" }]`, the nullable form
+/// for a node that cannot carry an inline null type (a `$ref` or a `const`).
+fn anyof_with_null(schema: Value) -> Value {
+    let mut null_branch = Map::new();
+    null_branch.insert(TYPE_KEY.to_owned(), Value::String(NULL_TYPE.to_owned()));
+    let mut wrapper = Map::new();
+    wrapper.insert(
+        ANY_OF_KEY.to_owned(),
+        Value::Array(vec![schema, Value::Object(null_branch)]),
+    );
+    Value::Object(wrapper)
 }
 
 /// Sets `additionalProperties: false` on every object schema that does not
@@ -425,6 +450,7 @@ fn walk_objects_mut_with_value(root: &mut Value, visit: &mut impl FnMut(&mut Val
 }
 
 /// Visits every object node in `root`, depth-first (read-only).
+#[cfg(any(test, feature = "test-helpers"))]
 fn for_each_object(root: &Value, visit: &mut impl FnMut(&Map<String, Value>)) {
     match root {
         Value::Object(map) => {
@@ -475,41 +501,68 @@ fn branch_const_signature(branch: &Value) -> Vec<(String, Value)> {
     signature
 }
 
-/// Asserts the transformed schema satisfies the subset's structural invariants:
-/// no combinator both subsets reject survives, and every object is closed (and,
-/// under `strict`, all-required).
+/// Combinators neither provider subset accepts on a transformed schema.
+#[cfg(any(test, feature = "test-helpers"))]
+const FORBIDDEN_COMBINATORS: &[&str] = &[ONE_OF_KEY, ALL_OF_KEY, "if", "then", "else", "not"];
+
+/// Asserts a transformed schema satisfies its provider subset's invariants: no
+/// forbidden combinator or leaf keyword survives, the meta and `default`
+/// keywords are stripped, numeric leaves carry no `format`, and every object is
+/// closed. `strict` adds the OpenAI-only requirement that every object lists all
+/// its properties as required.
 ///
-/// This is the dialect's postcondition over the complex recursive rewrites,
-/// holding for every transformed schema rather than only the pipeline response
-/// types. A violation is a bug in a transform pass, not a runtime condition, so
-/// it fails loudly in debug and is inert in release. Keyword stripping is a
-/// flat removal with its own unit coverage, so it is not re-asserted here.
-fn debug_assert_dialect_invariants(root: &Value, strict: bool) {
-    for_each_object(root, &mut |map| {
-        debug_assert!(
-            !map.contains_key(ONE_OF_KEY),
-            "oneOf survived the dialect transform"
-        );
-        debug_assert!(
-            !map.contains_key(ALL_OF_KEY),
-            "allOf survived the dialect transform"
-        );
-        debug_assert!(
-            !(is_object_schema(map)
-                && map.get(ADDITIONAL_PROPERTIES_KEY) != Some(&Value::Bool(false))),
-            "object left open by the dialect transform"
-        );
-        if strict {
-            debug_assert!(
-                all_properties_required(map),
-                "object left with an optional property under the strict transform"
+/// This is the single source of subset-invariant truth — reused by the dialect's
+/// own tests and by cross-crate snapshot tests — and it checks against the same
+/// keyword lists the transform strips by, so the assertion cannot drift from the
+/// transform.
+///
+/// # Panics
+///
+/// Panics if `schema` violates any invariant of the selected subset.
+#[cfg(any(test, feature = "test-helpers"))]
+pub fn assert_dialect_invariants(schema: &Value, strict: bool) {
+    for_each_object(schema, &mut |map| {
+        for combinator in FORBIDDEN_COMBINATORS {
+            assert!(
+                !map.contains_key(*combinator),
+                "combinator `{combinator}` survived: {map:?}"
             );
         }
+        assert!(!map.contains_key(SCHEMA_KEY), "$schema survived: {map:?}");
+        assert!(!map.contains_key(DEFAULT_KEY), "default survived: {map:?}");
+        for keyword in FORBIDDEN_VALIDATION_KEYWORDS {
+            assert!(
+                !map.contains_key(*keyword),
+                "leaf keyword `{keyword}` survived: {map:?}"
+            );
+        }
+        let is_numeric = matches!(
+            map.get(TYPE_KEY).and_then(Value::as_str),
+            Some("integer" | "number")
+        );
+        assert!(
+            !(is_numeric && map.contains_key(FORMAT_KEY)),
+            "numeric format survived: {map:?}"
+        );
+
+        if !is_object_schema(map) {
+            return;
+        }
+        assert_eq!(
+            map.get(ADDITIONAL_PROPERTIES_KEY),
+            Some(&Value::Bool(false)),
+            "object not closed: {map:?}"
+        );
+        assert!(
+            !strict || all_properties_required(map),
+            "object left with an optional property under the strict subset: {map:?}"
+        );
     });
 }
 
 /// Whether every property of an object node appears in its `required` list. A
 /// node without `properties` is vacuously satisfied.
+#[cfg(any(test, feature = "test-helpers"))]
 fn all_properties_required(map: &Map<String, Value>) -> bool {
     let Some(properties) = map.get(PROPERTIES_KEY).and_then(Value::as_object) else {
         return true;
@@ -723,6 +776,57 @@ mod tests {
     }
 
     #[test]
+    fn test_openai_wraps_optional_ref_as_nullable_anyof() {
+        // A described `$ref` field is unwrapped, stripped to a bare `$ref`, then
+        // — being optional — forced required and wrapped in a nullable anyOf.
+        let schema = json!({
+            "type": "object",
+            "properties": {
+                "ref_field": {
+                    "description": "an optional reference",
+                    "allOf": [{ "$ref": "#/definitions/Inner" }],
+                },
+            },
+            "required": [],
+            "definitions": {
+                "Inner": {
+                    "type": "object",
+                    "properties": { "n": { "type": "string" } },
+                    "required": ["n"],
+                },
+            },
+        });
+        let result = apply_openai(schema);
+        assert_eq!(result["required"], json!(["ref_field"]));
+        let branches = result["properties"]["ref_field"]["anyOf"]
+            .as_array()
+            .expect("optional $ref wrapped in a nullable anyOf");
+        assert!(branches.iter().any(|b| b.get("$ref").is_some()));
+        assert!(branches.iter().any(|b| b["type"] == json!("null")));
+    }
+
+    #[test]
+    fn test_openai_widens_optional_enum_with_null() {
+        // An optional inline enum is forced required and widened so `null` is
+        // accepted in both the type union and the enum set.
+        let schema = json!({
+            "type": "object",
+            "properties": { "kind": { "type": "string", "enum": ["a", "b"] } },
+            "required": [],
+        });
+        let result = apply_openai(schema);
+        assert_eq!(result["required"], json!(["kind"]));
+        assert_eq!(
+            result["properties"]["kind"]["type"],
+            json!(["string", "null"])
+        );
+        assert_eq!(
+            result["properties"]["kind"]["enum"],
+            json!(["a", "b", null])
+        );
+    }
+
+    #[test]
     fn test_anthropic_leaves_optionals_omitted_from_required() {
         let schema = json!({
             "type": "object",
@@ -777,7 +881,10 @@ mod tests {
     }
 
     #[test]
-    fn test_openai_strips_default_anthropic_keeps_it() {
+    fn test_both_subsets_strip_default() {
+        // `default` is advisory metadata a grammar-constrained decode never
+        // consumes, so both subsets strip it rather than risk a provider that
+        // rejects it.
         let schema = json!({
             "type": "object",
             "properties": {
@@ -790,9 +897,10 @@ mod tests {
                 .get("default")
                 .is_none()
         );
-        assert_eq!(
-            apply_anthropic(schema)["properties"]["hints"]["default"],
-            json!([])
+        assert!(
+            apply_anthropic(schema)["properties"]["hints"]
+                .get("default")
+                .is_none()
         );
     }
 
@@ -918,11 +1026,11 @@ mod tests {
     }
 
     #[test]
-    fn test_openai_leaves_no_combinators_on_composite() {
-        let result = apply_openai(representative_schema());
-        for_each_object(&result, &mut |map| {
-            assert!(!map.contains_key(ONE_OF_KEY), "oneOf survived");
-            assert!(!map.contains_key(ALL_OF_KEY), "allOf survived");
-        });
+    fn test_dialect_invariants_hold_on_composite() {
+        // The reusable assertion run over the composite covers the full subset
+        // invariant set (combinators, leaf keywords, closure, strict-required)
+        // for both dialects.
+        assert_dialect_invariants(&apply_openai(representative_schema()), true);
+        assert_dialect_invariants(&apply_anthropic(representative_schema()), false);
     }
 }

--- a/crates/tribal-worker/Cargo.toml
+++ b/crates/tribal-worker/Cargo.toml
@@ -29,6 +29,7 @@ tribal-inference.workspace = true
 tribal-telemetry.workspace = true
 
 [dev-dependencies]
+jsonschema.workspace = true
 tokio = { workspace = true, features = ["test-util"] }
 
 tribal-test-utils.workspace = true

--- a/crates/tribal-worker/Cargo.toml
+++ b/crates/tribal-worker/Cargo.toml
@@ -32,4 +32,5 @@ tribal-telemetry.workspace = true
 jsonschema.workspace = true
 tokio = { workspace = true, features = ["test-util"] }
 
+tribal-inference = { workspace = true, features = ["test-helpers"] }
 tribal-test-utils.workspace = true

--- a/crates/tribal-worker/src/parsing.rs
+++ b/crates/tribal-worker/src/parsing.rs
@@ -4,6 +4,9 @@ mod extraction;
 mod relation;
 mod triage;
 
+#[cfg(test)]
+mod schema_dialect_snapshots;
+
 pub(crate) use extraction::{ExtractionOutput, parse_extraction_response};
 #[cfg(test)]
 pub(crate) use relation::IngestionRelationKind;

--- a/crates/tribal-worker/src/parsing/schema_dialect_snapshots.rs
+++ b/crates/tribal-worker/src/parsing/schema_dialect_snapshots.rs
@@ -1,0 +1,173 @@
+//! Coverage for the per-provider schema dialects applied to the pipeline
+//! response schemas.
+//!
+//! The canonical `schemars` schema for each response type is transformed
+//! through [`apply_dialect`] and pinned as a golden snapshot — the reviewable
+//! record of what each provider's endpoint actually receives. The dialect's own
+//! debug-time postcondition verifies the subset invariants on every transform
+//! (these tests run in debug, so they exercise it on the real schemas), so this
+//! module covers only what the dialect cannot: pinning the shape, validating a
+//! correct instance with a real validator, and the cross-crate check that the
+//! tagged response types keep their discriminator.
+
+use jsonschema::Validator;
+use schemars::JsonSchema;
+use serde_json::{Value, json};
+use tribal_domain::ProviderKind;
+use tribal_inference::apply_dialect;
+use tribal_test_utils::assert_json_snapshot;
+
+use super::{ExtractionOutput, RelationOutput, TriageClassification};
+
+/// The canonical `schemars` schema for `T` as a JSON value.
+fn canonical_schema<T: JsonSchema>() -> Value {
+    serde_json::to_value(schemars::schema_for!(T)).expect("schema serialises")
+}
+
+/// A triage instance the strict and subset schemas must both accept.
+fn created_triage_instance() -> Value {
+    json!({ "outcome": { "decision": "created" }, "similar_item_decisions": [] })
+}
+
+// ---------------------------------------------------------------------------
+// OpenAI dialect snapshots
+// ---------------------------------------------------------------------------
+
+#[test]
+fn test_openai_dialect_extraction_snapshot() {
+    let schema = apply_dialect(ProviderKind::OpenAi, canonical_schema::<ExtractionOutput>());
+    assert_json_snapshot!(
+        &schema,
+        "src/parsing/snapshots/dialect/openai/extraction_output.json"
+    );
+}
+
+#[test]
+fn test_openai_dialect_triage_snapshot() {
+    let schema = apply_dialect(
+        ProviderKind::OpenAi,
+        canonical_schema::<TriageClassification>(),
+    );
+    assert_json_snapshot!(
+        &schema,
+        "src/parsing/snapshots/dialect/openai/triage_classification.json"
+    );
+}
+
+#[test]
+fn test_openai_dialect_relation_snapshot() {
+    let schema = apply_dialect(ProviderKind::OpenAi, canonical_schema::<RelationOutput>());
+    assert_json_snapshot!(
+        &schema,
+        "src/parsing/snapshots/dialect/openai/relation_output.json"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Anthropic dialect snapshots
+// ---------------------------------------------------------------------------
+
+#[test]
+fn test_anthropic_dialect_extraction_snapshot() {
+    let schema = apply_dialect(
+        ProviderKind::Anthropic,
+        canonical_schema::<ExtractionOutput>(),
+    );
+    assert_json_snapshot!(
+        &schema,
+        "src/parsing/snapshots/dialect/anthropic/extraction_output.json"
+    );
+}
+
+#[test]
+fn test_anthropic_dialect_triage_snapshot() {
+    let schema = apply_dialect(
+        ProviderKind::Anthropic,
+        canonical_schema::<TriageClassification>(),
+    );
+    assert_json_snapshot!(
+        &schema,
+        "src/parsing/snapshots/dialect/anthropic/triage_classification.json"
+    );
+}
+
+#[test]
+fn test_anthropic_dialect_relation_snapshot() {
+    let schema = apply_dialect(
+        ProviderKind::Anthropic,
+        canonical_schema::<RelationOutput>(),
+    );
+    assert_json_snapshot!(
+        &schema,
+        "src/parsing/snapshots/dialect/anthropic/relation_output.json"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Instance validation
+// ---------------------------------------------------------------------------
+
+#[test]
+fn test_openai_triage_schema_validates_created_instance() {
+    let schema = apply_dialect(
+        ProviderKind::OpenAi,
+        canonical_schema::<TriageClassification>(),
+    );
+    let validator = Validator::new(&schema).expect("transformed schema compiles");
+    assert!(
+        validator.is_valid(&created_triage_instance()),
+        "the strict triage schema must accept a correct created instance"
+    );
+}
+
+#[test]
+fn test_anthropic_triage_schema_validates_created_instance() {
+    let schema = apply_dialect(
+        ProviderKind::Anthropic,
+        canonical_schema::<TriageClassification>(),
+    );
+    let validator = Validator::new(&schema).expect("transformed schema compiles");
+    assert!(
+        validator.is_valid(&created_triage_instance()),
+        "the subset triage schema must accept a correct created instance"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Tag retention
+// ---------------------------------------------------------------------------
+
+#[test]
+fn test_openai_triage_retains_internal_tags() {
+    let schema = apply_dialect(
+        ProviderKind::OpenAi,
+        canonical_schema::<TriageClassification>(),
+    );
+
+    // The multi-variant tagged enum keeps its discriminator: each branch is an
+    // object with a const `decision` rather than being flattened.
+    let branches = schema["definitions"]["TriageDecision"]["anyOf"]
+        .as_array()
+        .expect("TriageDecision rewritten to anyOf branches");
+    assert!(
+        branches
+            .iter()
+            .all(|branch| branch["properties"]["decision"].get("const").is_some()),
+        "every branch must carry a const `decision` discriminator"
+    );
+
+    // The single-variant tagged enum is inlined but keeps its const `kind`.
+    assert_eq!(
+        schema["definitions"]["TriageItemReference"]["properties"]["kind"]["const"],
+        json!("context_index")
+    );
+}
+
+#[test]
+fn test_openai_relation_retains_target_kind_tag() {
+    let schema = apply_dialect(ProviderKind::OpenAi, canonical_schema::<RelationOutput>());
+    assert_eq!(
+        schema["definitions"]["RelationTarget"]["properties"]["kind"]["const"],
+        json!("context_index")
+    );
+}

--- a/crates/tribal-worker/src/parsing/schema_dialect_snapshots.rs
+++ b/crates/tribal-worker/src/parsing/schema_dialect_snapshots.rs
@@ -1,20 +1,19 @@
 //! Coverage for the per-provider schema dialects applied to the pipeline
 //! response schemas.
 //!
-//! The canonical `schemars` schema for each response type is transformed
-//! through [`apply_dialect`] and pinned as a golden snapshot — the reviewable
-//! record of what each provider's endpoint actually receives. The dialect's own
-//! debug-time postcondition verifies the subset invariants on every transform
-//! (these tests run in debug, so they exercise it on the real schemas), so this
-//! module covers only what the dialect cannot: pinning the shape, validating a
-//! correct instance with a real validator, and the cross-crate check that the
-//! tagged response types keep their discriminator.
+//! The canonical `schemars` schema for each response type is transformed through
+//! [`apply_dialect`], pinned as a golden snapshot, and checked against its
+//! provider subset by [`assert_dialect_invariants`] — the dialect crate's own
+//! reusable assertion, so the invariant list cannot drift from the transform. A
+//! `jsonschema` validator then confirms the strict triage schema accepts a
+//! correct instance and rejects the off-shape that motivated the change, and a
+//! structural check confirms the tagged response types keep their discriminator.
 
 use jsonschema::Validator;
 use schemars::JsonSchema;
 use serde_json::{Value, json};
 use tribal_domain::ProviderKind;
-use tribal_inference::apply_dialect;
+use tribal_inference::{apply_dialect, assert_dialect_invariants};
 use tribal_test_utils::assert_json_snapshot;
 
 use super::{ExtractionOutput, RelationOutput, TriageClassification};
@@ -36,6 +35,7 @@ fn created_triage_instance() -> Value {
 #[test]
 fn test_openai_dialect_extraction_snapshot() {
     let schema = apply_dialect(ProviderKind::OpenAi, canonical_schema::<ExtractionOutput>());
+    assert_dialect_invariants(&schema, true);
     assert_json_snapshot!(
         &schema,
         "src/parsing/snapshots/dialect/openai/extraction_output.json"
@@ -48,6 +48,7 @@ fn test_openai_dialect_triage_snapshot() {
         ProviderKind::OpenAi,
         canonical_schema::<TriageClassification>(),
     );
+    assert_dialect_invariants(&schema, true);
     assert_json_snapshot!(
         &schema,
         "src/parsing/snapshots/dialect/openai/triage_classification.json"
@@ -57,6 +58,7 @@ fn test_openai_dialect_triage_snapshot() {
 #[test]
 fn test_openai_dialect_relation_snapshot() {
     let schema = apply_dialect(ProviderKind::OpenAi, canonical_schema::<RelationOutput>());
+    assert_dialect_invariants(&schema, true);
     assert_json_snapshot!(
         &schema,
         "src/parsing/snapshots/dialect/openai/relation_output.json"
@@ -73,6 +75,7 @@ fn test_anthropic_dialect_extraction_snapshot() {
         ProviderKind::Anthropic,
         canonical_schema::<ExtractionOutput>(),
     );
+    assert_dialect_invariants(&schema, false);
     assert_json_snapshot!(
         &schema,
         "src/parsing/snapshots/dialect/anthropic/extraction_output.json"
@@ -85,6 +88,7 @@ fn test_anthropic_dialect_triage_snapshot() {
         ProviderKind::Anthropic,
         canonical_schema::<TriageClassification>(),
     );
+    assert_dialect_invariants(&schema, false);
     assert_json_snapshot!(
         &schema,
         "src/parsing/snapshots/dialect/anthropic/triage_classification.json"
@@ -97,6 +101,7 @@ fn test_anthropic_dialect_relation_snapshot() {
         ProviderKind::Anthropic,
         canonical_schema::<RelationOutput>(),
     );
+    assert_dialect_invariants(&schema, false);
     assert_json_snapshot!(
         &schema,
         "src/parsing/snapshots/dialect/anthropic/relation_output.json"
@@ -130,6 +135,22 @@ fn test_anthropic_triage_schema_validates_created_instance() {
     assert!(
         validator.is_valid(&created_triage_instance()),
         "the subset triage schema must accept a correct created instance"
+    );
+}
+
+#[test]
+fn test_openai_triage_schema_rejects_bare_string_outcome() {
+    // The off-shape that originally dead-lettered: a bare-string `outcome`
+    // instead of the internally tagged object. The strict schema must reject it.
+    let schema = apply_dialect(
+        ProviderKind::OpenAi,
+        canonical_schema::<TriageClassification>(),
+    );
+    let validator = Validator::new(&schema).expect("transformed schema compiles");
+    let off_shape = json!({ "outcome": "created", "similar_item_decisions": [] });
+    assert!(
+        !validator.is_valid(&off_shape),
+        "the strict triage schema must reject a bare-string outcome"
     );
 }
 

--- a/crates/tribal-worker/src/parsing/snapshots/dialect/anthropic/extraction_output.json
+++ b/crates/tribal-worker/src/parsing/snapshots/dialect/anthropic/extraction_output.json
@@ -1,0 +1,131 @@
+{
+  "additionalProperties": false,
+  "definitions": {
+    "Candidate": {
+      "additionalProperties": false,
+      "description": "A knowledge item candidate extracted from raw input.\n\nCandidates are the primary output of the extraction stage. Each candidate may progress through triage to become a committed knowledge item, or be discarded as a duplicate.",
+      "properties": {
+        "content": {
+          "description": "The knowledge content.",
+          "type": "string"
+        },
+        "kind": {
+          "$ref": "#/definitions/KnowledgeKind",
+          "description": "Classification of the candidate knowledge."
+        },
+        "suggested_references": {
+          "default": [],
+          "description": "Optional external references.",
+          "items": {
+            "$ref": "#/definitions/SuggestedReference"
+          },
+          "type": "array"
+        },
+        "suggested_tags": {
+          "description": "Suggested categorisation tags. Always expected from the extraction prompt — an absent field is a parse error.",
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        }
+      },
+      "required": [
+        "content",
+        "kind",
+        "suggested_tags"
+      ],
+      "type": "object"
+    },
+    "KnowledgeKind": {
+      "description": "The classification of a knowledge item.",
+      "enum": [
+        "fact",
+        "heuristic",
+        "procedure",
+        "decision_record"
+      ],
+      "type": "string"
+    },
+    "RelationHint": {
+      "additionalProperties": false,
+      "description": "An intra-batch relation hint between two candidates by index.\n\nEmitted by the extraction agent to indicate that one candidate is derived from another within the same batch.",
+      "properties": {
+        "hint_type": {
+          "$ref": "#/definitions/RelationHintType",
+          "description": "The type of relation hinted at."
+        },
+        "source_index": {
+          "description": "Index of the source candidate in the batch.",
+          "type": "integer"
+        },
+        "target_index": {
+          "description": "Index of the target candidate in the batch.",
+          "type": "integer"
+        }
+      },
+      "required": [
+        "hint_type",
+        "source_index",
+        "target_index"
+      ],
+      "type": "object"
+    },
+    "RelationHintType": {
+      "description": "The type of an intra-batch relation hint emitted by the extraction agent.\n\nCurrently a single variant; the enum exists as an extension point for future hint types.",
+      "enum": [
+        "derived_from"
+      ],
+      "type": "string"
+    },
+    "SuggestedReference": {
+      "additionalProperties": false,
+      "description": "A suggested external reference for a candidate.\n\nThe `reference_type` is a free string — the LLM may produce values outside the expected set. Validation and mapping to [`ReferenceKind`] happens during triage, not extraction.\n\n[`ReferenceKind`]: crate::ReferenceKind",
+      "properties": {
+        "description": {
+          "default": null,
+          "description": "Optional human-readable context.",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "reference_type": {
+          "description": "Free-form reference type (e.g. `\"url\"`, `\"file_path\"`).",
+          "type": "string"
+        },
+        "value": {
+          "description": "The reference value.",
+          "type": "string"
+        }
+      },
+      "required": [
+        "reference_type",
+        "value"
+      ],
+      "type": "object"
+    }
+  },
+  "description": "Extracted knowledge items and optional intra-batch relationship hints.",
+  "properties": {
+    "candidates": {
+      "description": "Knowledge items extracted from the input. Each candidate should be atomic (one claim per item) and self-contained. Return an empty array if the input contains no extractable knowledge.",
+      "items": {
+        "$ref": "#/definitions/Candidate"
+      },
+      "type": "array"
+    },
+    "relation_hints": {
+      "default": [],
+      "description": "Derivation relationships between candidates in this batch. Only include when one candidate is genuinely derived from another. Optional — omit or return an empty array when no intra-batch relationships exist.",
+      "items": {
+        "$ref": "#/definitions/RelationHint"
+      },
+      "type": "array"
+    }
+  },
+  "required": [
+    "candidates"
+  ],
+  "title": "ExtractionOutput",
+  "type": "object"
+}

--- a/crates/tribal-worker/src/parsing/snapshots/dialect/anthropic/extraction_output.json
+++ b/crates/tribal-worker/src/parsing/snapshots/dialect/anthropic/extraction_output.json
@@ -14,7 +14,6 @@
           "description": "Classification of the candidate knowledge."
         },
         "suggested_references": {
-          "default": [],
           "description": "Optional external references.",
           "items": {
             "$ref": "#/definitions/SuggestedReference"
@@ -82,7 +81,6 @@
       "description": "A suggested external reference for a candidate.\n\nThe `reference_type` is a free string — the LLM may produce values outside the expected set. Validation and mapping to [`ReferenceKind`] happens during triage, not extraction.\n\n[`ReferenceKind`]: crate::ReferenceKind",
       "properties": {
         "description": {
-          "default": null,
           "description": "Optional human-readable context.",
           "type": [
             "string",
@@ -115,7 +113,6 @@
       "type": "array"
     },
     "relation_hints": {
-      "default": [],
       "description": "Derivation relationships between candidates in this batch. Only include when one candidate is genuinely derived from another. Optional — omit or return an empty array when no intra-batch relationships exist.",
       "items": {
         "$ref": "#/definitions/RelationHint"

--- a/crates/tribal-worker/src/parsing/snapshots/dialect/anthropic/relation_output.json
+++ b/crates/tribal-worker/src/parsing/snapshots/dialect/anthropic/relation_output.json
@@ -1,0 +1,79 @@
+{
+  "additionalProperties": false,
+  "definitions": {
+    "IngestionRelationKind": {
+      "description": "The type of relationship between two knowledge items. 'supports' = source reinforces target. 'contradicts' = source conflicts with target. 'derived_from' = source was produced using target as input.",
+      "enum": [
+        "supports",
+        "contradicts",
+        "derived_from"
+      ],
+      "type": "string"
+    },
+    "RelationEdge": {
+      "additionalProperties": false,
+      "description": "A directed relationship between two knowledge items.",
+      "properties": {
+        "justification": {
+          "default": null,
+          "description": "Brief explanation referencing specific content from both items. Persists in the knowledge graph and informs future retrieval — write for someone encountering this relationship without the original context.",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "relation_type": {
+          "$ref": "#/definitions/IngestionRelationKind",
+          "description": "The relationship type."
+        },
+        "source": {
+          "$ref": "#/definitions/RelationTarget",
+          "description": "The item asserting the relationship."
+        },
+        "target": {
+          "$ref": "#/definitions/RelationTarget",
+          "description": "The item the relationship is asserted about."
+        }
+      },
+      "required": [
+        "relation_type",
+        "source",
+        "target"
+      ],
+      "type": "object"
+    },
+    "RelationTarget": {
+      "additionalProperties": false,
+      "description": "A reference to a knowledge item by its context index.",
+      "properties": {
+        "context_index": {
+          "type": "integer"
+        },
+        "kind": {
+          "const": "context_index",
+          "type": "string"
+        }
+      },
+      "required": [
+        "context_index",
+        "kind"
+      ],
+      "type": "object"
+    }
+  },
+  "description": "Relationship edges between knowledge items. Return an empty relations array when no genuine semantic relationships exist — forced relations degrade graph quality.",
+  "properties": {
+    "relations": {
+      "description": "Directed relationship edges. Each edge connects a source item to a target item with a typed relationship. Only include edges grounded in the actual content of both items.",
+      "items": {
+        "$ref": "#/definitions/RelationEdge"
+      },
+      "type": "array"
+    }
+  },
+  "required": [
+    "relations"
+  ],
+  "title": "RelationOutput",
+  "type": "object"
+}

--- a/crates/tribal-worker/src/parsing/snapshots/dialect/anthropic/relation_output.json
+++ b/crates/tribal-worker/src/parsing/snapshots/dialect/anthropic/relation_output.json
@@ -15,7 +15,6 @@
       "description": "A directed relationship between two knowledge items.",
       "properties": {
         "justification": {
-          "default": null,
           "description": "Brief explanation referencing specific content from both items. Persists in the knowledge graph and informs future retrieval — write for someone encountering this relationship without the original context.",
           "type": [
             "string",

--- a/crates/tribal-worker/src/parsing/snapshots/dialect/anthropic/triage_classification.json
+++ b/crates/tribal-worker/src/parsing/snapshots/dialect/anthropic/triage_classification.json
@@ -1,0 +1,114 @@
+{
+  "additionalProperties": false,
+  "definitions": {
+    "RelationSuggestion": {
+      "description": "The triage agent's classification of a similar item before any relationship is created.\n\nOverlaps with [`RelationKind`] but is distinct: `Supersedes` and `DerivedFrom` are never suggested by triage, and `Unrelated` is never stored as a relation row.",
+      "enum": [
+        "supports",
+        "contradicts",
+        "unrelated"
+      ],
+      "type": "string"
+    },
+    "SimilarItemClassification": {
+      "additionalProperties": false,
+      "description": "An independent assessment of one existing item's relationship to the candidate.",
+      "properties": {
+        "item": {
+          "$ref": "#/definitions/TriageItemReference",
+          "description": "The similar item being assessed, referenced by its context index in the provided similar items."
+        },
+        "justification": {
+          "description": "Brief explanation referencing specific content from both items. Explains why this relationship classification was chosen.",
+          "type": "string"
+        },
+        "suggested_relation": {
+          "$ref": "#/definitions/RelationSuggestion",
+          "description": "The relationship between the existing item and the candidate. If 'contradicts', the outcome decision must be 'created' — contradictory information cannot be a duplicate."
+        }
+      },
+      "required": [
+        "item",
+        "justification",
+        "suggested_relation"
+      ],
+      "type": "object"
+    },
+    "TriageDecision": {
+      "anyOf": [
+        {
+          "additionalProperties": false,
+          "description": "The candidate contains information not already captured. This is the default — use when the candidate adds any new context, detail, correction, or perspective beyond what existing items capture.",
+          "properties": {
+            "decision": {
+              "const": "created",
+              "type": "string"
+            }
+          },
+          "required": [
+            "decision"
+          ],
+          "type": "object"
+        },
+        {
+          "additionalProperties": false,
+          "description": "The candidate restates an existing item with no meaningful new information. Must not be used when any similar_item_decision has suggested_relation 'contradicts' — a contradiction is always novel.",
+          "properties": {
+            "decision": {
+              "const": "duplicate",
+              "type": "string"
+            },
+            "matched_item": {
+              "$ref": "#/definitions/TriageItemReference",
+              "description": "The similar item this candidate duplicates, referenced by its context index in the provided similar items."
+            }
+          },
+          "required": [
+            "decision",
+            "matched_item"
+          ],
+          "type": "object"
+        }
+      ],
+      "description": "The classification outcome. 'created' is the default — only use 'duplicate' when the candidate makes the exact same claim as an existing item. A candidate assessed as contradicting any similar item MUST be 'created'."
+    },
+    "TriageItemReference": {
+      "additionalProperties": false,
+      "description": "A reference to one of the provided similar items by its context index.",
+      "properties": {
+        "context_index": {
+          "type": "integer"
+        },
+        "kind": {
+          "const": "context_index",
+          "type": "string"
+        }
+      },
+      "required": [
+        "context_index",
+        "kind"
+      ],
+      "type": "object"
+    }
+  },
+  "description": "The triage classification for a single candidate. Contains the novel/duplicate decision and independent per-item relationship assessments.",
+  "properties": {
+    "outcome": {
+      "$ref": "#/definitions/TriageDecision",
+      "description": "The classification decision. Default to 'created' (novel) unless the candidate makes the exact same specific claim as an existing item with no meaningful new information. When uncertain, choose 'created'."
+    },
+    "similar_item_decisions": {
+      "description": "One entry per similar item provided. Each assessment is independent of the outcome decision and must include a justification referencing both items.",
+      "items": {
+        "$ref": "#/definitions/SimilarItemClassification"
+      },
+      "type": "array"
+    }
+  },
+  "required": [
+    "outcome",
+    "similar_item_decisions"
+  ],
+  "title": "TriageClassification",
+  "type": "object"
+}

--- a/crates/tribal-worker/src/parsing/snapshots/dialect/openai/extraction_output.json
+++ b/crates/tribal-worker/src/parsing/snapshots/dialect/openai/extraction_output.json
@@ -1,0 +1,129 @@
+{
+  "additionalProperties": false,
+  "definitions": {
+    "Candidate": {
+      "additionalProperties": false,
+      "description": "A knowledge item candidate extracted from raw input.\n\nCandidates are the primary output of the extraction stage. Each candidate may progress through triage to become a committed knowledge item, or be discarded as a duplicate.",
+      "properties": {
+        "content": {
+          "description": "The knowledge content.",
+          "type": "string"
+        },
+        "kind": {
+          "$ref": "#/definitions/KnowledgeKind"
+        },
+        "suggested_references": {
+          "description": "Optional external references.",
+          "items": {
+            "$ref": "#/definitions/SuggestedReference"
+          },
+          "type": "array"
+        },
+        "suggested_tags": {
+          "description": "Suggested categorisation tags. Always expected from the extraction prompt — an absent field is a parse error.",
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        }
+      },
+      "required": [
+        "content",
+        "kind",
+        "suggested_references",
+        "suggested_tags"
+      ],
+      "type": "object"
+    },
+    "KnowledgeKind": {
+      "description": "The classification of a knowledge item.",
+      "enum": [
+        "fact",
+        "heuristic",
+        "procedure",
+        "decision_record"
+      ],
+      "type": "string"
+    },
+    "RelationHint": {
+      "additionalProperties": false,
+      "description": "An intra-batch relation hint between two candidates by index.\n\nEmitted by the extraction agent to indicate that one candidate is derived from another within the same batch.",
+      "properties": {
+        "hint_type": {
+          "$ref": "#/definitions/RelationHintType"
+        },
+        "source_index": {
+          "description": "Index of the source candidate in the batch.",
+          "type": "integer"
+        },
+        "target_index": {
+          "description": "Index of the target candidate in the batch.",
+          "type": "integer"
+        }
+      },
+      "required": [
+        "hint_type",
+        "source_index",
+        "target_index"
+      ],
+      "type": "object"
+    },
+    "RelationHintType": {
+      "description": "The type of an intra-batch relation hint emitted by the extraction agent.\n\nCurrently a single variant; the enum exists as an extension point for future hint types.",
+      "enum": [
+        "derived_from"
+      ],
+      "type": "string"
+    },
+    "SuggestedReference": {
+      "additionalProperties": false,
+      "description": "A suggested external reference for a candidate.\n\nThe `reference_type` is a free string — the LLM may produce values outside the expected set. Validation and mapping to [`ReferenceKind`] happens during triage, not extraction.\n\n[`ReferenceKind`]: crate::ReferenceKind",
+      "properties": {
+        "description": {
+          "description": "Optional human-readable context.",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "reference_type": {
+          "description": "Free-form reference type (e.g. `\"url\"`, `\"file_path\"`).",
+          "type": "string"
+        },
+        "value": {
+          "description": "The reference value.",
+          "type": "string"
+        }
+      },
+      "required": [
+        "description",
+        "reference_type",
+        "value"
+      ],
+      "type": "object"
+    }
+  },
+  "description": "Extracted knowledge items and optional intra-batch relationship hints.",
+  "properties": {
+    "candidates": {
+      "description": "Knowledge items extracted from the input. Each candidate should be atomic (one claim per item) and self-contained. Return an empty array if the input contains no extractable knowledge.",
+      "items": {
+        "$ref": "#/definitions/Candidate"
+      },
+      "type": "array"
+    },
+    "relation_hints": {
+      "description": "Derivation relationships between candidates in this batch. Only include when one candidate is genuinely derived from another. Optional — omit or return an empty array when no intra-batch relationships exist.",
+      "items": {
+        "$ref": "#/definitions/RelationHint"
+      },
+      "type": "array"
+    }
+  },
+  "required": [
+    "candidates",
+    "relation_hints"
+  ],
+  "title": "ExtractionOutput",
+  "type": "object"
+}

--- a/crates/tribal-worker/src/parsing/snapshots/dialect/openai/relation_output.json
+++ b/crates/tribal-worker/src/parsing/snapshots/dialect/openai/relation_output.json
@@ -1,0 +1,76 @@
+{
+  "additionalProperties": false,
+  "definitions": {
+    "IngestionRelationKind": {
+      "description": "The type of relationship between two knowledge items. 'supports' = source reinforces target. 'contradicts' = source conflicts with target. 'derived_from' = source was produced using target as input.",
+      "enum": [
+        "supports",
+        "contradicts",
+        "derived_from"
+      ],
+      "type": "string"
+    },
+    "RelationEdge": {
+      "additionalProperties": false,
+      "description": "A directed relationship between two knowledge items.",
+      "properties": {
+        "justification": {
+          "description": "Brief explanation referencing specific content from both items. Persists in the knowledge graph and informs future retrieval — write for someone encountering this relationship without the original context.",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "relation_type": {
+          "$ref": "#/definitions/IngestionRelationKind"
+        },
+        "source": {
+          "$ref": "#/definitions/RelationTarget"
+        },
+        "target": {
+          "$ref": "#/definitions/RelationTarget"
+        }
+      },
+      "required": [
+        "justification",
+        "relation_type",
+        "source",
+        "target"
+      ],
+      "type": "object"
+    },
+    "RelationTarget": {
+      "additionalProperties": false,
+      "description": "A reference to a knowledge item by its context index.",
+      "properties": {
+        "context_index": {
+          "type": "integer"
+        },
+        "kind": {
+          "const": "context_index",
+          "type": "string"
+        }
+      },
+      "required": [
+        "context_index",
+        "kind"
+      ],
+      "type": "object"
+    }
+  },
+  "description": "Relationship edges between knowledge items. Return an empty relations array when no genuine semantic relationships exist — forced relations degrade graph quality.",
+  "properties": {
+    "relations": {
+      "description": "Directed relationship edges. Each edge connects a source item to a target item with a typed relationship. Only include edges grounded in the actual content of both items.",
+      "items": {
+        "$ref": "#/definitions/RelationEdge"
+      },
+      "type": "array"
+    }
+  },
+  "required": [
+    "relations"
+  ],
+  "title": "RelationOutput",
+  "type": "object"
+}

--- a/crates/tribal-worker/src/parsing/snapshots/dialect/openai/triage_classification.json
+++ b/crates/tribal-worker/src/parsing/snapshots/dialect/openai/triage_classification.json
@@ -1,0 +1,110 @@
+{
+  "additionalProperties": false,
+  "definitions": {
+    "RelationSuggestion": {
+      "description": "The triage agent's classification of a similar item before any relationship is created.\n\nOverlaps with [`RelationKind`] but is distinct: `Supersedes` and `DerivedFrom` are never suggested by triage, and `Unrelated` is never stored as a relation row.",
+      "enum": [
+        "supports",
+        "contradicts",
+        "unrelated"
+      ],
+      "type": "string"
+    },
+    "SimilarItemClassification": {
+      "additionalProperties": false,
+      "description": "An independent assessment of one existing item's relationship to the candidate.",
+      "properties": {
+        "item": {
+          "$ref": "#/definitions/TriageItemReference"
+        },
+        "justification": {
+          "description": "Brief explanation referencing specific content from both items. Explains why this relationship classification was chosen.",
+          "type": "string"
+        },
+        "suggested_relation": {
+          "$ref": "#/definitions/RelationSuggestion"
+        }
+      },
+      "required": [
+        "item",
+        "justification",
+        "suggested_relation"
+      ],
+      "type": "object"
+    },
+    "TriageDecision": {
+      "anyOf": [
+        {
+          "additionalProperties": false,
+          "description": "The candidate contains information not already captured. This is the default — use when the candidate adds any new context, detail, correction, or perspective beyond what existing items capture.",
+          "properties": {
+            "decision": {
+              "const": "created",
+              "type": "string"
+            }
+          },
+          "required": [
+            "decision"
+          ],
+          "type": "object"
+        },
+        {
+          "additionalProperties": false,
+          "description": "The candidate restates an existing item with no meaningful new information. Must not be used when any similar_item_decision has suggested_relation 'contradicts' — a contradiction is always novel.",
+          "properties": {
+            "decision": {
+              "const": "duplicate",
+              "type": "string"
+            },
+            "matched_item": {
+              "$ref": "#/definitions/TriageItemReference"
+            }
+          },
+          "required": [
+            "decision",
+            "matched_item"
+          ],
+          "type": "object"
+        }
+      ],
+      "description": "The classification outcome. 'created' is the default — only use 'duplicate' when the candidate makes the exact same claim as an existing item. A candidate assessed as contradicting any similar item MUST be 'created'."
+    },
+    "TriageItemReference": {
+      "additionalProperties": false,
+      "description": "A reference to one of the provided similar items by its context index.",
+      "properties": {
+        "context_index": {
+          "type": "integer"
+        },
+        "kind": {
+          "const": "context_index",
+          "type": "string"
+        }
+      },
+      "required": [
+        "context_index",
+        "kind"
+      ],
+      "type": "object"
+    }
+  },
+  "description": "The triage classification for a single candidate. Contains the novel/duplicate decision and independent per-item relationship assessments.",
+  "properties": {
+    "outcome": {
+      "$ref": "#/definitions/TriageDecision"
+    },
+    "similar_item_decisions": {
+      "description": "One entry per similar item provided. Each assessment is independent of the outcome decision and must include a justification referencing both items.",
+      "items": {
+        "$ref": "#/definitions/SimilarItemClassification"
+      },
+      "type": "array"
+    }
+  },
+  "required": [
+    "outcome",
+    "similar_item_decisions"
+  ],
+  "title": "TriageClassification",
+  "type": "object"
+}


### PR DESCRIPTION
Owns a per-provider JSON Schema dialect transform in `tribal-inference` plus a strict-output capability axis, so each pipeline response schema is sent in the dialect the provider accepts rather than as raw schemars output. Response Rust types are unchanged.

Closes tribal-memory/cortex#31.

Validated live end to end: OpenAI `gpt-5.4-mini` (strict) and Anthropic `claude-haiku-4-5` (`output_config`) both triage with zero dead-letters, where the pre-fix path dead-lettered. Committed coverage is golden snapshots, a shared invariant assertion, and positive/negative `jsonschema` instance checks.

Reviewer-flagged decisions:
- Live-probe confirmation is the manual run above, not a committed artefact.
- `StructuredOutputMode` is exhaustive by design (never serialised, binary domain).
- First-key discriminator ordering is not forced: the rule is unverified and no current enum is affected.