### PR TITLE
[CHORE] Cut 0.2.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,22 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ## [Unreleased]
 
+## [0.2.5] - 2026-05-30
+
+### Added
+
+- OAuth 2.1 authentication for the HTTP and SSE transports, in a new `tribal-auth` crate. Tribal now runs as an OAuth authorisation server: Dynamic Client Registration (RFC 7591), PKCE, an authorisation-code flow with an explicit consent step, the RFC 8414 and RFC 9728 discovery metadata endpoints, and audience-bound bearer tokens. An OAuth-capable harness registers and authenticates itself on first connect, so the loopback wire-up carries no token to copy.
+
+### Changed
+
+- `tribal bootstrap` and `tribal mcp-config` choose the wire-up shape from the deployment's onboarding mode rather than always emitting a token. A loopback deployment with dynamic registration enabled advertises a URL-only OAuth snippet with nothing to copy; every other surface (reachable beyond loopback, or with registration disabled) embeds the persisted static token. Pass `--static-token` to force that token for a harness that authenticates with a bearer header only.
+- `tribal check`'s token check follows the same onboarding mode: it skips on a URL-only surface, where clients authenticate over OAuth, and fails when a surface that depends on a static token has none.
+- A missing bearer token on a network request now logs at DEBUG rather than WARN, so a steady-state healthcheck cycle no longer emits misleading authentication warnings.
+
+### Security
+
+- The unauthenticated Dynamic Client Registration endpoint is refused whenever the OAuth surface is reachable beyond loopback. With no explicit advertised URL, a wildcard bind (`0.0.0.0` or `[::]`) is treated as routable and fails closed; a loopback `server.public_mcp_url` is the trusted-exposure override for the container host-port-mapping shape. `server.public_mcp_url` is validated at load as an `http(s)` endpoint with a host and no fragment, and the same check guards the non-validating `tribal mcp-config` renderer.
+
 ## [0.2.4] - 2026-05-28
 
 ### Fixed
@@ -48,7 +64,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 - Docker Compose provider configuration through `.env`, letting the containerised path target a cloud provider (OpenAI, Anthropic) instead of only a local Ollama.
 
