### PR TITLE
[REFACTOR] Tune pipeline response-schema field descriptions

### DIFF
--- a/crates/tribal-domain/src/candidate.rs
+++ b/crates/tribal-domain/src/candidate.rs
@@ -12,22 +12,22 @@ use crate::{KnowledgeKind, RelationHintType};
 // Candidate
 // ---------------------------------------------------------------------------
 
-/// A knowledge item candidate extracted from raw input.
+/// A single knowledge item extracted from the input.
 ///
-/// Candidates are the primary output of the extraction stage. Each
-/// candidate may progress through triage to become a committed
-/// knowledge item, or be discarded as a duplicate.
+/// The primary output of the extraction stage; each candidate is triaged
+/// against existing knowledge before it is committed or discarded.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
 pub struct Candidate {
-    /// Classification of the candidate knowledge.
+    /// The kind of knowledge this item records.
     kind: KnowledgeKind,
-    /// The knowledge content.
+    /// The captured tacit knowledge, as one self-contained claim.
     content: String,
-    /// Suggested categorisation tags. Always expected from the
-    /// extraction prompt — an absent field is a parse error.
+    /// Categorisation tags for the item. Always present; an absent field is a
+    /// parse error.
     suggested_tags: Vec<String>,
-    /// Optional external references.
+    /// External anchors the item refers to, used to connect it to related
+    /// knowledge even when wording differs.
     #[serde(default)]
     suggested_references: Vec<SuggestedReference>,
 }
@@ -58,21 +58,28 @@ impl Candidate {
 // SuggestedReference
 // ---------------------------------------------------------------------------
 
-/// A suggested external reference for a candidate.
+/// A suggested external reference for a candidate: an anchor (a URL, file path,
+/// code symbol, or concept) that connects items even when their wording differs.
 ///
-/// The `reference_type` is a free string — the LLM may produce values
-/// outside the expected set. Validation and mapping to [`ReferenceKind`]
-/// happens during triage, not extraction.
+/// The `reference_type` is a free string; the LLM may produce values outside the
+/// expected set, and mapping to [`ReferenceKind`] happens during triage, not
+/// extraction.
 ///
 /// [`ReferenceKind`]: crate::ReferenceKind
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
-#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
+#[cfg_attr(
+    feature = "schema",
+    derive(schemars::JsonSchema),
+    schemars(
+        description = "An external anchor a candidate refers to (a URL, file path, code symbol, or concept) that can connect items even when their wording differs."
+    )
+)]
 pub struct SuggestedReference {
-    /// Free-form reference type (e.g. `"url"`, `"file_path"`).
+    /// What kind of anchor this is (e.g. `"url"`, `"file_path"`); free-form.
     reference_type: String,
-    /// The reference value.
+    /// The anchor itself: the URL, path, symbol, or concept.
     value: String,
-    /// Optional human-readable context.
+    /// Optional human-readable context for the anchor.
     #[serde(default)]
     description: Option<String>,
 }

--- a/crates/tribal-domain/src/candidate.rs
+++ b/crates/tribal-domain/src/candidate.rs
@@ -17,14 +17,24 @@ use crate::{KnowledgeKind, RelationHintType};
 /// The primary output of the extraction stage; each candidate is triaged
 /// against existing knowledge before it is committed or discarded.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
-#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
+#[cfg_attr(
+    feature = "schema",
+    derive(schemars::JsonSchema),
+    schemars(description = "A single self-contained knowledge item extracted from the input.")
+)]
 pub struct Candidate {
     /// The kind of knowledge this item records.
     kind: KnowledgeKind,
-    /// The captured tacit knowledge, as one self-contained claim.
+    /// The captured tacit knowledge as one self-contained, atomic claim.
+    /// Include the reasoning, constraints, or rejected alternatives when
+    /// they are part of the knowledge being captured.
     content: String,
-    /// Categorisation tags for the item. Always present; an absent field is a
-    /// parse error.
+    /// Categorisation tags for the item. Always present (no serde default);
+    /// an absent field is a parse error.
+    #[cfg_attr(
+        feature = "schema",
+        schemars(description = "Categorisation tags for the item.")
+    )]
     suggested_tags: Vec<String>,
     /// External anchors the item refers to, used to connect it to related
     /// knowledge even when wording differs.
@@ -75,7 +85,14 @@ impl Candidate {
     )
 )]
 pub struct SuggestedReference {
-    /// What kind of anchor this is (e.g. `"url"`, `"file_path"`); free-form.
+    /// What kind of anchor this is. Free-form Rust string; mapping to
+    /// [`ReferenceKind`] happens during triage, not extraction.
+    #[cfg_attr(
+        feature = "schema",
+        schemars(
+            description = "What kind of anchor this is. Use one of `file_path`, `url`, `symbol`, or `concept`."
+        )
+    )]
     reference_type: String,
     /// The anchor itself: the URL, path, symbol, or concept.
     value: String,
@@ -110,7 +127,13 @@ impl SuggestedReference {
 /// Emitted by the extraction agent to indicate that one candidate
 /// is derived from another within the same batch.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
-#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
+#[cfg_attr(
+    feature = "schema",
+    derive(schemars::JsonSchema),
+    schemars(
+        description = "A relation between two candidates in this batch, referenced by their array indices."
+    )
+)]
 pub struct RelationHint {
     /// Index of the source candidate in the batch.
     source_index: u32,

--- a/crates/tribal-domain/src/knowledge.rs
+++ b/crates/tribal-domain/src/knowledge.rs
@@ -13,7 +13,11 @@ use crate::{EpisodeId, KnowledgeItemId, PrincipalId, ProjectId};
 
 /// The classification of a knowledge item.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
-#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
+#[cfg_attr(
+    feature = "schema",
+    derive(schemars::JsonSchema),
+    schemars(description = "The kind of knowledge captured.")
+)]
 #[serde(rename_all = "snake_case")]
 pub enum KnowledgeKind {
     /// A discrete, verifiable piece of information.

--- a/crates/tribal-domain/src/knowledge.rs
+++ b/crates/tribal-domain/src/knowledge.rs
@@ -13,15 +13,7 @@ use crate::{EpisodeId, KnowledgeItemId, PrincipalId, ProjectId};
 
 /// The classification of a knowledge item.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
-#[cfg_attr(
-    feature = "schema",
-    derive(schemars::JsonSchema),
-    schemars(
-        description = "The kind of knowledge: fact (a verifiable piece of information), \
-        heuristic (a rule of thumb learned from experience), procedure (an ordered set of \
-        steps), or decision_record (a choice made and its rationale)."
-    )
-)]
+#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
 #[serde(rename_all = "snake_case")]
 pub enum KnowledgeKind {
     /// A discrete, verifiable piece of information.

--- a/crates/tribal-domain/src/knowledge.rs
+++ b/crates/tribal-domain/src/knowledge.rs
@@ -13,7 +13,15 @@ use crate::{EpisodeId, KnowledgeItemId, PrincipalId, ProjectId};
 
 /// The classification of a knowledge item.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
-#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
+#[cfg_attr(
+    feature = "schema",
+    derive(schemars::JsonSchema),
+    schemars(
+        description = "The kind of knowledge: fact (a verifiable piece of information), \
+        heuristic (a rule of thumb learned from experience), procedure (an ordered set of \
+        steps), or decision_record (a choice made and its rationale)."
+    )
+)]
 #[serde(rename_all = "snake_case")]
 pub enum KnowledgeKind {
     /// A discrete, verifiable piece of information.

--- a/crates/tribal-domain/src/relation.rs
+++ b/crates/tribal-domain/src/relation.rs
@@ -72,11 +72,14 @@ enum_text_conversions!(RelationSuggestion {
 });
 
 /// The type of an intra-batch relation hint emitted by the extraction agent.
-///
-/// Currently a single variant; the enum exists as an extension point for
-/// future hint types.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
-#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
+#[cfg_attr(
+    feature = "schema",
+    derive(schemars::JsonSchema),
+    schemars(
+        description = "How two candidates relate within this batch. Currently `derived_from`: the source candidate was produced using the target candidate as input or premise."
+    )
+)]
 #[serde(rename_all = "snake_case")]
 pub enum RelationHintType {
     /// Intra-batch derivation hint from the extraction agent.

--- a/crates/tribal-domain/src/relation.rs
+++ b/crates/tribal-domain/src/relation.rs
@@ -36,21 +36,27 @@ enum_text_conversions!(RelationKind {
     RelationKind::DerivedFrom => "derived_from",
 });
 
-/// The triage agent's classification of a similar item before any
-/// relationship is created.
+/// The triage agent's classification of a similar item before any relationship
+/// is created.
 ///
-/// Overlaps with [`RelationKind`] but is distinct: `Supersedes` and
-/// `DerivedFrom` are never suggested by triage, and `Unrelated` is never
-/// stored as a relation row.
+/// Overlaps with [`RelationKind`] but is distinct: `Supersedes` and `DerivedFrom`
+/// are never suggested by triage, and `Unrelated` is never stored as a relation
+/// row.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
-#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
+#[cfg_attr(
+    feature = "schema",
+    derive(schemars::JsonSchema),
+    schemars(
+        description = "How an existing similar item relates to the candidate, assessed during triage independently of the novel-or-duplicate decision."
+    )
+)]
 #[serde(rename_all = "snake_case")]
 pub enum RelationSuggestion {
-    /// Similar item corroborates the candidate.
+    /// The existing item corroborates or reinforces the candidate.
     Supports,
-    /// Similar item conflicts with the candidate.
+    /// The existing item conflicts with or is incompatible with the candidate.
     Contradicts,
-    /// Semantic similarity is incidental; no meaningful relationship.
+    /// The similarity is incidental; no meaningful relationship holds.
     Unrelated,
 }
 

--- a/crates/tribal-domain/src/relation.rs
+++ b/crates/tribal-domain/src/relation.rs
@@ -47,7 +47,7 @@ enum_text_conversions!(RelationKind {
     feature = "schema",
     derive(schemars::JsonSchema),
     schemars(
-        description = "How an existing similar item relates to the candidate, assessed during triage independently of the novel-or-duplicate decision."
+        description = "How the candidate relates to an existing similar item, assessed during triage independently of the novel-or-duplicate decision."
     )
 )]
 #[serde(rename_all = "snake_case")]

--- a/crates/tribal-mcp/src/schemas/discover/input.json
+++ b/crates/tribal-mcp/src/schemas/discover/input.json
@@ -16,12 +16,12 @@
         "type": "string",
         "enum": ["fact", "heuristic", "procedure", "decision_record"]
       },
