### PR TITLE
[CHORE] Use pgvector/pgvector:pg17 for db-up

### DIFF
--- a/justfile
+++ b/justfile
@@ -30,7 +30,7 @@ db-up:
             -e POSTGRES_PASSWORD=tribal \
             -e POSTGRES_DB=tribal \
             -p 5432:5432 \
-            ankane/pgvector:latest
+            pgvector/pgvector:pg17
         echo "tribal-postgres created and started"
     fi
 


### PR DESCRIPTION
The local dev `db-up` recipe pinned `ankane/pgvector:latest`, the pre-org pgvector image. Align it with what `docker-compose.yml` already uses (`pgvector/pgvector:pg17`) so the dev loop and the bundled stack run the same Postgres. Dev-tooling only.