-[Unreleased]: https://github.com/tribal-memory/tribal/compare/v0.2.4...HEAD
+[Unreleased]: https://github.com/tribal-memory/tribal/compare/v0.2.5...HEAD
+[0.2.5]: https://github.com/tribal-memory/tribal/compare/v0.2.4...v0.2.5
 [0.2.4]: https://github.com/tribal-memory/tribal/compare/v0.2.3...v0.2.4
 [0.2.3]: https://github.com/tribal-memory/tribal/compare/v0.2.2...v0.2.3
 [0.2.2]: https://github.com/tribal-memory/tribal/compare/v0.2.1...v0.2.2

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5260,7 +5260,7 @@ dependencies = [
 
 [[package]]
 name = "tribal"
-version = "0.2.4"
+version = "0.2.5"
 dependencies = [
  "anstream 1.0.0",
  "axum",
@@ -5310,7 +5310,7 @@ dependencies = [
 
 [[package]]
 name = "tribal-auth"
-version = "0.2.4"
+version = "0.2.5"
 dependencies = [
  "async-trait",
  "axum",
@@ -5339,7 +5339,7 @@ dependencies = [
 
 [[package]]
 name = "tribal-common"
-version = "0.2.4"
+version = "0.2.5"
 dependencies = [
  "dashmap",
  "rand 0.10.1",
@@ -5350,7 +5350,7 @@ dependencies = [
 
 [[package]]
 name = "tribal-config"
-version = "0.2.4"
+version = "0.2.5"
 dependencies = [
  "dirs",
  "figment",
@@ -5366,7 +5366,7 @@ dependencies = [
 
 [[package]]
 name = "tribal-db"
-version = "0.2.4"
+version = "0.2.5"
 dependencies = [
  "async-trait",
  "chrono",
@@ -5385,7 +5385,7 @@ dependencies = [
 
 [[package]]
 name = "tribal-domain"
-version = "0.2.4"
+version = "0.2.5"
 dependencies = [
  "chrono",
  "schemars 0.8.22",
@@ -5399,7 +5399,7 @@ dependencies = [
 
 [[package]]
 name = "tribal-e2e"
-version = "0.2.4"
+version = "0.2.5"
 dependencies = [
  "chrono",
  "dashmap",
@@ -5427,7 +5427,7 @@ dependencies = [
 
 [[package]]
 name = "tribal-inference"
-version = "0.2.4"
+version = "0.2.5"
 dependencies = [
  "async-trait",
  "reqwest 0.13.2",
@@ -5443,7 +5443,7 @@ dependencies = [
 
 [[package]]
 name = "tribal-mcp"
-version = "0.2.4"
+version = "0.2.5"
 dependencies = [
  "axum",
  "chrono",
@@ -5477,7 +5477,7 @@ dependencies = [
 
 [[package]]
 name = "tribal-telemetry"
-version = "0.2.4"
+version = "0.2.5"
 dependencies = [
  "opentelemetry",
  "opentelemetry-otlp",
@@ -5498,7 +5498,7 @@ dependencies = [
 
 [[package]]
 name = "tribal-test-utils"
-version = "0.2.4"
+version = "0.2.5"
 dependencies = [
  "anstream 1.0.0",
  "async-trait",
@@ -5522,7 +5522,7 @@ dependencies = [
 
 [[package]]
 name = "tribal-ui"
-version = "0.2.4"
+version = "0.2.5"
 dependencies = [
  "anstream 1.0.0",
  "anstyle",
@@ -5537,7 +5537,7 @@ dependencies = [
 
 [[package]]
 name = "tribal-worker"
-version = "0.2.4"
+version = "0.2.5"
 dependencies = [
  "chrono",
  "dashmap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ members = [
 
 [workspace.package]
 edition = "2024"
-version = "0.2.4"
+version = "0.2.5"
 license = "Elastic-2.0"
 rust-version = "1.93"
 publish = false

--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ tribal check --json
 
 ## Connecting to your agent harness
 
-The canonical MCP config for any compatible harness comes from `tribal mcp-config --json`. The shape stays consistent across transports, with the right discriminator and credentials for whichever transport you chose during bootstrap.
+The canonical MCP config for any compatible harness comes from `tribal mcp-config`, which writes the JSON snippet to stdout. On a local HTTP or SSE deployment the snippet is URL-only: an OAuth-capable harness registers and authenticates itself on first connect, so there is nothing to copy. Pass `--static-token` to embed the persisted bearer token instead, for a harness that authenticates with an `Authorization` header only. The stdio snippet carries no token; it authenticates as a local principal at runtime.
 
 For per-harness translations, ask your agent to invoke the [`installing-tribal` skill](https://github.com/tribal-memory/skills/tree/main/skills/installing-tribal). It walks through wiring Tribal into your harness and produces the exact command to run.
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -19,7 +19,7 @@ services:
         max-file: "3"
 
   tribal:
-    image: ghcr.io/tribal-memory/tribal:0.2.4
+    image: ghcr.io/tribal-memory/tribal:0.2.5
     depends_on:
       postgres:
         condition: service_healthy


### PR DESCRIPTION
Cuts **0.2.5**. Version bump (`[workspace.package]` 0.2.4 to 0.2.5, Cargo.lock synced), changelog entry, and a README accuracy fix.

## What 0.2.5 ships

The authentication system lands: the `tribal-auth` crate, OAuth 2.1 with Dynamic Client Registration (RFC 7591), PKCE, an authorisation-code flow with a consent step, the RFC 8414 / 9728 metadata endpoints, and audience-bound bearer tokens. The onboarding surface (`tribal bootstrap`, `tribal mcp-config`, `tribal check`) is now keyed on deployment topology and DCR availability: a loopback deployment with registration enabled advertises a URL-only OAuth snippet with nothing to copy, and `--static-token` is the escape hatch for bearer-only harnesses.

Headline security property: the unauthenticated `/register` endpoint is refused whenever the OAuth surface is reachable beyond loopback, failing closed on a wildcard bind unless an explicit loopback `public_mcp_url` marks it trusted (the container host-port-mapping shape).

See the changelog entry for the full Added / Changed / Security breakdown.

## Also in this PR

- `docs(readme)`: the Connecting section now reflects the URL-only OAuth default and drops `tribal mcp-config --json` (not a valid flag; the command writes JSON to stdout unconditionally).

## After merge

Tagging the merge commit `v0.2.5` triggers `release.yml` (cargo-dist: GitHub release with installers, consumed by the Homebrew tap and the shell installer) and `docker.yml` (the `ghcr.io/tribal-memory/tribal` image). That published release is the prerequisite for the macOS smoke pass.