-      "description": "Filter to specific knowledge kinds. Use sparingly — semantic search naturally ranks relevant kinds higher. Most useful for explicit structural queries like 'show me all decision records for this project'."
+      "description": "Filter to specific knowledge kinds. Use sparingly; semantic search naturally ranks relevant kinds higher. Most useful for explicit structural queries like 'show me all decision records for this project'."
     },
     "tags": {
       "type": "array",
       "items": { "type": "string" },
-      "description": "Filter by tags (AND semantics — items must have ALL specified tags). Tags are lowercase. For OR semantics, make separate queries."
+      "description": "Filter by tags (AND semantics: items must have ALL specified tags). Tags are lowercase. For OR semantics, make separate queries."
     },
     "time_range": {
       "type": "object",

--- a/crates/tribal-mcp/src/schemas/discover/output.json
+++ b/crates/tribal-mcp/src/schemas/discover/output.json
@@ -35,7 +35,7 @@
         "item": { "$ref": "#/$defs/knowledge_item" },
         "similarity": {
           "type": "number",
-          "description": "Cosine similarity to query (0.0–1.0)."
+          "description": "Cosine similarity to query (0.0 to 1.0)."
         },
         "standing": { "$ref": "#/$defs/standing" },
         "references": {

--- a/crates/tribal-mcp/src/schemas/discover/output.json
+++ b/crates/tribal-mcp/src/schemas/discover/output.json
@@ -20,7 +20,7 @@
     },
     "trace_id": {
       "type": "string",
-      "description": "OpenTelemetry trace ID for this retrieval. Pass to tribal_feedback to rate this session."
+      "description": "Trace ID for this retrieval. Pass to tribal_feedback to rate this session."
     },
     "exact": {
       "type": "boolean",

--- a/crates/tribal-mcp/src/schemas/explore/input.json
+++ b/crates/tribal-mcp/src/schemas/explore/input.json
@@ -46,7 +46,7 @@
       "minimum": 1,
       "maximum": 100,
       "default": 20,
-      "description": "Maximum total results across all depths. BFS order ensures closer relations are returned first."
+      "description": "Maximum total results across all depths. Closer relations are returned first."
     }
   },
   "required": ["item_id"],

