### PR TITLE
[CHORE] Bump version to 0.2.4 and add changelog entry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,18 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ## [Unreleased]
 
+## [0.2.4] - 2026-05-28
+
+### Fixed
+
+- Pipeline response schemas are now sent in each provider's accepted JSON Schema dialect with hard schema enforcement. OpenAI requests carry the strict subset (closed all-required objects, nullable optionals, internally-tagged enums emitted as `anyOf` of closed branches) with `strict: true`; Anthropic requests rewrite `oneOf` to `anyOf` and close every object so its grammar enforcement applies. The previous advisory mode allowed weaker cloud models, including the recommended `gpt-5.4-mini`, to return malformed shapes that dead-lettered ingest jobs after exhausting retries. Structured output is now guaranteed by the provider rather than hoped for.
+
+### Changed
+
+- Pipeline response-schema field descriptions are tightened across the extraction, triage, and relation stages to give the model a clearer instruction surface.
+- MCP tool descriptions are rewritten to remove implementation jargon, presenting each tool through its user-facing contract rather than its internal mechanism.
+- The triage stage's relation-direction explanation in the prompt is aligned with the legend, with explicit source/target binding, so the model classifies similar-item relations more consistently.
+
 ## [0.2.3] - 2026-05-27
 
 ### Fixed
@@ -36,7 +48,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 - Docker Compose provider configuration through `.env`, letting the containerised path target a cloud provider (OpenAI, Anthropic) instead of only a local Ollama.
 
-[Unreleased]: https://github.com/tribal-memory/tribal/compare/v0.2.3...HEAD
+[Unreleased]: https://github.com/tribal-memory/tribal/compare/v0.2.4...HEAD
+[0.2.4]: https://github.com/tribal-memory/tribal/compare/v0.2.3...v0.2.4
 [0.2.3]: https://github.com/tribal-memory/tribal/compare/v0.2.2...v0.2.3
 [0.2.2]: https://github.com/tribal-memory/tribal/compare/v0.2.1...v0.2.2
 [0.2.1]: https://github.com/tribal-memory/tribal/releases/tag/v0.2.1

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5260,7 +5260,7 @@ dependencies = [
 
 [[package]]
 name = "tribal"
-version = "0.2.3"
+version = "0.2.4"
 dependencies = [
  "anstream 1.0.0",
  "axum",
@@ -5310,7 +5310,7 @@ dependencies = [
 
 [[package]]
 name = "tribal-common"
-version = "0.2.3"
+version = "0.2.4"
 dependencies = [
  "dashmap",
  "rand 0.10.1",
@@ -5321,7 +5321,7 @@ dependencies = [
 
 [[package]]
 name = "tribal-config"
-version = "0.2.3"
+version = "0.2.4"
 dependencies = [
  "dirs",
  "figment",
@@ -5336,7 +5336,7 @@ dependencies = [
 
 [[package]]
 name = "tribal-db"
-version = "0.2.3"
+version = "0.2.4"
 dependencies = [
  "async-trait",
  "chrono",
@@ -5355,7 +5355,7 @@ dependencies = [
 
 [[package]]
 name = "tribal-domain"
-version = "0.2.3"
+version = "0.2.4"
 dependencies = [
  "chrono",
  "schemars 0.8.22",
@@ -5369,7 +5369,7 @@ dependencies = [
 
 [[package]]
 name = "tribal-e2e"
-version = "0.2.3"
+version = "0.2.4"
 dependencies = [
  "chrono",
  "dashmap",
@@ -5395,7 +5395,7 @@ dependencies = [
 
 [[package]]
 name = "tribal-inference"
-version = "0.2.3"
+version = "0.2.4"
 dependencies = [
  "async-trait",
  "reqwest 0.13.2",
@@ -5411,7 +5411,7 @@ dependencies = [
 
 [[package]]
 name = "tribal-mcp"
-version = "0.2.3"
+version = "0.2.4"
 dependencies = [
  "axum",
  "chrono",
@@ -5444,7 +5444,7 @@ dependencies = [
 
 [[package]]
 name = "tribal-telemetry"
-version = "0.2.3"
+version = "0.2.4"
 dependencies = [
  "opentelemetry",
  "opentelemetry-otlp",
@@ -5465,7 +5465,7 @@ dependencies = [
 
 [[package]]
 name = "tribal-test-utils"
-version = "0.2.3"
+version = "0.2.4"
 dependencies = [
  "anstream 1.0.0",
  "async-trait",
@@ -5489,7 +5489,7 @@ dependencies = [
 
 [[package]]
 name = "tribal-ui"
-version = "0.2.3"
+version = "0.2.4"
 dependencies = [
  "anstream 1.0.0",
  "anstyle",
@@ -5504,7 +5504,7 @@ dependencies = [
 
 [[package]]
 name = "tribal-worker"
-version = "0.2.3"
+version = "0.2.4"
 dependencies = [
  "chrono",
  "dashmap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ members = [
 
 [workspace.package]
 edition = "2024"
-version = "0.2.3"
+version = "0.2.4"
 license = "Elastic-2.0"
 rust-version = "1.93"
 publish = false

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -19,7 +19,7 @@ services:
         max-file: "3"
 
   tribal:
-    image: ghcr.io/tribal-memory/tribal:0.2.3
+    image: ghcr.io/tribal-memory/tribal:0.2.4
     depends_on:
       postgres:
         condition: service_healthy


### PR DESCRIPTION
## Summary

Cut 0.2.4. Bundles the structured-output reliability fix (#175 via PR tribal-memory/tribal#176) and the schema-description tightening (#177 via PR tribal-memory/tribal#179) that have landed on `main` since 0.2.3. Bumps the workspace version, the docker-compose image tag, syncs `Cargo.lock`, and adds the CHANGELOG entry.

## Test plan

- [ ] CI green on this branch
- [ ] On merge, tag `v0.2.4` and push the tag so cargo-dist publishes the GitHub Release with the matching CHANGELOG section as notes