--- a/crates/tribal-mcp/src/schemas/explore/output.json
+++ b/crates/tribal-mcp/src/schemas/explore/output.json
@@ -9,7 +9,7 @@
     },
     "trace_id": {
       "type": "string",
-      "description": "OpenTelemetry trace ID. Pass to tribal_feedback if rating this session."
+      "description": "Trace ID. Pass to tribal_feedback if rating this session."
     },
     "exact": {
       "type": "boolean",

--- a/crates/tribal-mcp/src/schemas/feedback/input.json
+++ b/crates/tribal-mcp/src/schemas/feedback/input.json
@@ -3,7 +3,7 @@
   "properties": {
     "trace_id": {
       "type": "string",
-      "description": "OpenTelemetry trace ID from the tribal_discover or tribal_explore response being rated."
+      "description": "Trace ID from the tribal_discover or tribal_explore response being rated."
     },
     "query_text": {
       "type": "string",

--- a/crates/tribal-mcp/src/schemas/golden_snapshot.json
+++ b/crates/tribal-mcp/src/schemas/golden_snapshot.json
@@ -226,7 +226,7 @@
               "type": "array"
             },
             "similarity": {
-              "description": "Cosine similarity to query (0.0–1.0).",
+              "description": "Cosine similarity to query (0.0 to 1.0).",
               "type": "number"
             },
             "standing": {

--- a/crates/tribal-mcp/src/schemas/golden_snapshot.json
+++ b/crates/tribal-mcp/src/schemas/golden_snapshot.json
@@ -95,11 +95,11 @@
       "additionalProperties": false,
       "properties": {
         "content": {
-          "description": "The raw text to extract knowledge from. Write naturally — describe what you learned, what went wrong, what the fix was, why a decision was made. The system handles structuring. Richer input produces better results: include context, reasoning, and specifics rather than terse summaries.",
+          "description": "The raw text to extract knowledge from. Write naturally: describe what you learned, what went wrong, what the fix was, why a decision was made. The system handles structuring. Richer input produces better results: include context, reasoning, and specifics rather than terse summaries.",
           "type": "string"
         },
         "project_id": {
-          "description": "Override the session's active project for this ingest. Optional — defaults to the project set in session context.",
+          "description": "Override the session's active project for this ingest. Optional; defaults to the project set in session context.",
           "pattern": "^proj_[0-9a-f-]{36}$",
           "type": "string"
         }
@@ -127,7 +127,7 @@
     "title": "Tribal: Ingest Knowledge"
   },
   {
-    "description": "Search Tribal's knowledge base using natural language. Returns knowledge items ranked by semantic similarity to your query, with optional structured filters to narrow results.\n\nUse this as your first step when you need context: before starting work on a feature, debugging an issue, or making a design decision. Ask questions the way you'd ask a colleague — \"What do I know about connection pooling in this project?\" or \"Have I seen this async deadlock pattern before?\"\n\nSemantic search is the primary mechanism. Filters (project, kind, tags, time) narrow the candidate set but are not required. If you need to understand an item's evidence, contradictions, or derivation chain, follow up with tribal_explore using the item's ID.\n\nSuperseded items (replaced by newer understanding) are excluded by default. Set include_superseded to true for the historical picture.\n\nResults include standing (evidential profile) when requested, which summarises each item's support count, contradiction count, observation frequency, and diversity of supporting evidence.",
+    "description": "Search Tribal's knowledge base using natural language. Returns knowledge items ranked by semantic similarity to your query, with optional structured filters to narrow results.\n\nUse this as your first step when you need context: before starting work on a feature, debugging an issue, or making a design decision. Ask questions the way you'd ask a colleague: \"What do I know about connection pooling in this project?\" or \"Have I seen this async deadlock pattern before?\"\n\nSemantic search is the primary mechanism. Filters (project, kind, tags, time) narrow the candidate set but are not required. If you need to understand an item's evidence, contradictions, or derivation chain, follow up with tribal_explore using the item's ID.\n\nSuperseded items (replaced by newer understanding) are excluded by default. Set include_superseded to true for the historical picture.\n\nResults include standing (evidential profile) when requested, which summarises each item's support count, contradiction count, observation frequency, and diversity of supporting evidence.",
     "input_schema": {
       "additionalProperties": false,
       "properties": {
@@ -151,7 +151,7 @@
           "type": "boolean"
         },
         "kinds": {
-          "description": "Filter to specific knowledge kinds. Use sparingly — semantic search naturally ranks relevant kinds higher. Most useful for explicit structural queries like 'show me all decision records for this project'.",
+          "description": "Filter to specific knowledge kinds. Use sparingly; semantic search naturally ranks relevant kinds higher. Most useful for explicit structural queries like 'show me all decision records for this project'.",
           "items": {
             "enum": [
               "fact",
@@ -183,7 +183,7 @@
           "type": "string"
         },
         "tags": {
-          "description": "Filter by tags (AND semantics — items must have ALL specified tags). Tags are lowercase. For OR semantics, make separate queries.",
+          "description": "Filter by tags (AND semantics: items must have ALL specified tags). Tags are lowercase. For OR semantics, make separate queries.",
           "items": {
             "type": "string"
           },
@@ -476,7 +476,7 @@
           ]
         },
         "trace_id": {
-          "description": "OpenTelemetry trace ID for this retrieval. Pass to tribal_feedback to rate this session.",
+          "description": "Trace ID for this retrieval. Pass to tribal_feedback to rate this session.",
           "type": "string"
         }
       },
@@ -494,7 +494,7 @@
     "title": "Tribal: Discover Knowledge"
   },
   {
-    "description": "Traverse the relationship graph from a specific knowledge item. Use this after tribal_discover to understand an item's context: what supports it, what contradicts it, what it was derived from, or what it supersedes.\n\nTypical workflow:\n1. tribal_discover finds relevant items\n2. Pick an item with interesting standing (high support, or contradictions)\n3. tribal_explore to see the evidence, contradictions, or derivation chain\n\nDirection controls traversal:\n- \"inbound\": What do others assert about this item? (supports, contradictions, what supersedes it)\n- \"outbound\": What does this item assert about others? (what it's derived from, what it supports)\n- \"both\": Full neighbourhood in all directions\n\nRelation types:\n- \"supports\": Evidence that reinforces the item\n- \"contradicts\": Evidence that challenges the item\n- \"supersedes\": A newer item that replaces this one\n- \"derived_from\": Provenance — what input was used to produce this item\n\nDepth controls hops: depth 1 = direct relations, depth 2 = relations of relations. Higher depth gives more context but more results. Depth is capped at 3 to avoid mixing unrelated evidence across distant graph regions — use multiple targeted calls for deeper investigation.",
+    "description": "Traverse the relationship graph from a specific knowledge item. Use this after tribal_discover to understand an item's context: what supports it, what contradicts it, what it was derived from, or what it supersedes.\n\nTypical workflow:\n1. tribal_discover finds relevant items\n2. Pick an item with interesting standing (high support, or contradictions)\n3. tribal_explore to see the evidence, contradictions, or derivation chain\n\nDirection controls traversal:\n- \"inbound\": What do others assert about this item? (supports, contradictions, what supersedes it)\n- \"outbound\": What does this item assert about others? (what it's derived from, what it supports)\n- \"both\": Full neighbourhood in all directions\n\nRelation types:\n- \"supports\": Evidence that reinforces the item\n- \"contradicts\": Evidence that challenges the item\n- \"supersedes\": A newer item that replaces this one\n- \"derived_from\": Provenance. The input used to produce this item\n\nDepth controls hops: depth 1 = direct relations, depth 2 = relations of relations. Higher depth gives more context but more results. Depth is capped at 3 to avoid mixing unrelated evidence across distant graph regions; use multiple targeted calls for deeper investigation.",
     "input_schema": {
       "additionalProperties": false,
       "properties": {
@@ -532,7 +532,7 @@
         },
         "limit": {
           "default": 20,
-          "description": "Maximum total results across all depths. BFS order ensures closer relations are returned first.",
+          "description": "Maximum total results across all depths. Closer relations are returned first.",
           "maximum": 100,
           "minimum": 1,
           "type": "integer"
@@ -837,7 +837,7 @@
           "type": "array"
         },
         "trace_id": {
-          "description": "OpenTelemetry trace ID. Pass to tribal_feedback if rating this session.",
+          "description": "Trace ID. Pass to tribal_feedback if rating this session.",
           "type": "string"
         }
       },
@@ -854,7 +854,7 @@
     "title": "Tribal: Explore Relationships"
   },
   {
-    "description": "Retrieve one or more knowledge items by their IDs. Use this when you have a specific item ID — from a standing field (newest_supporting_id, newest_contradicting_id, superseded_by), a previous session, or a cross-reference — and need the full item.\n\nFor semantic search, use tribal_discover. For relationship traversal, use tribal_explore. This tool is for direct lookup when you already know what you want.\n\nThe response is keyed by item ID. Missing or unknown IDs map to null.",
+    "description": "Retrieve one or more knowledge items by their IDs. Use this when you have a specific item ID (from a standing field, a previous session, or a cross-reference) and need the full item.\n\nFor semantic search, use tribal_discover. For relationship traversal, use tribal_explore. This tool is for direct lookup when you already know what you want.\n\nThe response is keyed by item ID. Missing or unknown IDs map to null.",
     "input_schema": {
       "additionalProperties": false,
       "properties": {
@@ -1135,7 +1135,7 @@
     "title": "Tribal: Get Knowledge Item by ID"
   },
   {
-    "description": "Record a quality signal about a retrieval session. Use this when Tribal's knowledge meaningfully helped (or failed to help) your current task.\n\nThis is NOT about rating individual items — item-level signals are captured through the Supports/Contradicts relationship system during ingest. This is about rating the *combination of items returned for a query, assembled in a particular way*.\n\nRate \"positive\" when: Tribal surfaced knowledge that directly informed your approach, saved you from a known pitfall, or provided context that improved your decision-making.\n\nRate \"negative\" when: The query should have found relevant knowledge but didn't, or the returned items were irrelevant or misleading for the task at hand.\n\nFeedback builds an organic eval dataset. Be selective — only rate when the signal is clear. If no trace_id is available from the retrieval response, do not submit feedback rather than fabricating a trace_id — incomplete feedback is noise.",
+    "description": "Record a quality signal about a retrieval session. Use this when Tribal's knowledge meaningfully helped (or failed to help) your current task.\n\nThis is NOT about rating individual items. Item-level signals are captured through the Supports/Contradicts relationship system during ingest. This is about rating the *combination of items returned for a query, assembled in a particular way*.\n\nRate \"positive\" when: Tribal surfaced knowledge that directly informed your approach, saved you from a known pitfall, or provided context that improved your decision-making.\n\nRate \"negative\" when: The query should have found relevant knowledge but didn't, or the returned items were irrelevant or misleading for the task at hand.\n\nFeedback builds an organic eval dataset. Be selective: only rate when the signal is clear. If no trace_id is available from the retrieval response, do not submit feedback rather than fabricating a trace_id. Incomplete feedback is noise.",
     "input_schema": {
       "additionalProperties": false,
       "properties": {
@@ -1172,7 +1172,7 @@
           "type": "array"
         },
         "trace_id": {
-          "description": "OpenTelemetry trace ID from the tribal_discover or tribal_explore response being rated.",
+          "description": "Trace ID from the tribal_discover or tribal_explore response being rated.",
           "type": "string"
         }
       },
@@ -1202,7 +1202,7 @@
     "title": "Tribal: Rate Retrieval Quality"
   },
   {
-    "description": "Check the progress of an ingest job submitted via tribal_ingest.\n\nJob lifecycle: queued → extracting → triaging → relating → completed/failed\n\nTerminal states:\n- \"completed\": Pipeline ran to conclusion. Check outcome for details:\n  - \"success\": All candidates triaged successfully and relations committed.\n  - \"partial\": Some triage tasks dead-lettered; relation task ran on a subset.\n  - \"empty\": Relation task ran with zero items to relate (all duplicates or all triage failures). If tasks_failed > 0, the pipeline likely failed at triage — treat as degraded rather than \"nothing new\".\n- \"failed\": Pipeline could not complete. outcome = \"failure\". Check error context.\n\nSet wait_seconds to block until the job completes or the timeout expires. This collapses ingest + poll into a single round-trip for fast operations. With wait_seconds=0 (default), returns immediately with current status.",
+    "description": "Check the progress of an ingest job submitted via tribal_ingest.\n\nJob lifecycle: queued → extracting → triaging → relating → completed/failed\n\nTerminal states:\n- \"completed\": Pipeline ran to conclusion. Check outcome for details:\n  - \"success\": All candidates triaged successfully and relations committed.\n  - \"partial\": Some triage tasks failed permanently; the relation task ran on a subset.\n  - \"empty\": Relation task ran with zero items to relate (all duplicates or all triage failures). If tasks_failed > 0, the pipeline likely failed at triage; treat as degraded rather than \"nothing new\".\n- \"failed\": Pipeline could not complete. outcome = \"failure\". Check error context.\n\nSet wait_seconds to block until the job completes or the timeout expires. This collapses ingest + poll into a single round-trip for fast operations. With wait_seconds=0 (default), returns immediately with current status.",
     "input_schema": {
       "additionalProperties": false,
       "properties": {

--- a/crates/tribal-mcp/src/schemas/ingest/input.json
+++ b/crates/tribal-mcp/src/schemas/ingest/input.json
@@ -3,12 +3,12 @@
   "properties": {
     "content": {
       "type": "string",
-      "description": "The raw text to extract knowledge from. Write naturally — describe what you learned, what went wrong, what the fix was, why a decision was made. The system handles structuring. Richer input produces better results: include context, reasoning, and specifics rather than terse summaries."
+      "description": "The raw text to extract knowledge from. Write naturally: describe what you learned, what went wrong, what the fix was, why a decision was made. The system handles structuring. Richer input produces better results: include context, reasoning, and specifics rather than terse summaries."
     },
     "project_id": {
       "type": "string",
       "pattern": "^proj_[0-9a-f-]{36}$",
-      "description": "Override the session's active project for this ingest. Optional — defaults to the project set in session context."
+      "description": "Override the session's active project for this ingest. Optional; defaults to the project set in session context."
     }
   },
   "required": ["content"],

--- a/crates/tribal-mcp/src/tools.rs
+++ b/crates/tribal-mcp/src/tools.rs
@@ -105,7 +105,7 @@ optional structured filters to narrow results.
 
 Use this as your first step when you need context: before starting \
 work on a feature, debugging an issue, or making a design decision. \
-Ask questions the way you'd ask a colleague — \"What do I know about \
+Ask questions the way you'd ask a colleague: \"What do I know about \
 connection pooling in this project?\" or \"Have I seen this async \
 deadlock pattern before?\"
 
@@ -147,12 +147,12 @@ Relation types:
 - \"supports\": Evidence that reinforces the item
 - \"contradicts\": Evidence that challenges the item
 - \"supersedes\": A newer item that replaces this one
-- \"derived_from\": Provenance — what input was used to produce this item
+- \"derived_from\": Provenance. The input used to produce this item
 
 Depth controls hops: depth 1 = direct relations, depth 2 = relations \
 of relations. Higher depth gives more context but more results. Depth \
 is capped at 3 to avoid mixing unrelated evidence across distant \
-graph regions — use multiple targeted calls for deeper investigation.",
+graph regions; use multiple targeted calls for deeper investigation.",
         input_schema: include_str!("schemas/explore/input.json"),
         output_schema: include_str!("schemas/explore/output.json"),
         required_scope: "tribal.knowledge:read",
@@ -162,9 +162,8 @@ graph regions — use multiple targeted calls for deeper investigation.",
         title: "Tribal: Get Knowledge Item by ID",
         description: "\
 Retrieve one or more knowledge items by their IDs. Use this when you \
-have a specific item ID — from a standing field \
-(newest_supporting_id, newest_contradicting_id, superseded_by), a \
-previous session, or a cross-reference — and need the full item.
+have a specific item ID (from a standing field, a previous session, \
+or a cross-reference) and need the full item.
 
 For semantic search, use tribal_discover. For relationship traversal, \
 use tribal_explore. This tool is for direct lookup when you already \
@@ -183,7 +182,7 @@ Record a quality signal about a retrieval session. Use this when \
 Tribal's knowledge meaningfully helped (or failed to help) your \
 current task.
 
-This is NOT about rating individual items — item-level signals are \
+This is NOT about rating individual items. Item-level signals are \
 captured through the Supports/Contradicts relationship system during \
 ingest. This is about rating the *combination of items returned for a \
 query, assembled in a particular way*.
@@ -196,10 +195,10 @@ Rate \"negative\" when: The query should have found relevant knowledge \
 but didn't, or the returned items were irrelevant or misleading for \
 the task at hand.
 
-Feedback builds an organic eval dataset. Be selective — only rate \
+Feedback builds an organic eval dataset. Be selective: only rate \
 when the signal is clear. If no trace_id is available from the \
 retrieval response, do not submit feedback rather than fabricating a \
-trace_id — incomplete feedback is noise.",
+trace_id. Incomplete feedback is noise.",
         input_schema: include_str!("schemas/feedback/input.json"),
         output_schema: include_str!("schemas/feedback/output.json"),
         required_scope: "tribal.knowledge:write",
@@ -215,10 +214,10 @@ Job lifecycle: queued → extracting → triaging → relating → completed/fai
 Terminal states:
 - \"completed\": Pipeline ran to conclusion. Check outcome for details:
   - \"success\": All candidates triaged successfully and relations committed.
-  - \"partial\": Some triage tasks dead-lettered; relation task ran on a subset.
+  - \"partial\": Some triage tasks failed permanently; the relation task ran on a subset.
   - \"empty\": Relation task ran with zero items to relate (all duplicates \
 or all triage failures). If tasks_failed > 0, the pipeline likely failed \
-at triage — treat as degraded rather than \"nothing new\".
+at triage; treat as degraded rather than \"nothing new\".
 - \"failed\": Pipeline could not complete. outcome = \"failure\". Check error context.
 
 Set wait_seconds to block until the job completes or the timeout \

--- a/crates/tribal-worker/src/parsing.rs
+++ b/crates/tribal-worker/src/parsing.rs
@@ -8,9 +8,9 @@ mod triage;
 mod schema_dialect_snapshots;
 
 pub(crate) use extraction::{ExtractionOutput, parse_extraction_response};
-#[cfg(test)]
-pub(crate) use relation::IngestionRelationKind;
-pub(crate) use relation::{RelationEdge, RelationOutput, RelationTarget, parse_relation_response};
+pub(crate) use relation::{
+    IngestionRelationKind, RelationEdge, RelationOutput, RelationTarget, parse_relation_response,
+};
 pub(crate) use triage::{
     SimilarItemClassification, TriageClassification, TriageDecision, TriageItemReference,
     parse_triage_response,

--- a/crates/tribal-worker/src/parsing/extraction.rs
+++ b/crates/tribal-worker/src/parsing/extraction.rs
@@ -19,17 +19,15 @@ use crate::error::StageError;
 pub(crate) struct ExtractionOutput {
     /// Extracted knowledge item candidates.
     #[schemars(
-        description = "Knowledge items extracted from the input. Each candidate should be \
-        atomic (one claim per item) and self-contained. Return an empty array if the \
-        input contains no extractable knowledge."
+        description = "Knowledge items extracted from the input, each an atomic, \
+        self-contained claim. Empty when the input contains no extractable knowledge."
     )]
     pub candidates: Vec<Candidate>,
     /// Intra-batch relation hints between candidates.
     #[serde(default)]
     #[schemars(
-        description = "Derivation relationships between candidates in this batch. Only \
-        include when one candidate is genuinely derived from another. Optional — omit \
-        or return an empty array when no intra-batch relationships exist."
+        description = "Derivation links between candidates in this batch. Empty unless \
+        one candidate is genuinely derived from another."
     )]
     pub relation_hints: Vec<RelationHint>,
 }

--- a/crates/tribal-worker/src/parsing/relation.rs
+++ b/crates/tribal-worker/src/parsing/relation.rs
@@ -20,24 +20,18 @@ use crate::error::StageError;
 /// out post-hoc or constrained only via prompt instructions.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Deserialize, schemars::JsonSchema)]
 #[serde(rename_all = "snake_case")]
-#[schemars(description = "The type of relationship between two knowledge items. \
-    'supports' = source reinforces target. 'contradicts' = source conflicts \
-    with target. 'derived_from' = source was produced using target as input.")]
+#[schemars(
+    description = "How the source item relates to the target: supports (the source \
+    corroborates the target), contradicts (the source conflicts with or corrects it), \
+    or derived_from (the source was produced using the target as input)."
+)]
 pub(crate) enum IngestionRelationKind {
     /// Source provides evidence for, reinforces, or adds supporting
     /// context to target.
-    #[schemars(description = "Source reinforces or provides evidence for target. \
-        Both items point in the same direction.")]
     Supports,
     /// Source conflicts with, corrects, or undermines target.
-    #[schemars(
-        description = "Source conflicts with or corrects target. The two items \
-        cannot both be fully accurate simultaneously."
-    )]
     Contradicts,
     /// Source was logically derived from or builds upon target.
-    #[schemars(description = "Source was produced using target as input. Tracks \
-        intellectual provenance.")]
     DerivedFrom,
 }
 
@@ -61,16 +55,14 @@ impl From<IngestionRelationKind> for RelationKind {
 /// can return extra keys without breaking parsing.
 #[derive(Debug, Clone, PartialEq, Deserialize, schemars::JsonSchema)]
 #[schemars(
-    description = "Relationship edges between knowledge items. Return an empty \
-    relations array when no genuine semantic relationships exist — forced \
-    relations degrade graph quality."
+    description = "The relationship edges to create. Empty when no genuine relationship \
+    holds between the items."
 )]
 pub(crate) struct RelationOutput {
     /// The complete set of relations to create for this job.
     #[schemars(
-        description = "Directed relationship edges. Each edge connects a source item \
-        to a target item with a typed relationship. Only include edges grounded in \
-        the actual content of both items."
+        description = "Directed edges, each connecting a source item to a target item. \
+        Only edges grounded in the content of both items."
     )]
     pub relations: Vec<RelationEdge>,
 }
@@ -86,13 +78,12 @@ pub(crate) struct RelationEdge {
     #[schemars(description = "The item the relationship is asserted about.")]
     pub target: RelationTarget,
     /// The relationship type.
+    #[schemars(description = "How the source relates to the target.")]
     pub relation_type: IngestionRelationKind,
     /// The agent's reasoning for this relationship.
     #[serde(default)]
     #[schemars(
-        description = "Brief explanation referencing specific content from both items. \
-        Persists in the knowledge graph and informs future retrieval — write for \
-        someone encountering this relationship without the original context."
+        description = "Why this relationship holds, grounded in the content of both items."
     )]
     pub justification: Option<String>,
 }

--- a/crates/tribal-worker/src/parsing/relation.rs
+++ b/crates/tribal-worker/src/parsing/relation.rs
@@ -1,5 +1,7 @@
 //! Relation response parsing and LLM response types.
 
+use std::fmt;
+
 use serde::Deserialize;
 use tribal_domain::RelationKind;
 use tribal_inference::CompletionResponse;
@@ -20,11 +22,7 @@ use crate::error::StageError;
 /// out post-hoc or constrained only via prompt instructions.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Deserialize, schemars::JsonSchema)]
 #[serde(rename_all = "snake_case")]
-#[schemars(
-    description = "How the source item relates to the target: supports (the source \
-    corroborates the target), contradicts (the source conflicts with or corrects it), \
-    or derived_from (the source was produced using the target as input)."
-)]
+#[schemars(description = "How the source item relates to the target item.")]
 pub(crate) enum IngestionRelationKind {
     /// Source provides evidence for, reinforces, or adds supporting
     /// context to target.
@@ -35,6 +33,11 @@ pub(crate) enum IngestionRelationKind {
     DerivedFrom,
 }
 
+impl IngestionRelationKind {
+    /// All variants in display order.
+    pub(crate) const ALL: &[Self] = &[Self::Supports, Self::Contradicts, Self::DerivedFrom];
+}
+
 impl From<IngestionRelationKind> for RelationKind {
     fn from(kind: IngestionRelationKind) -> Self {
         match kind {
@@ -42,6 +45,12 @@ impl From<IngestionRelationKind> for RelationKind {
             IngestionRelationKind::Contradicts => Self::Contradicts,
             IngestionRelationKind::DerivedFrom => Self::DerivedFrom,
         }
+    }
+}
+
+impl fmt::Display for IngestionRelationKind {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        RelationKind::from(*self).fmt(f)
     }
 }
 

--- a/crates/tribal-worker/src/parsing/snapshots/dialect/anthropic/extraction_output.json
+++ b/crates/tribal-worker/src/parsing/snapshots/dialect/anthropic/extraction_output.json
@@ -36,7 +36,7 @@
       "type": "object"
     },
     "KnowledgeKind": {
-      "description": "The classification of a knowledge item.",
+      "description": "The kind of knowledge captured.",
       "enum": [
         "fact",
         "heuristic",

--- a/crates/tribal-worker/src/parsing/snapshots/dialect/anthropic/extraction_output.json
+++ b/crates/tribal-worker/src/parsing/snapshots/dialect/anthropic/extraction_output.json
@@ -3,10 +3,10 @@
   "definitions": {
     "Candidate": {
       "additionalProperties": false,
-      "description": "A single knowledge item extracted from the input.\n\nThe primary output of the extraction stage; each candidate is triaged against existing knowledge before it is committed or discarded.",
+      "description": "A single self-contained knowledge item extracted from the input.",
       "properties": {
         "content": {
-          "description": "The captured tacit knowledge, as one self-contained claim.",
+          "description": "The captured tacit knowledge as one self-contained, atomic claim. Include the reasoning, constraints, or rejected alternatives when they are part of the knowledge being captured.",
           "type": "string"
         },
         "kind": {
@@ -21,7 +21,7 @@
           "type": "array"
         },
         "suggested_tags": {
-          "description": "Categorisation tags for the item. Always present; an absent field is a parse error.",
+          "description": "Categorisation tags for the item.",
           "items": {
             "type": "string"
           },
@@ -36,7 +36,7 @@
       "type": "object"
     },
     "KnowledgeKind": {
-      "description": "The kind of knowledge: fact (a verifiable piece of information), heuristic (a rule of thumb learned from experience), procedure (an ordered set of steps), or decision_record (a choice made and its rationale).",
+      "description": "The classification of a knowledge item.",
       "enum": [
         "fact",
         "heuristic",
@@ -47,7 +47,7 @@
     },
     "RelationHint": {
       "additionalProperties": false,
-      "description": "An intra-batch relation hint between two candidates by index.\n\nEmitted by the extraction agent to indicate that one candidate is derived from another within the same batch.",
+      "description": "A relation between two candidates in this batch, referenced by their array indices.",
       "properties": {
         "hint_type": {
           "$ref": "#/definitions/RelationHintType",
@@ -70,7 +70,7 @@
       "type": "object"
     },
     "RelationHintType": {
-      "description": "The type of an intra-batch relation hint emitted by the extraction agent.\n\nCurrently a single variant; the enum exists as an extension point for future hint types.",
+      "description": "How two candidates relate within this batch. Currently `derived_from`: the source candidate was produced using the target candidate as input or premise.",
       "enum": [
         "derived_from"
       ],
@@ -88,7 +88,7 @@
           ]
         },
         "reference_type": {
-          "description": "What kind of anchor this is (e.g. `\"url\"`, `\"file_path\"`); free-form.",
+          "description": "What kind of anchor this is. Use one of `file_path`, `url`, `symbol`, or `concept`.",
           "type": "string"
         },
         "value": {

--- a/crates/tribal-worker/src/parsing/snapshots/dialect/anthropic/extraction_output.json
+++ b/crates/tribal-worker/src/parsing/snapshots/dialect/anthropic/extraction_output.json
@@ -3,25 +3,25 @@
   "definitions": {
     "Candidate": {
       "additionalProperties": false,
-      "description": "A knowledge item candidate extracted from raw input.\n\nCandidates are the primary output of the extraction stage. Each candidate may progress through triage to become a committed knowledge item, or be discarded as a duplicate.",
+      "description": "A single knowledge item extracted from the input.\n\nThe primary output of the extraction stage; each candidate is triaged against existing knowledge before it is committed or discarded.",
       "properties": {
         "content": {
-          "description": "The knowledge content.",
+          "description": "The captured tacit knowledge, as one self-contained claim.",
           "type": "string"
         },
         "kind": {
           "$ref": "#/definitions/KnowledgeKind",
-          "description": "Classification of the candidate knowledge."
+          "description": "The kind of knowledge this item records."
         },
         "suggested_references": {
-          "description": "Optional external references.",
+          "description": "External anchors the item refers to, used to connect it to related knowledge even when wording differs.",
           "items": {
             "$ref": "#/definitions/SuggestedReference"
           },
           "type": "array"
         },
         "suggested_tags": {
-          "description": "Suggested categorisation tags. Always expected from the extraction prompt — an absent field is a parse error.",
+          "description": "Categorisation tags for the item. Always present; an absent field is a parse error.",
           "items": {
             "type": "string"
           },
@@ -36,7 +36,7 @@
       "type": "object"
     },
     "KnowledgeKind": {
-      "description": "The classification of a knowledge item.",
+      "description": "The kind of knowledge: fact (a verifiable piece of information), heuristic (a rule of thumb learned from experience), procedure (an ordered set of steps), or decision_record (a choice made and its rationale).",
       "enum": [
         "fact",
         "heuristic",
@@ -78,21 +78,21 @@
     },
     "SuggestedReference": {
       "additionalProperties": false,
-      "description": "A suggested external reference for a candidate.\n\nThe `reference_type` is a free string — the LLM may produce values outside the expected set. Validation and mapping to [`ReferenceKind`] happens during triage, not extraction.\n\n[`ReferenceKind`]: crate::ReferenceKind",
+      "description": "An external anchor a candidate refers to (a URL, file path, code symbol, or concept) that can connect items even when their wording differs.",
       "properties": {
         "description": {
-          "description": "Optional human-readable context.",
+          "description": "Optional human-readable context for the anchor.",
           "type": [
             "string",
             "null"
           ]
         },
         "reference_type": {
-          "description": "Free-form reference type (e.g. `\"url\"`, `\"file_path\"`).",
+          "description": "What kind of anchor this is (e.g. `\"url\"`, `\"file_path\"`); free-form.",
           "type": "string"
         },
         "value": {
-          "description": "The reference value.",
+          "description": "The anchor itself: the URL, path, symbol, or concept.",
           "type": "string"
         }
       },
@@ -106,14 +106,14 @@
   "description": "Extracted knowledge items and optional intra-batch relationship hints.",
   "properties": {
     "candidates": {
-      "description": "Knowledge items extracted from the input. Each candidate should be atomic (one claim per item) and self-contained. Return an empty array if the input contains no extractable knowledge.",
+      "description": "Knowledge items extracted from the input, each an atomic, self-contained claim. Empty when the input contains no extractable knowledge.",
       "items": {
         "$ref": "#/definitions/Candidate"
       },
       "type": "array"
     },
     "relation_hints": {
-      "description": "Derivation relationships between candidates in this batch. Only include when one candidate is genuinely derived from another. Optional — omit or return an empty array when no intra-batch relationships exist.",
+      "description": "Derivation links between candidates in this batch. Empty unless one candidate is genuinely derived from another.",
       "items": {
         "$ref": "#/definitions/RelationHint"
       },

--- a/crates/tribal-worker/src/parsing/snapshots/dialect/anthropic/relation_output.json
+++ b/crates/tribal-worker/src/parsing/snapshots/dialect/anthropic/relation_output.json
@@ -2,7 +2,7 @@
   "additionalProperties": false,
   "definitions": {
     "IngestionRelationKind": {
-      "description": "How the source item relates to the target: supports (the source corroborates the target), contradicts (the source conflicts with or corrects it), or derived_from (the source was produced using the target as input).",
+      "description": "How the source item relates to the target item.",
       "enum": [
         "supports",
         "contradicts",

--- a/crates/tribal-worker/src/parsing/snapshots/dialect/anthropic/relation_output.json
+++ b/crates/tribal-worker/src/parsing/snapshots/dialect/anthropic/relation_output.json
@@ -2,7 +2,7 @@
   "additionalProperties": false,
   "definitions": {
     "IngestionRelationKind": {
-      "description": "The type of relationship between two knowledge items. 'supports' = source reinforces target. 'contradicts' = source conflicts with target. 'derived_from' = source was produced using target as input.",
+      "description": "How the source item relates to the target: supports (the source corroborates the target), contradicts (the source conflicts with or corrects it), or derived_from (the source was produced using the target as input).",
       "enum": [
         "supports",
         "contradicts",
@@ -15,7 +15,7 @@
       "description": "A directed relationship between two knowledge items.",
       "properties": {
         "justification": {
-          "description": "Brief explanation referencing specific content from both items. Persists in the knowledge graph and informs future retrieval — write for someone encountering this relationship without the original context.",
+          "description": "Why this relationship holds, grounded in the content of both items.",
           "type": [
             "string",
             "null"
@@ -23,7 +23,7 @@
         },
         "relation_type": {
           "$ref": "#/definitions/IngestionRelationKind",
-          "description": "The relationship type."
+          "description": "How the source relates to the target."
         },
         "source": {
           "$ref": "#/definitions/RelationTarget",
@@ -60,10 +60,10 @@
       "type": "object"
     }
   },
-  "description": "Relationship edges between knowledge items. Return an empty relations array when no genuine semantic relationships exist — forced relations degrade graph quality.",
+  "description": "The relationship edges to create. Empty when no genuine relationship holds between the items.",
   "properties": {
     "relations": {
-      "description": "Directed relationship edges. Each edge connects a source item to a target item with a typed relationship. Only include edges grounded in the actual content of both items.",
+      "description": "Directed edges, each connecting a source item to a target item. Only edges grounded in the content of both items.",
       "items": {
         "$ref": "#/definitions/RelationEdge"
       },

--- a/crates/tribal-worker/src/parsing/snapshots/dialect/anthropic/triage_classification.json
+++ b/crates/tribal-worker/src/parsing/snapshots/dialect/anthropic/triage_classification.json
@@ -19,7 +19,7 @@
           "description": "The existing item being assessed, referenced by its context index."
         },
         "justification": {
-          "description": "Why this relationship holds, grounded in the content of both items.",
+          "description": "Why this assessment was chosen, grounded in the content of both items.",
           "type": "string"
         },
         "suggested_relation": {
@@ -38,7 +38,7 @@
       "anyOf": [
         {
           "additionalProperties": false,
-          "description": "The candidate records knowledge not already captured by an existing item.",
+          "description": "The candidate records knowledge not already captured by an existing item. Default to this when the candidate adds any new context, or when uncertain.",
           "properties": {
             "decision": {
               "const": "created",

--- a/crates/tribal-worker/src/parsing/snapshots/dialect/anthropic/triage_classification.json
+++ b/crates/tribal-worker/src/parsing/snapshots/dialect/anthropic/triage_classification.json
@@ -2,7 +2,7 @@
   "additionalProperties": false,
   "definitions": {
     "RelationSuggestion": {
-      "description": "The triage agent's classification of a similar item before any relationship is created.\n\nOverlaps with [`RelationKind`] but is distinct: `Supersedes` and `DerivedFrom` are never suggested by triage, and `Unrelated` is never stored as a relation row.",
+      "description": "How an existing similar item relates to the candidate, assessed during triage independently of the novel-or-duplicate decision.",
       "enum": [
         "supports",
         "contradicts",
@@ -16,15 +16,15 @@
       "properties": {
         "item": {
           "$ref": "#/definitions/TriageItemReference",
-          "description": "The similar item being assessed, referenced by its context index in the provided similar items."
+          "description": "The existing item being assessed, referenced by its context index."
         },
         "justification": {
-          "description": "Brief explanation referencing specific content from both items. Explains why this relationship classification was chosen.",
+          "description": "Why this relationship holds, grounded in the content of both items.",
           "type": "string"
         },
         "suggested_relation": {
           "$ref": "#/definitions/RelationSuggestion",
-          "description": "The relationship between the existing item and the candidate. If 'contradicts', the outcome decision must be 'created' — contradictory information cannot be a duplicate."
+          "description": "How the existing item relates to the candidate."
         }
       },
       "required": [
@@ -38,7 +38,7 @@
       "anyOf": [
         {
           "additionalProperties": false,
-          "description": "The candidate contains information not already captured. This is the default — use when the candidate adds any new context, detail, correction, or perspective beyond what existing items capture.",
+          "description": "The candidate records knowledge not already captured by an existing item.",
           "properties": {
             "decision": {
               "const": "created",
@@ -52,7 +52,7 @@
         },
         {
           "additionalProperties": false,
-          "description": "The candidate restates an existing item with no meaningful new information. Must not be used when any similar_item_decision has suggested_relation 'contradicts' — a contradiction is always novel.",
+          "description": "The candidate restates an existing item, adding no meaningful new information. A candidate that contradicts an existing item is never a duplicate.",
           "properties": {
             "decision": {
               "const": "duplicate",
@@ -60,7 +60,7 @@
             },
             "matched_item": {
               "$ref": "#/definitions/TriageItemReference",
-              "description": "The similar item this candidate duplicates, referenced by its context index in the provided similar items."
+              "description": "The existing item this candidate duplicates, referenced by its context index."
             }
           },
           "required": [
@@ -70,7 +70,7 @@
           "type": "object"
         }
       ],
-      "description": "The classification outcome. 'created' is the default — only use 'duplicate' when the candidate makes the exact same claim as an existing item. A candidate assessed as contradicting any similar item MUST be 'created'."
+      "description": "Whether the candidate records new knowledge or duplicates an existing item."
     },
     "TriageItemReference": {
       "additionalProperties": false,
@@ -95,10 +95,10 @@
   "properties": {
     "outcome": {
       "$ref": "#/definitions/TriageDecision",
-      "description": "The classification decision. Default to 'created' (novel) unless the candidate makes the exact same specific claim as an existing item with no meaningful new information. When uncertain, choose 'created'."
+      "description": "Whether the candidate is novel or duplicates an existing item."
     },
     "similar_item_decisions": {
-      "description": "One entry per similar item provided. Each assessment is independent of the outcome decision and must include a justification referencing both items.",
+      "description": "One assessment per provided similar item, each made independently of the novel/duplicate outcome.",
       "items": {
         "$ref": "#/definitions/SimilarItemClassification"
       },

--- a/crates/tribal-worker/src/parsing/snapshots/dialect/anthropic/triage_classification.json
+++ b/crates/tribal-worker/src/parsing/snapshots/dialect/anthropic/triage_classification.json
@@ -2,7 +2,7 @@
   "additionalProperties": false,
   "definitions": {
     "RelationSuggestion": {
-      "description": "How an existing similar item relates to the candidate, assessed during triage independently of the novel-or-duplicate decision.",
+      "description": "How the candidate relates to an existing similar item, assessed during triage independently of the novel-or-duplicate decision.",
       "enum": [
         "supports",
         "contradicts",
@@ -24,7 +24,7 @@
         },
         "suggested_relation": {
           "$ref": "#/definitions/RelationSuggestion",
-          "description": "How the existing item relates to the candidate."
+          "description": "How the candidate relates to the existing item."
         }
       },
       "required": [

--- a/crates/tribal-worker/src/parsing/snapshots/dialect/openai/extraction_output.json
+++ b/crates/tribal-worker/src/parsing/snapshots/dialect/openai/extraction_output.json
@@ -3,10 +3,10 @@
   "definitions": {
     "Candidate": {
       "additionalProperties": false,
-      "description": "A single knowledge item extracted from the input.\n\nThe primary output of the extraction stage; each candidate is triaged against existing knowledge before it is committed or discarded.",
+      "description": "A single self-contained knowledge item extracted from the input.",
       "properties": {
         "content": {
-          "description": "The captured tacit knowledge, as one self-contained claim.",
+          "description": "The captured tacit knowledge as one self-contained, atomic claim. Include the reasoning, constraints, or rejected alternatives when they are part of the knowledge being captured.",
           "type": "string"
         },
         "kind": {
@@ -20,7 +20,7 @@
           "type": "array"
         },
         "suggested_tags": {
-          "description": "Categorisation tags for the item. Always present; an absent field is a parse error.",
+          "description": "Categorisation tags for the item.",
           "items": {
             "type": "string"
           },
@@ -36,7 +36,7 @@
       "type": "object"
     },
     "KnowledgeKind": {
-      "description": "The kind of knowledge: fact (a verifiable piece of information), heuristic (a rule of thumb learned from experience), procedure (an ordered set of steps), or decision_record (a choice made and its rationale).",
+      "description": "The classification of a knowledge item.",
       "enum": [
         "fact",
         "heuristic",
@@ -47,7 +47,7 @@
     },
     "RelationHint": {
       "additionalProperties": false,
-      "description": "An intra-batch relation hint between two candidates by index.\n\nEmitted by the extraction agent to indicate that one candidate is derived from another within the same batch.",
+      "description": "A relation between two candidates in this batch, referenced by their array indices.",
       "properties": {
         "hint_type": {
           "$ref": "#/definitions/RelationHintType"
@@ -69,7 +69,7 @@
       "type": "object"
     },
     "RelationHintType": {
-      "description": "The type of an intra-batch relation hint emitted by the extraction agent.\n\nCurrently a single variant; the enum exists as an extension point for future hint types.",
+      "description": "How two candidates relate within this batch. Currently `derived_from`: the source candidate was produced using the target candidate as input or premise.",
       "enum": [
         "derived_from"
       ],
@@ -87,7 +87,7 @@
           ]
         },
         "reference_type": {
-          "description": "What kind of anchor this is (e.g. `\"url\"`, `\"file_path\"`); free-form.",
+          "description": "What kind of anchor this is. Use one of `file_path`, `url`, `symbol`, or `concept`.",
           "type": "string"
         },
         "value": {

--- a/crates/tribal-worker/src/parsing/snapshots/dialect/openai/extraction_output.json
+++ b/crates/tribal-worker/src/parsing/snapshots/dialect/openai/extraction_output.json
@@ -3,24 +3,24 @@
   "definitions": {
     "Candidate": {
       "additionalProperties": false,
-      "description": "A knowledge item candidate extracted from raw input.\n\nCandidates are the primary output of the extraction stage. Each candidate may progress through triage to become a committed knowledge item, or be discarded as a duplicate.",
+      "description": "A single knowledge item extracted from the input.\n\nThe primary output of the extraction stage; each candidate is triaged against existing knowledge before it is committed or discarded.",
       "properties": {
         "content": {
-          "description": "The knowledge content.",
+          "description": "The captured tacit knowledge, as one self-contained claim.",
           "type": "string"
         },
         "kind": {
           "$ref": "#/definitions/KnowledgeKind"
         },
         "suggested_references": {
-          "description": "Optional external references.",
+          "description": "External anchors the item refers to, used to connect it to related knowledge even when wording differs.",
           "items": {
             "$ref": "#/definitions/SuggestedReference"
           },
           "type": "array"
         },
         "suggested_tags": {
-          "description": "Suggested categorisation tags. Always expected from the extraction prompt — an absent field is a parse error.",
+          "description": "Categorisation tags for the item. Always present; an absent field is a parse error.",
           "items": {
             "type": "string"
           },
@@ -36,7 +36,7 @@
       "type": "object"
     },
     "KnowledgeKind": {
-      "description": "The classification of a knowledge item.",
+      "description": "The kind of knowledge: fact (a verifiable piece of information), heuristic (a rule of thumb learned from experience), procedure (an ordered set of steps), or decision_record (a choice made and its rationale).",
       "enum": [
         "fact",
         "heuristic",
@@ -77,21 +77,21 @@
     },
     "SuggestedReference": {
       "additionalProperties": false,
-      "description": "A suggested external reference for a candidate.\n\nThe `reference_type` is a free string — the LLM may produce values outside the expected set. Validation and mapping to [`ReferenceKind`] happens during triage, not extraction.\n\n[`ReferenceKind`]: crate::ReferenceKind",
+      "description": "An external anchor a candidate refers to (a URL, file path, code symbol, or concept) that can connect items even when their wording differs.",
       "properties": {
         "description": {
-          "description": "Optional human-readable context.",
+          "description": "Optional human-readable context for the anchor.",
           "type": [
             "string",
             "null"
           ]
         },
         "reference_type": {
-          "description": "Free-form reference type (e.g. `\"url\"`, `\"file_path\"`).",
+          "description": "What kind of anchor this is (e.g. `\"url\"`, `\"file_path\"`); free-form.",
           "type": "string"
         },
         "value": {
-          "description": "The reference value.",
+          "description": "The anchor itself: the URL, path, symbol, or concept.",
           "type": "string"
         }
       },
@@ -106,14 +106,14 @@
   "description": "Extracted knowledge items and optional intra-batch relationship hints.",
   "properties": {
     "candidates": {
-      "description": "Knowledge items extracted from the input. Each candidate should be atomic (one claim per item) and self-contained. Return an empty array if the input contains no extractable knowledge.",
+      "description": "Knowledge items extracted from the input, each an atomic, self-contained claim. Empty when the input contains no extractable knowledge.",
       "items": {
         "$ref": "#/definitions/Candidate"
       },
       "type": "array"
     },
     "relation_hints": {
-      "description": "Derivation relationships between candidates in this batch. Only include when one candidate is genuinely derived from another. Optional — omit or return an empty array when no intra-batch relationships exist.",
+      "description": "Derivation links between candidates in this batch. Empty unless one candidate is genuinely derived from another.",
       "items": {
         "$ref": "#/definitions/RelationHint"
       },

--- a/crates/tribal-worker/src/parsing/snapshots/dialect/openai/extraction_output.json
+++ b/crates/tribal-worker/src/parsing/snapshots/dialect/openai/extraction_output.json
@@ -36,7 +36,7 @@
       "type": "object"
     },
     "KnowledgeKind": {
-      "description": "The classification of a knowledge item.",
+      "description": "The kind of knowledge captured.",
       "enum": [
         "fact",
         "heuristic",

--- a/crates/tribal-worker/src/parsing/snapshots/dialect/openai/relation_output.json
+++ b/crates/tribal-worker/src/parsing/snapshots/dialect/openai/relation_output.json
@@ -2,7 +2,7 @@
   "additionalProperties": false,
   "definitions": {
     "IngestionRelationKind": {
-      "description": "The type of relationship between two knowledge items. 'supports' = source reinforces target. 'contradicts' = source conflicts with target. 'derived_from' = source was produced using target as input.",
+      "description": "How the source item relates to the target: supports (the source corroborates the target), contradicts (the source conflicts with or corrects it), or derived_from (the source was produced using the target as input).",
       "enum": [
         "supports",
         "contradicts",
@@ -15,7 +15,7 @@
       "description": "A directed relationship between two knowledge items.",
       "properties": {
         "justification": {
-          "description": "Brief explanation referencing specific content from both items. Persists in the knowledge graph and informs future retrieval — write for someone encountering this relationship without the original context.",
+          "description": "Why this relationship holds, grounded in the content of both items.",
           "type": [
             "string",
             "null"
@@ -58,10 +58,10 @@
       "type": "object"
     }
   },
-  "description": "Relationship edges between knowledge items. Return an empty relations array when no genuine semantic relationships exist — forced relations degrade graph quality.",
+  "description": "The relationship edges to create. Empty when no genuine relationship holds between the items.",
   "properties": {
     "relations": {
-      "description": "Directed relationship edges. Each edge connects a source item to a target item with a typed relationship. Only include edges grounded in the actual content of both items.",
+      "description": "Directed edges, each connecting a source item to a target item. Only edges grounded in the content of both items.",
       "items": {
         "$ref": "#/definitions/RelationEdge"
       },

--- a/crates/tribal-worker/src/parsing/snapshots/dialect/openai/relation_output.json
+++ b/crates/tribal-worker/src/parsing/snapshots/dialect/openai/relation_output.json
@@ -2,7 +2,7 @@
   "additionalProperties": false,
   "definitions": {
     "IngestionRelationKind": {
-      "description": "How the source item relates to the target: supports (the source corroborates the target), contradicts (the source conflicts with or corrects it), or derived_from (the source was produced using the target as input).",
+      "description": "How the source item relates to the target item.",
       "enum": [
         "supports",
         "contradicts",

--- a/crates/tribal-worker/src/parsing/snapshots/dialect/openai/triage_classification.json
+++ b/crates/tribal-worker/src/parsing/snapshots/dialect/openai/triage_classification.json
@@ -2,7 +2,7 @@
   "additionalProperties": false,
   "definitions": {
     "RelationSuggestion": {
-      "description": "How an existing similar item relates to the candidate, assessed during triage independently of the novel-or-duplicate decision.",
+      "description": "How the candidate relates to an existing similar item, assessed during triage independently of the novel-or-duplicate decision.",
       "enum": [
         "supports",
         "contradicts",

--- a/crates/tribal-worker/src/parsing/snapshots/dialect/openai/triage_classification.json
+++ b/crates/tribal-worker/src/parsing/snapshots/dialect/openai/triage_classification.json
@@ -2,7 +2,7 @@
   "additionalProperties": false,
   "definitions": {
     "RelationSuggestion": {
-      "description": "The triage agent's classification of a similar item before any relationship is created.\n\nOverlaps with [`RelationKind`] but is distinct: `Supersedes` and `DerivedFrom` are never suggested by triage, and `Unrelated` is never stored as a relation row.",
+      "description": "How an existing similar item relates to the candidate, assessed during triage independently of the novel-or-duplicate decision.",
       "enum": [
         "supports",
         "contradicts",
@@ -18,7 +18,7 @@
           "$ref": "#/definitions/TriageItemReference"
         },
         "justification": {
-          "description": "Brief explanation referencing specific content from both items. Explains why this relationship classification was chosen.",
+          "description": "Why this relationship holds, grounded in the content of both items.",
           "type": "string"
         },
         "suggested_relation": {
@@ -36,7 +36,7 @@
       "anyOf": [
         {
           "additionalProperties": false,
-          "description": "The candidate contains information not already captured. This is the default — use when the candidate adds any new context, detail, correction, or perspective beyond what existing items capture.",
+          "description": "The candidate records knowledge not already captured by an existing item.",
           "properties": {
             "decision": {
               "const": "created",
@@ -50,7 +50,7 @@
         },
         {
           "additionalProperties": false,
-          "description": "The candidate restates an existing item with no meaningful new information. Must not be used when any similar_item_decision has suggested_relation 'contradicts' — a contradiction is always novel.",
+          "description": "The candidate restates an existing item, adding no meaningful new information. A candidate that contradicts an existing item is never a duplicate.",
           "properties": {
             "decision": {
               "const": "duplicate",
@@ -67,7 +67,7 @@
           "type": "object"
         }
       ],
-      "description": "The classification outcome. 'created' is the default — only use 'duplicate' when the candidate makes the exact same claim as an existing item. A candidate assessed as contradicting any similar item MUST be 'created'."
+      "description": "Whether the candidate records new knowledge or duplicates an existing item."
     },
     "TriageItemReference": {
       "additionalProperties": false,
@@ -94,7 +94,7 @@
       "$ref": "#/definitions/TriageDecision"
     },
     "similar_item_decisions": {
-      "description": "One entry per similar item provided. Each assessment is independent of the outcome decision and must include a justification referencing both items.",
+      "description": "One assessment per provided similar item, each made independently of the novel/duplicate outcome.",
       "items": {
         "$ref": "#/definitions/SimilarItemClassification"
       },

--- a/crates/tribal-worker/src/parsing/snapshots/dialect/openai/triage_classification.json
+++ b/crates/tribal-worker/src/parsing/snapshots/dialect/openai/triage_classification.json
@@ -18,7 +18,7 @@
           "$ref": "#/definitions/TriageItemReference"
         },
         "justification": {
-          "description": "Why this relationship holds, grounded in the content of both items.",
+          "description": "Why this assessment was chosen, grounded in the content of both items.",
           "type": "string"
         },
         "suggested_relation": {
@@ -36,7 +36,7 @@
       "anyOf": [
         {
           "additionalProperties": false,
-          "description": "The candidate records knowledge not already captured by an existing item.",
+          "description": "The candidate records knowledge not already captured by an existing item. Default to this when the candidate adds any new context, or when uncertain.",
           "properties": {
             "decision": {
               "const": "created",

--- a/crates/tribal-worker/src/parsing/triage.rs
+++ b/crates/tribal-worker/src/parsing/triage.rs
@@ -132,7 +132,7 @@ pub(crate) struct SimilarItemClassification {
     #[schemars(description = "The existing item being assessed, referenced by its context index.")]
     pub item: TriageItemReference,
     /// The agent's suggested relation classification.
-    #[schemars(description = "How the existing item relates to the candidate.")]
+    #[schemars(description = "How the candidate relates to the existing item.")]
     pub suggested_relation: RelationSuggestion,
     /// The agent's reasoning for the classification.
     #[schemars(

--- a/crates/tribal-worker/src/parsing/triage.rs
+++ b/crates/tribal-worker/src/parsing/triage.rs
@@ -18,16 +18,12 @@ use crate::error::StageError;
 )]
 pub(crate) struct TriageClassification {
     /// Whether the candidate is novel or a duplicate.
-    #[schemars(
-        description = "The classification decision. Default to 'created' (novel) unless \
-        the candidate makes the exact same specific claim as an existing item with no \
-        meaningful new information. When uncertain, choose 'created'."
-    )]
+    #[schemars(description = "Whether the candidate is novel or duplicates an existing item.")]
     pub outcome: TriageDecision,
     /// Per-similar-item decisions with justifications.
     #[schemars(
-        description = "One entry per similar item provided. Each assessment is independent \
-        of the outcome decision and must include a justification referencing both items."
+        description = "One assessment per provided similar item, each made independently \
+        of the novel/duplicate outcome."
     )]
     pub similar_item_decisions: Vec<SimilarItemClassification>,
 }
@@ -98,31 +94,27 @@ pub(crate) enum TriageItemReference {
 #[derive(Debug, Clone, PartialEq, Eq, Deserialize, schemars::JsonSchema)]
 #[serde(tag = "decision")]
 #[schemars(
-    description = "The classification outcome. 'created' is the default — only use \
-    'duplicate' when the candidate makes the exact same claim as an existing item. \
-    A candidate assessed as contradicting any similar item MUST be 'created'."
+    description = "Whether the candidate records new knowledge or duplicates an existing item."
 )]
 pub(crate) enum TriageDecision {
     /// The candidate is novel — a new knowledge item should be created.
     #[serde(rename = "created")]
     #[schemars(
-        description = "The candidate contains information not already captured. \
-        This is the default — use when the candidate adds any new context, detail, \
-        correction, or perspective beyond what existing items capture."
+        description = "The candidate records knowledge not already captured by an \
+        existing item."
     )]
     Novel,
     /// The candidate duplicates an existing item.
     #[serde(rename = "duplicate")]
     #[schemars(
-        description = "The candidate restates an existing item with no meaningful new \
-        information. Must not be used when any similar_item_decision has suggested_relation \
-        'contradicts' — a contradiction is always novel."
+        description = "The candidate restates an existing item, adding no meaningful new \
+        information. A candidate that contradicts an existing item is never a duplicate."
     )]
     Duplicate {
         /// The similar item the candidate duplicates, referenced by index.
         #[schemars(
-            description = "The similar item this candidate duplicates, referenced by its \
-            context index in the provided similar items."
+            description = "The existing item this candidate duplicates, referenced by its \
+            context index."
         )]
         matched_item: TriageItemReference,
     },
@@ -136,22 +128,14 @@ pub(crate) enum TriageDecision {
 )]
 pub(crate) struct SimilarItemClassification {
     /// The similar item that was compared against, referenced by index.
-    #[schemars(
-        description = "The similar item being assessed, referenced by its context index \
-        in the provided similar items."
-    )]
+    #[schemars(description = "The existing item being assessed, referenced by its context index.")]
     pub item: TriageItemReference,
     /// The agent's suggested relation classification.
-    #[schemars(
-        description = "The relationship between the existing item and the candidate. \
-        If 'contradicts', the outcome decision must be 'created' — contradictory \
-        information cannot be a duplicate."
-    )]
+    #[schemars(description = "How the existing item relates to the candidate.")]
     pub suggested_relation: RelationSuggestion,
     /// The agent's reasoning for the classification.
     #[schemars(
-        description = "Brief explanation referencing specific content from both items. \
-        Explains why this relationship classification was chosen."
+        description = "Why this relationship holds, grounded in the content of both items."
     )]
     pub justification: String,
 }

--- a/crates/tribal-worker/src/parsing/triage.rs
+++ b/crates/tribal-worker/src/parsing/triage.rs
@@ -101,7 +101,8 @@ pub(crate) enum TriageDecision {
     #[serde(rename = "created")]
     #[schemars(
         description = "The candidate records knowledge not already captured by an \
-        existing item."
+        existing item. Default to this when the candidate adds any new context, or when \
+        uncertain."
     )]
     Novel,
     /// The candidate duplicates an existing item.
@@ -135,7 +136,7 @@ pub(crate) struct SimilarItemClassification {
     pub suggested_relation: RelationSuggestion,
     /// The agent's reasoning for the classification.
     #[schemars(
-        description = "Why this relationship holds, grounded in the content of both items."
+        description = "Why this assessment was chosen, grounded in the content of both items."
     )]
     pub justification: String,
 }

--- a/crates/tribal-worker/src/prompt/legends.rs
+++ b/crates/tribal-worker/src/prompt/legends.rs
@@ -9,6 +9,8 @@ use std::fmt;
 
 use tribal_domain::RelationSuggestion;
 
+use crate::parsing::IngestionRelationKind;
+
 // ---------------------------------------------------------------------------
 // Similarity score bands
 // ---------------------------------------------------------------------------
@@ -127,16 +129,16 @@ pub(crate) fn similarity_score_legend() -> String {
 pub(crate) fn relation_suggestion_description(suggestion: RelationSuggestion) -> &'static str {
     match suggestion {
         RelationSuggestion::Supports => {
-            "The candidate reinforces or provides additional evidence \
-             for the existing item's claim."
+            "The new claim reinforces or provides additional evidence \
+             for the existing claim."
         }
         RelationSuggestion::Contradicts => {
-            "The candidate conflicts with, corrects, or updates \
-             the existing item."
+            "The new claim conflicts with, corrects, or updates the \
+             existing claim."
         }
         RelationSuggestion::Unrelated => {
-            "Despite appearing in the search results, the items \
-             address different concerns."
+            "Despite appearing in the search results, the new and \
+             existing claims address different concerns."
         }
     }
 }
@@ -146,6 +148,38 @@ pub(crate) fn relation_suggestion_legend() -> String {
     RelationSuggestion::ALL
         .iter()
         .map(|s| format!("- **{s}**: {}", relation_suggestion_description(*s)))
+        .collect::<Vec<_>>()
+        .join("\n")
+}
+
+/// Returns the prompt-facing description for an [`IngestionRelationKind`] variant.
+///
+/// Exhaustive match ensures a compile error when a new variant is added.
+pub(crate) fn ingestion_relation_kind_description(kind: IngestionRelationKind) -> &'static str {
+    match kind {
+        IngestionRelationKind::Supports => {
+            "A provides evidence for, reinforces, or adds supporting context \
+             to B. Both point in the same direction; one strengthens the claim \
+             made by the other."
+        }
+        IngestionRelationKind::Contradicts => {
+            "A conflicts with, corrects, or undermines B. They cannot both be \
+             fully accurate simultaneously, or one represents a time-bound \
+             update that invalidates the other."
+        }
+        IngestionRelationKind::DerivedFrom => {
+            "A was logically derived from or builds directly upon B. This \
+             tracks intellectual provenance: where a conclusion or procedure \
+             came from."
+        }
+    }
+}
+
+/// Renders the ingestion relation kind legend for injection into system prompts.
+pub(crate) fn ingestion_relation_kind_legend() -> String {
+    IngestionRelationKind::ALL
+        .iter()
+        .map(|k| format!("- **{k}**: {}", ingestion_relation_kind_description(*k)))
         .collect::<Vec<_>>()
         .join("\n")
 }
@@ -244,6 +278,22 @@ mod tests {
             );
             assert!(
                 legend.contains(relation_suggestion_description(*suggestion)),
+                "legend should contain description for '{label}': {legend}",
+            );
+        }
+    }
+
+    #[test]
+    fn test_ingestion_relation_kind_legend_contains_all_variants() {
+        let legend = ingestion_relation_kind_legend();
+        for kind in IngestionRelationKind::ALL {
+            let label = kind.to_string();
+            assert!(
+                legend.contains(&label),
+                "legend should contain '{label}': {legend}",
+            );
+            assert!(
+                legend.contains(ingestion_relation_kind_description(*kind)),
                 "legend should contain description for '{label}': {legend}",
             );
         }

--- a/crates/tribal-worker/src/prompt/snapshots/relation/system.md
+++ b/crates/tribal-worker/src/prompt/snapshots/relation/system.md
@@ -18,6 +18,8 @@ Reference any item by its context index: `{"kind": "context_index", "context_ind
 
 ### Relation Types
 
+In the descriptions below, A is the edge's source and B is the edge's target.
+
 - **supports**: A provides evidence for, reinforces, or adds supporting context to B. Both point in the same direction; one strengthens the claim made by the other.
 - **contradicts**: A conflicts with, corrects, or undermines B. They cannot both be fully accurate simultaneously, or one represents a time-bound update that invalidates the other.
 - **derived_from**: A was logically derived from or builds directly upon B. This tracks intellectual provenance: where a conclusion or procedure came from.
@@ -77,7 +79,7 @@ Effective justifications:
 Examples:
 - "The incident report describes a 45-second failover caused by DNS cache TTL, providing direct evidence for the heuristic's claim that failover latency is governed by DNS TTL rather than health-check interval."
 - "These items describe the authentication token validation path at different points in time. The post-audit item states Redis is bypassed entirely, which directly contradicts the existing item's description of Redis-first validation with database fallback."
-- "The key rotation procedure in the source item explicitly depends on the 4-hour batch cycle described in the target — the 6-hour overlap window is calculated from the batch timing."
+- "The key rotation procedure explicitly depends on the 4-hour settlement batch cycle; the 6-hour overlap window is calculated from that batch timing."
 
 ## Inputs You Will Receive
 

--- a/crates/tribal-worker/src/prompt/snapshots/relation/system.md
+++ b/crates/tribal-worker/src/prompt/snapshots/relation/system.md
@@ -18,9 +18,9 @@ Reference any item by its context index: `{"kind": "context_index", "context_ind
 
 ### Relation Types
 
-- **supports**: Item A provides evidence for, reinforces, or adds supporting context to item B. Both items point in the same direction — one strengthens the claim made by the other.
-- **contradicts**: Item A conflicts with, corrects, or undermines item B. The two items cannot both be fully accurate simultaneously, or one represents a time-bound update that invalidates the other.
-- **derived_from**: Item A was logically derived from or builds directly upon item B. This tracks intellectual provenance — where a conclusion or procedure came from.
+- **supports**: A provides evidence for, reinforces, or adds supporting context to B. Both point in the same direction; one strengthens the claim made by the other.
+- **contradicts**: A conflicts with, corrects, or undermines B. They cannot both be fully accurate simultaneously, or one represents a time-bound update that invalidates the other.
+- **derived_from**: A was logically derived from or builds directly upon B. This tracks intellectual provenance: where a conclusion or procedure came from.
 
 ### When to Produce Relations
 
@@ -45,14 +45,14 @@ Returning an empty relations array is valid and often correct. Not every batch o
 Both directions of a relationship are valid when each carries independent semantic weight. Do not produce inverse edges mechanically — only when both directions are genuinely meaningful.
 
 Example of valid bidirectional support:
-- Item A (fact): "The March 2025 API gateway outage lasted 45 seconds instead of the expected 5-second failover window because the regional DNS cache TTL was set to 60 seconds."
-- Item B (heuristic): "Failover SLA is primarily governed by DNS cache TTLs, not health-check intervals. Always verify the DNS TTL configuration when failover latency is a hard requirement."
+- A (fact): "The March 2025 API gateway outage lasted 45 seconds instead of the expected 5-second failover window because the regional DNS cache TTL was set to 60 seconds."
+- B (heuristic): "Failover SLA is primarily governed by DNS cache TTLs, not health-check intervals. Always verify the DNS TTL configuration when failover latency is a hard requirement."
 - A supports B: The specific incident provides concrete evidence for the heuristic's claim about DNS TTL being the governing factor.
 - B supports A: The heuristic provides the analytical framework that explains why the incident occurred.
 
 Example of valid bidirectional contradiction:
-- Item A (fact): "The authentication service validates tokens by checking Redis first, falling back to the database only on cache miss."
-- Item B (fact): "Since the Q3 2025 security audit, the authentication service validates tokens directly against the database on every request. The Redis cache is deployed but no longer consulted."
+- A (fact): "The authentication service validates tokens by checking Redis first, falling back to the database only on cache miss."
+- B (fact): "Since the Q3 2025 security audit, the authentication service validates tokens directly against the database on every request. The Redis cache is deployed but no longer consulted."
 - A contradicts B and B contradicts A: Each item describes a state incompatible with the other. Both may be referenced by other items in the graph, and both directions of the contradiction are meaningful for understanding the system's evolution.
 
 ## Interpreting Similarity Scores

--- a/crates/tribal-worker/src/prompt/snapshots/triage/system.md
+++ b/crates/tribal-worker/src/prompt/snapshots/triage/system.md
@@ -116,9 +116,9 @@ The following candidates should be classified as duplicate:
 
 For each existing item you receive, independently assess its relationship to the candidate regardless of your novel/duplicate decision:
 
-- **supports**: The candidate reinforces or provides additional evidence for the existing item's claim.
-- **contradicts**: The candidate conflicts with, corrects, or updates the existing item.
-- **unrelated**: Despite appearing in the search results, the items address different concerns.
+- **supports**: The new claim reinforces or provides additional evidence for the existing claim.
+- **contradicts**: The new claim conflicts with, corrects, or updates the existing claim.
+- **unrelated**: Despite appearing in the search results, the new and existing claims address different concerns.
 
 Justifications should reference the specific content of both items and explain why the relationship holds. Examples of effective justifications:
 - "Both items address checkout flow performance. The candidate identifies CartContext provider placement as the root cause of the re-rendering latency the existing item reports."

--- a/crates/tribal-worker/src/prompt/variables.rs
+++ b/crates/tribal-worker/src/prompt/variables.rs
@@ -3,7 +3,9 @@
 
 use strum::IntoEnumIterator;
 
-use super::legends::{relation_suggestion_legend, similarity_score_legend};
+use super::legends::{
+    ingestion_relation_kind_legend, relation_suggestion_legend, similarity_score_legend,
+};
 
 // ---------------------------------------------------------------------------
 // Variable names
@@ -38,6 +40,9 @@ pub(crate) const VAR_SIMILARITY_SCORE_LEGEND: &str = "similarity_score_legend";
 
 /// Tera context variable: formatted relation suggestion value descriptions.
 pub(crate) const VAR_RELATION_SUGGESTION_LEGEND: &str = "relation_suggestion_legend";
+
+/// Tera context variable: formatted ingestion relation kind value descriptions.
+pub(crate) const VAR_INGESTION_RELATION_KIND_LEGEND: &str = "ingestion_relation_kind_legend";
 
 // ---------------------------------------------------------------------------
 // Reserved variables
@@ -115,6 +120,10 @@ pub(crate) fn triage_system_context() -> tera::Context {
 pub(crate) fn relation_system_context() -> tera::Context {
     let mut ctx = tera::Context::new();
     ctx.insert(VAR_SIMILARITY_SCORE_LEGEND, &similarity_score_legend());
+    ctx.insert(
+        VAR_INGESTION_RELATION_KIND_LEGEND,
+        &ingestion_relation_kind_legend(),
+    );
     ctx
 }
 

--- a/prompts/relation/system.tera
+++ b/prompts/relation/system.tera
@@ -18,6 +18,8 @@ Reference any item by its context index: `{"kind": "context_index", "context_ind
 
 ### Relation Types
 
+In the descriptions below, A is the edge's source and B is the edge's target.
+
 {{ ingestion_relation_kind_legend }}
 
 ### When to Produce Relations
@@ -72,7 +74,7 @@ Effective justifications:
 Examples:
 - "The incident report describes a 45-second failover caused by DNS cache TTL, providing direct evidence for the heuristic's claim that failover latency is governed by DNS TTL rather than health-check interval."
 - "These items describe the authentication token validation path at different points in time. The post-audit item states Redis is bypassed entirely, which directly contradicts the existing item's description of Redis-first validation with database fallback."
-- "The key rotation procedure in the source item explicitly depends on the 4-hour batch cycle described in the target — the 6-hour overlap window is calculated from the batch timing."
+- "The key rotation procedure explicitly depends on the 4-hour settlement batch cycle; the 6-hour overlap window is calculated from that batch timing."
 
 ## Inputs You Will Receive
 

--- a/prompts/relation/system.tera
+++ b/prompts/relation/system.tera
@@ -18,9 +18,7 @@ Reference any item by its context index: `{"kind": "context_index", "context_ind
 
 ### Relation Types
 
-- **supports**: Item A provides evidence for, reinforces, or adds supporting context to item B. Both items point in the same direction — one strengthens the claim made by the other.
-- **contradicts**: Item A conflicts with, corrects, or undermines item B. The two items cannot both be fully accurate simultaneously, or one represents a time-bound update that invalidates the other.
-- **derived_from**: Item A was logically derived from or builds directly upon item B. This tracks intellectual provenance — where a conclusion or procedure came from.
+{{ ingestion_relation_kind_legend }}
 
 ### When to Produce Relations
 
@@ -45,14 +43,14 @@ Returning an empty relations array is valid and often correct. Not every batch o
 Both directions of a relationship are valid when each carries independent semantic weight. Do not produce inverse edges mechanically — only when both directions are genuinely meaningful.
 
 Example of valid bidirectional support:
-- Item A (fact): "The March 2025 API gateway outage lasted 45 seconds instead of the expected 5-second failover window because the regional DNS cache TTL was set to 60 seconds."
-- Item B (heuristic): "Failover SLA is primarily governed by DNS cache TTLs, not health-check intervals. Always verify the DNS TTL configuration when failover latency is a hard requirement."
+- A (fact): "The March 2025 API gateway outage lasted 45 seconds instead of the expected 5-second failover window because the regional DNS cache TTL was set to 60 seconds."
+- B (heuristic): "Failover SLA is primarily governed by DNS cache TTLs, not health-check intervals. Always verify the DNS TTL configuration when failover latency is a hard requirement."
 - A supports B: The specific incident provides concrete evidence for the heuristic's claim about DNS TTL being the governing factor.
 - B supports A: The heuristic provides the analytical framework that explains why the incident occurred.
 
 Example of valid bidirectional contradiction:
-- Item A (fact): "The authentication service validates tokens by checking Redis first, falling back to the database only on cache miss."
-- Item B (fact): "Since the Q3 2025 security audit, the authentication service validates tokens directly against the database on every request. The Redis cache is deployed but no longer consulted."
+- A (fact): "The authentication service validates tokens by checking Redis first, falling back to the database only on cache miss."
+- B (fact): "Since the Q3 2025 security audit, the authentication service validates tokens directly against the database on every request. The Redis cache is deployed but no longer consulted."
 - A contradicts B and B contradicts A: Each item describes a state incompatible with the other. Both may be referenced by other items in the graph, and both directions of the contradiction are meaningful for understanding the system's evolution.
 
 ## Interpreting Similarity Scores


### PR DESCRIPTION
Tunes the schemars field descriptions on the three pipeline response types and their nested types to steer the model now that tribal-memory/cortex#31 makes descriptions reliably delivered. Also strips em dashes and impl jargon from the MCP tool surface while in the neighbourhood. Per-rule channel ownership (schema, prompt, or legend) is recorded at `docs/draft/177-schema-prompt-division.md`; the broader prompt-vocabulary migration is split out as tribal-memory/cortex#29.

Closes tribal-memory/cortex#30.