### PR TITLE
[REFACTOR] Style and harden the OAuth consent page

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -130,6 +130,59 @@ dependencies = [
 ]
 
 [[package]]
+name = "askama"
+version = "0.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1bf825125edd887a019d0a3a837dcc5499a68b0d034cc3eb594070c3e18addc"
+dependencies = [
+ "askama_macros",
+ "itoa",
+ "percent-encoding",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "askama_derive"
+version = "0.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1c7065972a130eafa84215f21352ae15b4a7393da48c1f5e103904490736738"
+dependencies = [
+ "askama_parser",
+ "basic-toml",
+ "glob",
+ "memchr",
+ "proc-macro2",
+ "quote",
+ "rustc-hash",
+ "serde",
+ "serde_derive",
+ "syn",
+]
+
+[[package]]
+name = "askama_macros"
+version = "0.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0e23b1d2c4bd39a41971f6124cef4cc6fd0540913ecb90919b69ab3bbe44ae1a"
+dependencies = [
+ "askama_derive",
+]
+
+[[package]]
+name = "askama_parser"
+version = "0.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7db09fde9143e7ac4513358fb32ee32847125b63b18ea715afd487956da715da"
+dependencies = [
+ "rustc-hash",
+ "serde",
+ "serde_derive",
+ "unicode-ident",
+ "winnow 1.0.3",
+]
+
+[[package]]
 name = "assert-json-diff"
 version = "2.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -309,6 +362,15 @@ name = "base64ct"
 version = "1.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2af50177e190e07a26ab74f8b1efbfe2ef87da2116221318cb1c2e82baf7de06"
+
+[[package]]
+name = "basic-toml"
+version = "0.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba62675e8242a4c4e806d12f11d136e626e6c8361d6b829310732241652a178a"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "bit-set"
@@ -1437,7 +1499,7 @@ dependencies = [
  "bstr",
  "gix-date",
  "gix-error",
- "winnow",
+ "winnow 0.7.15",
 ]
 
 [[package]]
@@ -1493,7 +1555,7 @@ dependencies = [
  "smallvec",
  "thiserror 2.0.18",
  "unicode-bom",
- "winnow",
+ "winnow 0.7.15",
 ]
 
 [[package]]
@@ -1654,7 +1716,7 @@ dependencies = [
  "itoa",
  "smallvec",
  "thiserror 2.0.18",
- "winnow",
+ "winnow 0.7.15",
 ]
 
 [[package]]
@@ -1737,7 +1799,7 @@ dependencies = [
  "maybe-async",
  "nonempty",
  "thiserror 2.0.18",
- "winnow",
+ "winnow 0.7.15",
 ]
 
 [[package]]
@@ -1769,7 +1831,7 @@ dependencies = [
  "gix-validate",
  "memmap2",
  "thiserror 2.0.18",
- "winnow",
+ "winnow 0.7.15",
 ]
 
 [[package]]
@@ -1928,6 +1990,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "glob"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
+
+[[package]]
 name = "globset"
 version = "0.4.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2075,6 +2143,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cc627f471c528ff0c4a49e1d5e60450c8f6461dd6d10ba9dcd3a61d3dff7728d"
 dependencies = [
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "html-escape"
+version = "0.2.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d1ad449764d627e22bfd7cd5e8868264fc9236e07c752972b4080cd351cb476"
+dependencies = [
+ "utf8-width",
 ]
 
 [[package]]
@@ -5312,10 +5389,12 @@ dependencies = [
 name = "tribal-auth"
 version = "0.2.5"
 dependencies = [
+ "askama",
  "async-trait",
  "axum",
  "base64 0.22.1",
  "chrono",
+ "html-escape",
  "http",
  "rand 0.10.1",
  "serde",
@@ -5735,6 +5814,12 @@ name = "utf-8"
 version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09cc8ee72d2a9becf2f2febe0205bbed8fc6615b7cb429ad062dc7b7ddd036a9"
+
+[[package]]
+name = "utf8-width"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1292c0d970b54115d14f2492fe0170adf21d68a1de108eebc51c1df4f346a091"
 
 [[package]]
 name = "utf8_iter"
@@ -6376,6 +6461,15 @@ name = "winnow"
 version = "0.7.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df79d97927682d2fd8adb29682d1140b343be4ac0f08fd68b7765d9c059d3945"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
+name = "winnow"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0592e1c9d151f854e6fd382574c3a0855250e1d9b2f99d9281c6e6391af352f1"
 dependencies = [
  "memchr",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5413,6 +5413,7 @@ dependencies = [
  "tribal-domain",
  "tribal-test-utils",
  "typed-builder",
+ "unicode-general-category",
  "url",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -141,6 +141,7 @@ owo-colors = "4"
 supports-color = "3"
 termbg = "0.6"
 textwrap = "0.16"
+unicode-general-category = "1.1"
 unicode-segmentation = "1.13"
 unicode-width = "0.2"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,6 +35,10 @@ http-body = "1"
 pin-project-lite = "0.2"
 tower = { version = "0.5", features = ["util"] }
 
+# HTML templating
+askama = "0.16"
+html-escape = "0.2"
+
 # Database
 sqlx = { version = "0.8", default-features = false, features = ["runtime-tokio", "tls-rustls", "postgres", "uuid", "chrono", "json"] }
 pgvector = { version = "0.4", features = ["sqlx"] }

--- a/crates/tribal-auth/Cargo.toml
+++ b/crates/tribal-auth/Cargo.toml
@@ -7,6 +7,7 @@ publish.workspace = true
 license.workspace = true
 
 [dependencies]
+askama.workspace = true
 async-trait.workspace = true
 axum.workspace = true
 base64.workspace = true
@@ -33,6 +34,7 @@ tribal-domain.workspace = true
 test-helpers = []
 
 [dev-dependencies]
+html-escape.workspace = true
 serde_urlencoded.workspace = true
 tokio = { workspace = true, features = ["test-util"] }
 tower.workspace = true

--- a/crates/tribal-auth/Cargo.toml
+++ b/crates/tribal-auth/Cargo.toml
@@ -23,6 +23,7 @@ thiserror.workspace = true
 tokio.workspace = true
 tracing.workspace = true
 typed-builder.workspace = true
+unicode-general-category.workspace = true
 url.workspace = true
 
 tribal-common.workspace = true

--- a/crates/tribal-auth/src/oauth/authorize.rs
+++ b/crates/tribal-auth/src/oauth/authorize.rs
@@ -25,7 +25,7 @@ use tribal_domain::{LOCAL_PRINCIPAL_KEY, OauthAuthorizationCode, OauthClient};
 use url::Url;
 
 use crate::oauth::{
-    common::RESPONSE_TYPE_CODE,
+    common::{RESPONSE_TYPE_CODE, is_loopback_host},
     config::{OAuthRuntimeConfig, canonicalise_resource_url},
     consent::build_consent_html,
     error::{
@@ -34,7 +34,7 @@ use crate::oauth::{
     },
     pkce::CodeChallenge,
     redirect::matches_redirect_uri,
-    scope::{DEFAULT_GRANT_SCOPE, first_uncatalogued_scope, scope_exceeding_registration},
+    scope::{effective_scope, first_uncatalogued_scope, scope_exceeding_registration},
 };
 
 // ---------------------------------------------------------------------------
@@ -418,23 +418,31 @@ async fn issue_code(
             }
         })?;
 
-    // Resolve the effective grant once, here, so the consent page shows
-    // exactly what /token will mint and the stored code carries the same
-    // value: the requested scope, else the client's registered scope, else
-    // the default grant. Deriving it in one place keeps the displayed scope
-    // and the stored scope from drifting apart.
-    let effective_scope = query
-        .scope
-        .clone()
-        .or_else(|| resolved.registered_scope.clone())
-        .unwrap_or_else(|| DEFAULT_GRANT_SCOPE.to_owned());
+    // Resolve the effective grant through the shared resolver so the consent
+    // page, the stored code, and the token minted at /token all carry the same
+    // scope. Empty and whitespace-only requested or registered scopes resolve
+    // to the default there, so a blank scope cannot display as nothing while a
+    // token still mints.
+    let granted_scope =
+        effective_scope(query.scope.as_deref(), resolved.registered_scope.as_deref());
+
+    // Build the consent page before persisting the code, so a render failure
+    // leaves no orphaned, never-presented authorisation code behind.
+    let response = consent_page_response(
+        &resolved.redirect_uri,
+        &raw_code,
+        query.state.as_deref(),
+        &query.client_id,
+        resolved.client_name.as_deref(),
+        &granted_scope,
+    )?;
 
     let new = NewOauthAuthorizationCode::builder()
         .code_hash(code_hash)
         .client_id(query.client_id.clone())
         .redirect_uri(resolved.redirect_uri.as_str().to_owned())
         .code_challenge(challenge.as_str().to_owned())
-        .scope(Some(effective_scope.clone()))
+        .scope(Some(granted_scope))
         .resource(Some(canonical))
         .principal_id(principal_id)
         .expires_at(expires_at)
@@ -457,14 +465,7 @@ async fn issue_code(
             source: Some(Box::new(err)),
         })?;
 
-    consent_page_response(
-        &resolved.redirect_uri,
-        &raw_code,
-        query.state.as_deref(),
-        &query.client_id,
-        resolved.client_name.as_deref(),
-        &effective_scope,
-    )
+    Ok(response)
 }
 
 fn consent_page_response(
@@ -484,12 +485,27 @@ fn consent_page_response(
         }
     }
     let target = url.as_str().to_owned();
-    let host = redirect_uri.host_str().unwrap_or("");
-    let body = build_consent_html(&target, host, client_id, client_name, scope).map_err(|err| {
-        OAuthError::Internal {
-            operation: InternalOperation::RenderConsentPage,
-            source: Some(Box::new(err)),
-        }
+    // Display the full authority the code is delivered to, including a
+    // non-default port: the port is part of where the code goes, and for a
+    // loopback redirect it identifies which local process can receive it.
+    // Classify loopback from the bare host, not the host:port shown.
+    let bare_host = redirect_uri.host_str().unwrap_or("");
+    let authority = match redirect_uri.port() {
+        Some(port) => format!("{bare_host}:{port}"),
+        None => bare_host.to_owned(),
+    };
+    let is_loopback = is_loopback_host(bare_host);
+    let body = build_consent_html(
+        &target,
+        &authority,
+        client_id,
+        client_name,
+        scope,
+        is_loopback,
+    )
+    .map_err(|err| OAuthError::Internal {
+        operation: InternalOperation::RenderConsentPage,
+        source: Some(Box::new(err)),
     })?;
     let mut headers = HeaderMap::new();
     headers.insert(

--- a/crates/tribal-auth/src/oauth/authorize.rs
+++ b/crates/tribal-auth/src/oauth/authorize.rs
@@ -34,7 +34,7 @@ use crate::oauth::{
     },
     pkce::CodeChallenge,
     redirect::matches_redirect_uri,
-    scope::{first_uncatalogued_scope, scope_exceeding_registration},
+    scope::{DEFAULT_GRANT_SCOPE, first_uncatalogued_scope, scope_exceeding_registration},
 };
 
 // ---------------------------------------------------------------------------
@@ -200,11 +200,13 @@ pub async fn handle_authorize(
 }
 
 /// A `/authorize` client resolved against the registry: the matched
-/// redirect URI, and the registered scope grant that bounds what a code
-/// issued to this client may carry.
+/// redirect URI, the registered scope grant that bounds what a code issued
+/// to this client may carry, and the registered display name (when one was
+/// supplied at registration) shown on the consent page.
 struct ResolvedClient {
     redirect_uri: Url,
     registered_scope: Option<String>,
+    client_name: Option<String>,
 }
 
 async fn validate_pre_redirect(
@@ -232,6 +234,7 @@ async fn validate_pre_redirect(
     Ok(ResolvedClient {
         redirect_uri,
         registered_scope: client.scope().map(str::to_owned),
+        client_name: client.client_name().map(str::to_owned),
     })
 }
 
@@ -328,7 +331,7 @@ async fn issue_code(
 
     // A requested scope outside the advertised catalogue is rejected
     // before the code issues (RFC 6749 §4.1.2.1 invalid_scope). An absent
-    // scope is permitted; the grant falls back to the default at /token.
+    // scope is permitted; the effective grant is resolved below.
     if let Some(uncatalogued) = query.scope.as_deref().and_then(first_uncatalogued_scope) {
         return Err(OAuthError::InvalidScope {
             unknown_token: uncatalogued.to_owned(),
@@ -415,20 +418,23 @@ async fn issue_code(
             }
         })?;
 
+    // Resolve the effective grant once, here, so the consent page shows
+    // exactly what /token will mint and the stored code carries the same
+    // value: the requested scope, else the client's registered scope, else
+    // the default grant. Deriving it in one place keeps the displayed scope
+    // and the stored scope from drifting apart.
+    let effective_scope = query
+        .scope
+        .clone()
+        .or_else(|| resolved.registered_scope.clone())
+        .unwrap_or_else(|| DEFAULT_GRANT_SCOPE.to_owned());
+
     let new = NewOauthAuthorizationCode::builder()
         .code_hash(code_hash)
         .client_id(query.client_id.clone())
         .redirect_uri(resolved.redirect_uri.as_str().to_owned())
         .code_challenge(challenge.as_str().to_owned())
-        // Fall back to the client's registered scope when the request
-        // omits one, so /token mints within the registration rather than
-        // defaulting to the broader DEFAULT_GRANT_SCOPE.
-        .scope(
-            query
-                .scope
-                .clone()
-                .or_else(|| resolved.registered_scope.clone()),
-        )
+        .scope(Some(effective_scope.clone()))
         .resource(Some(canonical))
         .principal_id(principal_id)
         .expires_at(expires_at)
@@ -456,7 +462,8 @@ async fn issue_code(
         &raw_code,
         query.state.as_deref(),
         &query.client_id,
-        query.scope.as_deref(),
+        resolved.client_name.as_deref(),
+        &effective_scope,
     )
 }
 
@@ -465,7 +472,8 @@ fn consent_page_response(
     code: &str,
     state: Option<&str>,
     client_id: &str,
-    scope: Option<&str>,
+    client_name: Option<&str>,
+    scope: &str,
 ) -> Result<Response, OAuthError> {
     let mut url = redirect_uri.clone();
     {
@@ -477,7 +485,7 @@ fn consent_page_response(
     }
     let target = url.as_str().to_owned();
     let host = redirect_uri.host_str().unwrap_or("");
-    let body = build_consent_html(&target, host, client_id, scope).map_err(|err| {
+    let body = build_consent_html(&target, host, client_id, client_name, scope).map_err(|err| {
         OAuthError::Internal {
             operation: InternalOperation::RenderConsentPage,
             source: Some(Box::new(err)),

--- a/crates/tribal-auth/src/oauth/authorize.rs
+++ b/crates/tribal-auth/src/oauth/authorize.rs
@@ -43,6 +43,12 @@ use crate::oauth::{
 
 const RANDOM_CODE_BYTE_LENGTH: usize = 32;
 
+/// Content-Security-Policy for the consent page. The page is fully
+/// self-contained: it loads nothing and runs no script, so everything is
+/// denied except its own inline styles. `frame-ancestors 'none'` blocks
+/// the page being framed for a clickjacked authorisation.
+const CONSENT_CSP: &str = "default-src 'none'; style-src 'unsafe-inline'; base-uri 'none'; form-action 'none'; frame-ancestors 'none'";
+
 // ---------------------------------------------------------------------------
 // Query parameters
 // ---------------------------------------------------------------------------
@@ -481,6 +487,24 @@ fn consent_page_response(
     headers.insert(
         header::CONTENT_TYPE,
         HeaderValue::from_static("text/html; charset=utf-8"),
+    );
+    // The page embeds a single-use authorisation code and gates a
+    // credential grant, so it is locked down: never cached or stored,
+    // never framed (clickjacking), no MIME sniffing, and no referrer
+    // leak of the `/authorize` request URL to the redirect target.
+    headers.insert(header::CACHE_CONTROL, HeaderValue::from_static("no-store"));
+    headers.insert(
+        header::CONTENT_SECURITY_POLICY,
+        HeaderValue::from_static(CONSENT_CSP),
+    );
+    headers.insert(header::X_FRAME_OPTIONS, HeaderValue::from_static("DENY"));
+    headers.insert(
+        header::X_CONTENT_TYPE_OPTIONS,
+        HeaderValue::from_static("nosniff"),
+    );
+    headers.insert(
+        header::REFERRER_POLICY,
+        HeaderValue::from_static("no-referrer"),
     );
     Ok((StatusCode::OK, headers, body).into_response())
 }

--- a/crates/tribal-auth/src/oauth/authorize.rs
+++ b/crates/tribal-auth/src/oauth/authorize.rs
@@ -445,13 +445,13 @@ async fn issue_code(
             source: Some(Box::new(err)),
         })?;
 
-    Ok(consent_page_response(
+    consent_page_response(
         &resolved.redirect_uri,
         &raw_code,
         query.state.as_deref(),
         &query.client_id,
         query.scope.as_deref(),
-    ))
+    )
 }
 
 fn consent_page_response(
@@ -460,7 +460,7 @@ fn consent_page_response(
     state: Option<&str>,
     client_id: &str,
     scope: Option<&str>,
-) -> Response {
+) -> Result<Response, OAuthError> {
     let mut url = redirect_uri.clone();
     {
         let mut query = url.query_pairs_mut();
@@ -471,13 +471,18 @@ fn consent_page_response(
     }
     let target = url.as_str().to_owned();
     let host = redirect_uri.host_str().unwrap_or("");
-    let body = build_consent_html(&target, host, client_id, scope);
+    let body = build_consent_html(&target, host, client_id, scope).map_err(|err| {
+        OAuthError::Internal {
+            operation: InternalOperation::RenderConsentPage,
+            source: Some(Box::new(err)),
+        }
+    })?;
     let mut headers = HeaderMap::new();
     headers.insert(
         header::CONTENT_TYPE,
         HeaderValue::from_static("text/html; charset=utf-8"),
     );
-    (StatusCode::OK, headers, body).into_response()
+    Ok((StatusCode::OK, headers, body).into_response())
 }
 
 fn generate_random_code() -> String {

--- a/crates/tribal-auth/src/oauth/consent.rs
+++ b/crates/tribal-auth/src/oauth/consent.rs
@@ -34,8 +34,6 @@
 
 use askama::Template;
 
-use crate::oauth::common::is_loopback_host;
-
 /// Consent page model. The template HTML-escapes every interpolated
 /// value, and the markup carries no script, so a hostile `client_id`,
 /// `client_name`, `scope`, or redirect host cannot break out of its text
@@ -54,12 +52,13 @@ struct ConsentPage<'a> {
 /// Builds the consent page HTML.
 ///
 /// `target` is the full redirect URL (with the code and state) the
-/// approve anchor points at; `redirect_host` is the redirect URI host
-/// displayed to the user and checked against the loopback list;
-/// `client_name` is the client's registered display name, shown in place
-/// of the opaque `client_id` when present; `scope` is the effective grant
-/// the code carries, resolved by the caller. All interpolated values are
-/// HTML-escaped.
+/// approve anchor points at; `redirect_host` is the redirect authority
+/// (host, with its port when non-default) displayed to the user;
+/// `is_loopback` selects the loopback warning and is classified by the
+/// caller from the bare host; `client_name` is the client's registered
+/// display name, shown in place of the opaque `client_id` when present;
+/// `scope` is the effective grant the code carries, resolved by the
+/// caller. All interpolated values are HTML-escaped.
 ///
 /// # Errors
 ///
@@ -70,6 +69,7 @@ pub fn build_consent_html(
     client_id: &str,
     client_name: Option<&str>,
     scope: &str,
+    is_loopback: bool,
 ) -> Result<String, askama::Error> {
     ConsentPage {
         target,
@@ -77,7 +77,7 @@ pub fn build_consent_html(
         client_id,
         client_name,
         scope_display: scope,
-        is_loopback: is_loopback_host(redirect_host),
+        is_loopback,
     }
     .render()
 }
@@ -96,6 +96,7 @@ mod tests {
             "<script>alert(1)</script>",
             Some("<b>spoofed name</b>"),
             "\"><img src=x onerror=alert(1)>",
+            true,
         )
         .expect("template renders");
 
@@ -119,6 +120,7 @@ mod tests {
             "cid",
             None,
             "tribal:read",
+            true,
         )
         .expect("template renders");
         assert!(loopback.contains("Loopback redirect"));
@@ -129,6 +131,7 @@ mod tests {
             "cid",
             None,
             "tribal:read",
+            false,
         )
         .expect("template renders");
         assert!(!remote.contains("Loopback redirect"));
@@ -144,6 +147,7 @@ mod tests {
             "cid",
             None,
             "tribal:read",
+            true,
         )
         .expect("template renders");
         assert!(
@@ -182,6 +186,7 @@ mod tests {
             "cid",
             None,
             "tribal:read",
+            false,
         )
         .expect("template renders");
         assert!(!html.contains("<link"), "no external stylesheet");
@@ -209,6 +214,7 @@ mod tests {
             "tribal-cli-7f3a9c2e",
             Some("Tribal CLI"),
             "tribal.memory:read tribal.memory:write",
+            false,
         )
         .expect("template renders");
         assert_text_snapshot!(&html, "src/oauth/snapshots/consent-remote.html");
@@ -218,10 +224,11 @@ mod tests {
     fn test_consent_html_loopback_snapshot() {
         let html = build_consent_html(
             "http://127.0.0.1:53017/callback?code=abc123&state=xyz",
-            "127.0.0.1",
+            "127.0.0.1:53017",
             "s6BhdRkqt3",
             None,
             "tribal.memory:read",
+            true,
         )
         .expect("template renders");
         assert_text_snapshot!(&html, "src/oauth/snapshots/consent-loopback.html");

--- a/crates/tribal-auth/src/oauth/consent.rs
+++ b/crates/tribal-auth/src/oauth/consent.rs
@@ -1,9 +1,9 @@
 //! Consent page for the authorisation endpoint.
 //!
-//! Renders a minimal HTML page that displays the redirect URI hostname,
-//! the client identifier, and the requested scope, plus a loopback
-//! warning, and requires the user to click Authorise to release the
-//! authorisation code to the redirect target.
+//! Renders a self-contained HTML page that displays the redirect URI
+//! hostname, the client identifier, and the requested scope, plus a
+//! loopback warning, and requires the user to click Authorise to release
+//! the authorisation code to the redirect target.
 //!
 //! The page clearly displays the redirect URI hostname and requires an
 //! explicit human action rather than auto-advancing (MCP 2025-11-25,
@@ -31,13 +31,26 @@
 //! string from input fields and strip those parameters; the anchor
 //! follows the `href` byte-for-byte.
 
+use askama::Template;
+
 use crate::oauth::common::is_loopback_host;
 
 /// Placeholder shown when the client requested no explicit scope.
 const NO_SCOPE_REQUESTED: &str = "(no explicit scope requested)";
 
-/// Warning rendered for loopback redirect hosts.
-const LOOPBACK_WARNING: &str = "<p>This is a loopback redirect. Any process listening on this host can receive the code; only proceed if you started a local client expecting it.</p>";
+/// Consent page model. The template HTML-escapes every interpolated
+/// value, and the markup carries no script, so a hostile `client_id`,
+/// `scope`, or redirect host cannot break out of its text or attribute
+/// context.
+#[derive(Template)]
+#[template(path = "consent.html")]
+struct ConsentPage<'a> {
+    target: &'a str,
+    redirect_host: &'a str,
+    client_id: &'a str,
+    scope_display: &'a str,
+    is_loopback: bool,
+}
 
 /// Builds the consent page HTML.
 ///
@@ -45,57 +58,30 @@ const LOOPBACK_WARNING: &str = "<p>This is a loopback redirect. Any process list
 /// approve anchor points at; `redirect_host` is the redirect URI host
 /// displayed to the user and checked against the loopback list. All
 /// interpolated values are HTML-escaped.
-#[must_use]
+///
+/// # Errors
+///
+/// Returns an [`askama::Error`] if the template fails to render.
 pub fn build_consent_html(
     target: &str,
     redirect_host: &str,
     client_id: &str,
     scope: Option<&str>,
-) -> String {
-    let scope_display = scope.unwrap_or(NO_SCOPE_REQUESTED);
-    let warning_html = if is_loopback_host(redirect_host) {
-        LOOPBACK_WARNING
-    } else {
-        ""
-    };
-    let target_html = escape_html_attribute(target);
-    let client_id_html = escape_html_text(client_id);
-    let redirect_host_html = escape_html_text(redirect_host);
-    let scope_html = escape_html_text(scope_display);
-    format!(
-        "<!doctype html>
-<html><head><meta charset=\"utf-8\"><title>Tribal authorisation</title></head>
-<body>
-  <h1>Authorisation request</h1>
-  <p><strong>client_id</strong>: <code>{client_id_html}</code></p>
-  <p><strong>redirect_uri host</strong>: <code>{redirect_host_html}</code></p>
-  <p><strong>requested scope</strong>: <code>{scope_html}</code></p>
-  {warning_html}
-  <p><a id=\"approve\" href=\"{target_html}\">Authorise</a></p>
-</body></html>
-",
-    )
-}
-
-/// HTML-escapes a value for use inside a double-quoted attribute.
-fn escape_html_attribute(input: &str) -> String {
-    input
-        .replace('&', "&amp;")
-        .replace('"', "&quot;")
-        .replace('<', "&lt;")
-        .replace('>', "&gt;")
-}
-
-/// HTML-escapes a value for use inside element text content.
-fn escape_html_text(input: &str) -> String {
-    input
-        .replace('&', "&amp;")
-        .replace('<', "&lt;")
-        .replace('>', "&gt;")
+) -> Result<String, askama::Error> {
+    ConsentPage {
+        target,
+        redirect_host,
+        client_id,
+        scope_display: scope.unwrap_or(NO_SCOPE_REQUESTED),
+        is_loopback: is_loopback_host(redirect_host),
+    }
+    .render()
 }
 
 #[cfg(test)]
 mod tests {
+    use tribal_test_utils::assert_text_snapshot;
+
     use super::*;
 
     #[test]
@@ -105,31 +91,37 @@ mod tests {
             "127.0.0.1",
             "<script>alert(1)</script>",
             Some("\"><img src=x onerror=alert(1)>"),
-        );
+        )
+        .expect("template renders");
 
         // No raw angle bracket from the injected client_id or scope
-        // survives into the rendered page.
+        // survives into the rendered page. The template escaper emits
+        // numeric character references (&#60; &#62; &#38;), so the
+        // injected markup renders as inert text.
         assert!(!html.contains("<script>alert(1)</script>"));
         assert!(!html.contains("<img src=x"));
-        assert!(html.contains("&lt;script&gt;alert(1)&lt;/script&gt;"));
+        assert!(html.contains("&#60;script&#62;alert(1)&#60;/script&#62;"));
         // The ampersand in the redirect target is attribute-escaped.
-        assert!(html.contains("code=abc&amp;state=x"));
+        assert!(html.contains("code=abc&#38;state=x"));
     }
 
     #[test]
     fn test_consent_html_shows_loopback_warning_only_for_loopback() {
-        let loopback = build_consent_html("http://127.0.0.1/cb", "127.0.0.1", "cid", None);
-        assert!(loopback.contains("loopback redirect"));
+        let loopback = build_consent_html("http://127.0.0.1/cb", "127.0.0.1", "cid", None)
+            .expect("template renders");
+        assert!(loopback.contains("Loopback redirect"));
 
-        let remote = build_consent_html("https://example.com/cb", "example.com", "cid", None);
-        assert!(!remote.contains("loopback redirect"));
+        let remote = build_consent_html("https://example.com/cb", "example.com", "cid", None)
+            .expect("template renders");
+        assert!(!remote.contains("Loopback redirect"));
     }
 
     #[test]
     fn test_consent_html_requires_explicit_click_no_auto_advance() {
         // The page must not auto-advance: no script that clicks or
         // submits, and no meta refresh. The user clicks Authorise.
-        let html = build_consent_html("http://127.0.0.1/cb?code=abc", "127.0.0.1", "cid", None);
+        let html = build_consent_html("http://127.0.0.1/cb?code=abc", "127.0.0.1", "cid", None)
+            .expect("template renders");
         assert!(
             !html.contains("<script"),
             "consent page must carry no script"
@@ -146,5 +138,45 @@ mod tests {
             html.contains(">Authorise</a>"),
             "consent page must offer an explicit Authorise action",
         );
+    }
+
+    #[test]
+    fn test_consent_html_makes_no_external_request() {
+        // The page is self-contained: styles are inline and nothing is
+        // fetched, so it has no external attack or tracking surface.
+        let html = build_consent_html(
+            "https://mcp.example.com/cb?code=abc",
+            "mcp.example.com",
+            "cid",
+            None,
+        )
+        .expect("template renders");
+        assert!(!html.contains("<link"), "no external stylesheet");
+        assert!(!html.contains("<script"), "no external or inline script");
+        assert!(!html.contains("src="), "no external resource reference");
+    }
+
+    #[test]
+    fn test_consent_html_remote_snapshot() {
+        let html = build_consent_html(
+            "https://mcp.example.com/callback?code=abc123&state=xyz",
+            "mcp.example.com",
+            "tribal-cli-7f3a9c2e",
+            Some("tribal.memory:read tribal.memory:write"),
+        )
+        .expect("template renders");
+        assert_text_snapshot!(&html, "src/oauth/snapshots/consent-remote.html");
+    }
+
+    #[test]
+    fn test_consent_html_loopback_snapshot() {
+        let html = build_consent_html(
+            "http://127.0.0.1:53017/callback?code=abc123&state=xyz",
+            "127.0.0.1",
+            "s6BhdRkqt3",
+            Some("tribal.memory:read"),
+        )
+        .expect("template renders");
+        assert_text_snapshot!(&html, "src/oauth/snapshots/consent-loopback.html");
     }
 }

--- a/crates/tribal-auth/src/oauth/consent.rs
+++ b/crates/tribal-auth/src/oauth/consent.rs
@@ -16,9 +16,11 @@
 //! user confirms the hostname shown.
 //!
 //! This is a display-and-confirm gate, not a server-enforced one. The
-//! code is persisted before the page renders and the Authorise anchor is
-//! a client-side navigation, so the human click gates delivery of the
-//! code to the redirect target but is not itself recorded server-side.
+//! page is built before the code is persisted, and the code is persisted
+//! before the response is returned, so by the time the user can act the
+//! code exists server-side; the Authorise anchor is a client-side
+//! navigation, so the human click gates delivery of the code to the
+//! redirect target but is not itself recorded server-side.
 //! Its security value is that a human perceives the redirect host before
 //! any code reaches it, which is what the loopback threat model requires:
 //! a single-user local server where the agent acts on the user's own
@@ -213,7 +215,7 @@ mod tests {
             "mcp.example.com",
             "tribal-cli-7f3a9c2e",
             Some("Tribal CLI"),
-            "tribal.memory:read tribal.memory:write",
+            "tribal:read tribal:write",
             false,
         )
         .expect("template renders");
@@ -227,10 +229,27 @@ mod tests {
             "127.0.0.1:53017",
             "s6BhdRkqt3",
             None,
-            "tribal.memory:read",
+            "tribal:read",
             true,
         )
         .expect("template renders");
         assert_text_snapshot!(&html, "src/oauth/snapshots/consent-loopback.html");
+    }
+
+    #[test]
+    fn test_consent_html_named_loopback_snapshot() {
+        // The highest-value real-world case: a named client (an MCP CLI)
+        // connecting to a loopback redirect, so the bdi-wrapped name and the
+        // loopback warning appear on the same page.
+        let html = build_consent_html(
+            "http://127.0.0.1:7777/callback?code=abc123&state=xyz",
+            "127.0.0.1:7777",
+            "s6BhdRkqt3",
+            Some("Local MCP Client"),
+            "tribal:read",
+            true,
+        )
+        .expect("template renders");
+        assert_text_snapshot!(&html, "src/oauth/snapshots/consent-loopback-named.html");
     }
 }

--- a/crates/tribal-auth/src/oauth/consent.rs
+++ b/crates/tribal-auth/src/oauth/consent.rs
@@ -1,9 +1,10 @@
 //! Consent page for the authorisation endpoint.
 //!
 //! Renders a self-contained HTML page that displays the redirect URI
-//! hostname, the client identifier, and the requested scope, plus a
-//! loopback warning, and requires the user to click Authorise to release
-//! the authorisation code to the redirect target.
+//! hostname, the client (its registered name when present, otherwise the
+//! opaque identifier), and the effective granted scope, plus a loopback
+//! warning, and requires the user to click Authorise to release the
+//! authorisation code to the redirect target.
 //!
 //! The page clearly displays the redirect URI hostname and requires an
 //! explicit human action rather than auto-advancing (MCP 2025-11-25,
@@ -35,19 +36,17 @@ use askama::Template;
 
 use crate::oauth::common::is_loopback_host;
 
-/// Placeholder shown when the client requested no explicit scope.
-const NO_SCOPE_REQUESTED: &str = "(no explicit scope requested)";
-
 /// Consent page model. The template HTML-escapes every interpolated
 /// value, and the markup carries no script, so a hostile `client_id`,
-/// `scope`, or redirect host cannot break out of its text or attribute
-/// context.
+/// `client_name`, `scope`, or redirect host cannot break out of its text
+/// or attribute context.
 #[derive(Template)]
 #[template(path = "consent.html")]
 struct ConsentPage<'a> {
     target: &'a str,
     redirect_host: &'a str,
     client_id: &'a str,
+    client_name: Option<&'a str>,
     scope_display: &'a str,
     is_loopback: bool,
 }
@@ -56,8 +55,11 @@ struct ConsentPage<'a> {
 ///
 /// `target` is the full redirect URL (with the code and state) the
 /// approve anchor points at; `redirect_host` is the redirect URI host
-/// displayed to the user and checked against the loopback list. All
-/// interpolated values are HTML-escaped.
+/// displayed to the user and checked against the loopback list;
+/// `client_name` is the client's registered display name, shown in place
+/// of the opaque `client_id` when present; `scope` is the effective grant
+/// the code carries, resolved by the caller. All interpolated values are
+/// HTML-escaped.
 ///
 /// # Errors
 ///
@@ -66,13 +68,15 @@ pub fn build_consent_html(
     target: &str,
     redirect_host: &str,
     client_id: &str,
-    scope: Option<&str>,
+    client_name: Option<&str>,
+    scope: &str,
 ) -> Result<String, askama::Error> {
     ConsentPage {
         target,
         redirect_host,
         client_id,
-        scope_display: scope.unwrap_or(NO_SCOPE_REQUESTED),
+        client_name,
+        scope_display: scope,
         is_loopback: is_loopback_host(redirect_host),
     }
     .render()
@@ -90,16 +94,18 @@ mod tests {
             "http://127.0.0.1:9000/cb?code=abc&state=x",
             "127.0.0.1",
             "<script>alert(1)</script>",
-            Some("\"><img src=x onerror=alert(1)>"),
+            Some("<b>spoofed name</b>"),
+            "\"><img src=x onerror=alert(1)>",
         )
         .expect("template renders");
 
-        // No raw angle bracket from the injected client_id or scope
-        // survives into the rendered page. The template escaper emits
-        // numeric character references (&#60; &#62; &#38;), so the
+        // No raw angle bracket from the injected client_id, client_name,
+        // or scope survives into the rendered page. The template escaper
+        // emits numeric character references (&#60; &#62; &#38;), so the
         // injected markup renders as inert text.
         assert!(!html.contains("<script>alert(1)</script>"));
         assert!(!html.contains("<img src=x"));
+        assert!(!html.contains("<b>spoofed name</b>"));
         assert!(html.contains("&#60;script&#62;alert(1)&#60;/script&#62;"));
         // The ampersand in the redirect target is attribute-escaped.
         assert!(html.contains("code=abc&#38;state=x"));
@@ -107,12 +113,24 @@ mod tests {
 
     #[test]
     fn test_consent_html_shows_loopback_warning_only_for_loopback() {
-        let loopback = build_consent_html("http://127.0.0.1/cb", "127.0.0.1", "cid", None)
-            .expect("template renders");
+        let loopback = build_consent_html(
+            "http://127.0.0.1/cb",
+            "127.0.0.1",
+            "cid",
+            None,
+            "tribal:read",
+        )
+        .expect("template renders");
         assert!(loopback.contains("Loopback redirect"));
 
-        let remote = build_consent_html("https://example.com/cb", "example.com", "cid", None)
-            .expect("template renders");
+        let remote = build_consent_html(
+            "https://example.com/cb",
+            "example.com",
+            "cid",
+            None,
+            "tribal:read",
+        )
+        .expect("template renders");
         assert!(!remote.contains("Loopback redirect"));
     }
 
@@ -120,8 +138,14 @@ mod tests {
     fn test_consent_html_requires_explicit_click_no_auto_advance() {
         // The page must not auto-advance: no script that clicks or
         // submits, and no meta refresh. The user clicks Authorise.
-        let html = build_consent_html("http://127.0.0.1/cb?code=abc", "127.0.0.1", "cid", None)
-            .expect("template renders");
+        let html = build_consent_html(
+            "http://127.0.0.1/cb?code=abc",
+            "127.0.0.1",
+            "cid",
+            None,
+            "tribal:read",
+        )
+        .expect("template renders");
         assert!(
             !html.contains("<script"),
             "consent page must carry no script"
@@ -135,8 +159,16 @@ mod tests {
             "consent page must not auto-refresh",
         );
         assert!(
+            !html.contains("<form"),
+            "consent page must navigate by anchor, never submit a form",
+        );
+        assert!(
             html.contains(">Authorise</a>"),
             "consent page must offer an explicit Authorise action",
+        );
+        assert!(
+            html.contains("<a class=\"approve\"") && html.contains("href=\""),
+            "the Authorise action must be an anchor carrying an href",
         );
     }
 
@@ -149,11 +181,24 @@ mod tests {
             "mcp.example.com",
             "cid",
             None,
+            "tribal:read",
         )
         .expect("template renders");
         assert!(!html.contains("<link"), "no external stylesheet");
         assert!(!html.contains("<script"), "no external or inline script");
         assert!(!html.contains("src="), "no external resource reference");
+        assert!(
+            !html.contains("@import"),
+            "no CSS @import of a remote sheet"
+        );
+        assert!(
+            !html.contains("url("),
+            "no CSS url() fetch of a font, image, or sheet",
+        );
+        assert!(
+            !html.contains("<iframe") && !html.contains("<object") && !html.contains("<embed"),
+            "no embedded external document",
+        );
     }
 
     #[test]
@@ -162,7 +207,8 @@ mod tests {
             "https://mcp.example.com/callback?code=abc123&state=xyz",
             "mcp.example.com",
             "tribal-cli-7f3a9c2e",
-            Some("tribal.memory:read tribal.memory:write"),
+            Some("Tribal CLI"),
+            "tribal.memory:read tribal.memory:write",
         )
         .expect("template renders");
         assert_text_snapshot!(&html, "src/oauth/snapshots/consent-remote.html");
@@ -174,7 +220,8 @@ mod tests {
             "http://127.0.0.1:53017/callback?code=abc123&state=xyz",
             "127.0.0.1",
             "s6BhdRkqt3",
-            Some("tribal.memory:read"),
+            None,
+            "tribal.memory:read",
         )
         .expect("template renders");
         assert_text_snapshot!(&html, "src/oauth/snapshots/consent-loopback.html");

--- a/crates/tribal-auth/src/oauth/error.rs
+++ b/crates/tribal-auth/src/oauth/error.rs
@@ -256,6 +256,12 @@ pub enum ClientMetadataRejection {
         /// The scope token the client declared.
         presented: String,
     },
+    /// `client_name` is unacceptable for display on the consent page.
+    #[error("client_name is not acceptable: {detail}")]
+    InvalidClientName {
+        /// Why the name was rejected.
+        detail: String,
+    },
     /// The registration body could not be parsed as client metadata.
     #[error("client metadata is malformed: {detail}")]
     MalformedMetadata {

--- a/crates/tribal-auth/src/oauth/error.rs
+++ b/crates/tribal-auth/src/oauth/error.rs
@@ -314,6 +314,9 @@ pub enum InternalOperation {
     /// Parsing a code challenge read back from the code store.
     #[error("stored code_challenge parsing")]
     MalformedStoredCodeChallenge,
+    /// Rendering the consent page template.
+    #[error("consent page rendering")]
+    RenderConsentPage,
 }
 
 // ---------------------------------------------------------------------------

--- a/crates/tribal-auth/src/oauth/register.rs
+++ b/crates/tribal-auth/src/oauth/register.rs
@@ -24,7 +24,7 @@ use crate::{
     oauth::{
         common::{GRANT_TYPE_AUTHORIZATION_CODE, RESPONSE_TYPE_CODE, is_loopback_host},
         error::{ClientMetadataRejection, InternalOperation, OAuthError, RedirectUriRejection},
-        scope::first_uncatalogued_scope,
+        scope::{first_uncatalogued_scope, present_scope},
     },
 };
 
@@ -185,13 +185,23 @@ async fn register(
     }
     validate_grant_response_consistency(&grant_types, &response_types)?;
 
-    if let Some(uncatalogued) = req.scope.as_deref().and_then(first_uncatalogued_scope) {
+    // Treat a blank or whitespace-only declared scope as absent so the stored
+    // client never carries an empty scope, which would later display as nothing
+    // on the consent page while a token still minted the default grant.
+    let scope = present_scope(req.scope.as_deref());
+    if let Some(uncatalogued) = scope.and_then(first_uncatalogued_scope) {
         return Err(OAuthError::InvalidClientMetadata {
             reason: ClientMetadataRejection::UnsupportedScope {
                 presented: uncatalogued.to_owned(),
             },
         });
     }
+
+    // The registered name is shown on the consent page, a security prompt, and
+    // is attacker-chosen at open registration. Validate it before persistence:
+    // a blank name resolves to none, and control or directional formatting
+    // characters or an excessive length are rejected.
+    let client_name = validate_client_name(req.client_name.as_deref())?;
 
     // Default an omitted auth method to the public PKCE client (`none`),
     // not the RFC 7591 §2 default of `client_secret_basic`. Tribal's
@@ -223,12 +233,12 @@ async fn register(
     let new = NewOauthClient::builder()
         .client_id(client_id.clone())
         .client_secret_hash(client_secret_hash)
-        .client_name(req.client_name.clone())
+        .client_name(client_name)
         .redirect_uris(redirect_uris.clone())
         .grant_types(grant_types.clone())
         .response_types(response_types.clone())
         .token_endpoint_auth_method(auth_method)
-        .scope(req.scope.clone())
+        .scope(scope.map(str::to_owned))
         .application_type(application_type)
         .build();
 
@@ -284,6 +294,55 @@ fn parse_application_type(raw: &str) -> Result<ApplicationType, OAuthError> {
             presented: raw.to_owned(),
         },
     })
+}
+
+/// Maximum number of characters in a registered `client_name` shown on the
+/// consent page.
+const MAX_CLIENT_NAME_CHARS: usize = 200;
+
+/// Validates and normalises a registered `client_name` for safe display on the
+/// consent page. A blank or whitespace-only name resolves to `None`. A name
+/// carrying control or Unicode directional-formatting characters, or exceeding
+/// [`MAX_CLIENT_NAME_CHARS`], is rejected: the value is attacker-chosen at open
+/// registration and the consent page is a security prompt, so a name that could
+/// reorder its own disclaimer, smuggle a newline, or push the redirect host out
+/// of view is not admitted.
+fn validate_client_name(raw: Option<&str>) -> Result<Option<String>, OAuthError> {
+    let Some(name) = raw else {
+        return Ok(None);
+    };
+    let trimmed = name.trim();
+    if trimmed.is_empty() {
+        return Ok(None);
+    }
+    if trimmed.chars().count() > MAX_CLIENT_NAME_CHARS {
+        return Err(invalid_client_name(format!(
+            "exceeds {MAX_CLIENT_NAME_CHARS} characters"
+        )));
+    }
+    if trimmed.chars().any(is_unsafe_display_char) {
+        return Err(invalid_client_name(
+            "contains control or directional formatting characters".to_owned(),
+        ));
+    }
+    Ok(Some(trimmed.to_owned()))
+}
+
+fn invalid_client_name(detail: String) -> OAuthError {
+    OAuthError::InvalidClientMetadata {
+        reason: ClientMetadataRejection::InvalidClientName { detail },
+    }
+}
+
+/// Control characters (including newlines and tabs) and the Unicode
+/// bidirectional formatting characters, which can visually reorder the text
+/// that follows them, are unsafe to display in the consent prompt.
+fn is_unsafe_display_char(c: char) -> bool {
+    c.is_control()
+        || matches!(c,
+            '\u{200E}' | '\u{200F}'
+            | '\u{202A}'..='\u{202E}'
+            | '\u{2066}'..='\u{2069}')
 }
 
 fn validate_redirect_uri(raw: &str) -> Result<(), OAuthError> {
@@ -437,5 +496,50 @@ mod tests {
             )
             .is_empty(),
         );
+    }
+
+    #[test]
+    fn test_validate_client_name_normalises_blank_to_none() {
+        assert_eq!(validate_client_name(None).unwrap(), None);
+        assert_eq!(validate_client_name(Some("")).unwrap(), None);
+        assert_eq!(validate_client_name(Some("   ")).unwrap(), None);
+    }
+
+    #[test]
+    fn test_validate_client_name_trims_and_accepts() {
+        assert_eq!(
+            validate_client_name(Some("  Tribal CLI  ")).unwrap(),
+            Some("Tribal CLI".to_owned()),
+        );
+    }
+
+    #[test]
+    fn test_validate_client_name_rejects_directional_and_control_chars() {
+        // U+202E (right-to-left override) can visually reorder the disclaimer
+        // and identifier that follow the name on the consent page.
+        assert!(matches!(
+            validate_client_name(Some("Tribal\u{202E}lacirT")),
+            Err(OAuthError::InvalidClientMetadata {
+                reason: ClientMetadataRejection::InvalidClientName { .. },
+            }),
+        ));
+        // A newline would let the value span lines in the prompt.
+        assert!(matches!(
+            validate_client_name(Some("line one\nline two")),
+            Err(OAuthError::InvalidClientMetadata {
+                reason: ClientMetadataRejection::InvalidClientName { .. },
+            }),
+        ));
+    }
+
+    #[test]
+    fn test_validate_client_name_rejects_overlong() {
+        let long = "a".repeat(MAX_CLIENT_NAME_CHARS + 1);
+        assert!(matches!(
+            validate_client_name(Some(&long)),
+            Err(OAuthError::InvalidClientMetadata {
+                reason: ClientMetadataRejection::InvalidClientName { .. },
+            }),
+        ));
     }
 }

--- a/crates/tribal-auth/src/oauth/register.rs
+++ b/crates/tribal-auth/src/oauth/register.rs
@@ -17,6 +17,7 @@ use serde::{Deserialize, Serialize};
 use tribal_common::sha256_hex;
 use tribal_db::{NewOauthClient, OauthClientRepository, PgOauthClientRepository};
 use tribal_domain::{ApplicationType, OauthClient, TokenEndpointAuthMethod};
+use unicode_general_category::{GeneralCategory, get_general_category};
 use url::Url;
 
 use crate::{
@@ -27,6 +28,14 @@ use crate::{
         scope::{first_uncatalogued_scope, present_scope},
     },
 };
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+/// Maximum number of characters in a registered `client_name` shown on the
+/// consent page.
+const MAX_CLIENT_NAME_CHARS: usize = 200;
 
 // ---------------------------------------------------------------------------
 // Request and response types
@@ -296,10 +305,6 @@ fn parse_application_type(raw: &str) -> Result<ApplicationType, OAuthError> {
     })
 }
 
-/// Maximum number of characters in a registered `client_name` shown on the
-/// consent page.
-const MAX_CLIENT_NAME_CHARS: usize = 200;
-
 /// Validates and normalises a registered `client_name` for safe display on the
 /// consent page. A blank or whitespace-only name resolves to `None`. A name
 /// carrying control or Unicode directional-formatting characters, or exceeding
@@ -334,15 +339,22 @@ fn invalid_client_name(detail: String) -> OAuthError {
     }
 }
 
-/// Control characters (including newlines and tabs) and the Unicode
-/// bidirectional formatting characters, which can visually reorder the text
-/// that follows them, are unsafe to display in the consent prompt.
+/// Characters unsafe to display in the consent prompt, rejected by Unicode
+/// general category rather than an enumerated list so the rejection set cannot
+/// fall behind: control characters (`Cc`, including newlines and tabs), format
+/// characters (`Cf`, the bidirectional ordering controls and the zero-width and
+/// invisible marks), and line and paragraph separators (`Zl`/`Zp`, which render
+/// as forced line breaks). This conservatively refuses some legitimate uses (a
+/// name relying on a zero-width joiner, say), the right trade-off for an
+/// unverified name shown on a security prompt.
 fn is_unsafe_display_char(c: char) -> bool {
-    c.is_control()
-        || matches!(c,
-            '\u{200E}' | '\u{200F}'
-            | '\u{202A}'..='\u{202E}'
-            | '\u{2066}'..='\u{2069}')
+    matches!(
+        get_general_category(c),
+        GeneralCategory::Control
+            | GeneralCategory::Format
+            | GeneralCategory::LineSeparator
+            | GeneralCategory::ParagraphSeparator
+    )
 }
 
 fn validate_redirect_uri(raw: &str) -> Result<(), OAuthError> {
@@ -514,22 +526,31 @@ mod tests {
     }
 
     #[test]
-    fn test_validate_client_name_rejects_directional_and_control_chars() {
-        // U+202E (right-to-left override) can visually reorder the disclaimer
-        // and identifier that follow the name on the consent page.
-        assert!(matches!(
-            validate_client_name(Some("Tribal\u{202E}lacirT")),
-            Err(OAuthError::InvalidClientMetadata {
-                reason: ClientMetadataRejection::InvalidClientName { .. },
-            }),
-        ));
-        // A newline would let the value span lines in the prompt.
-        assert!(matches!(
-            validate_client_name(Some("line one\nline two")),
-            Err(OAuthError::InvalidClientMetadata {
-                reason: ClientMetadataRejection::InvalidClientName { .. },
-            }),
-        ));
+    fn test_validate_client_name_rejects_unsafe_display_chars() {
+        // Every category is_unsafe_display_char rejects must be refused: a bidi
+        // override and an invisible bidi mark and a zero-width character (all
+        // Cf), a line separator (Zl) and a paragraph separator (Zp) that render
+        // as forced line breaks, and an ordinary control character (Cc).
+        for unsafe_char in [
+            '\u{202E}', // right-to-left override
+            '\u{061C}', // Arabic letter mark
+            '\u{200B}', // zero-width space
+            '\u{2028}', // line separator
+            '\u{2029}', // paragraph separator
+            '\n',       // newline
+        ] {
+            let name = format!("Tribal{unsafe_char}CLI");
+            assert!(
+                matches!(
+                    validate_client_name(Some(&name)),
+                    Err(OAuthError::InvalidClientMetadata {
+                        reason: ClientMetadataRejection::InvalidClientName { .. },
+                    }),
+                ),
+                "expected rejection for U+{:04X}",
+                unsafe_char as u32,
+            );
+        }
     }
 
     #[test]

--- a/crates/tribal-auth/src/oauth/scope.rs
+++ b/crates/tribal-auth/src/oauth/scope.rs
@@ -30,6 +30,36 @@ pub const SCOPES_CATALOGUE: &[&str] = &[
 pub(crate) const DEFAULT_GRANT_SCOPE: &str = "tribal:read";
 
 // ---------------------------------------------------------------------------
+// Effective grant resolution
+// ---------------------------------------------------------------------------
+
+/// A scope string with surrounding whitespace removed, or `None` if it is
+/// empty or whitespace-only. Empty and whitespace-only scopes are treated as
+/// absent everywhere a grant is resolved, so a client cannot register or
+/// request a blank scope that displays as nothing while a token still mints.
+pub(crate) fn present_scope(raw: Option<&str>) -> Option<&str> {
+    raw.map(str::trim).filter(|trimmed| !trimmed.is_empty())
+}
+
+/// Resolves the effective grant a code carries at issue time: the requested
+/// scope if present, else the client's registered scope, else
+/// [`DEFAULT_GRANT_SCOPE`]. This is the single definition of the grant the
+/// consent page displays and the code stores, so the two cannot disagree.
+pub(crate) fn effective_scope(requested: Option<&str>, registered: Option<&str>) -> String {
+    present_scope(requested)
+        .or_else(|| present_scope(registered))
+        .map_or_else(|| DEFAULT_GRANT_SCOPE.to_owned(), str::to_owned)
+}
+
+/// Resolves the grant a stored code mints into a token: the code's scope if
+/// present, else [`DEFAULT_GRANT_SCOPE`]. Shares the emptiness rule with
+/// [`effective_scope`] so a code issued by `/authorize` and the token minted
+/// at `/token` carry the same grant the consent page showed.
+pub(crate) fn grant_or_default(stored: Option<&str>) -> String {
+    present_scope(stored).map_or_else(|| DEFAULT_GRANT_SCOPE.to_owned(), str::to_owned)
+}
+
+// ---------------------------------------------------------------------------
 // Validation
 // ---------------------------------------------------------------------------
 
@@ -107,6 +137,36 @@ mod tests {
     #[test]
     fn test_default_grant_scope_is_catalogued() {
         assert!(SCOPES_CATALOGUE.contains(&DEFAULT_GRANT_SCOPE));
+    }
+
+    #[test]
+    fn test_effective_scope_prefers_requested_then_registered() {
+        assert_eq!(
+            effective_scope(Some("tribal:read"), Some("tribal:write")),
+            "tribal:read",
+        );
+        assert_eq!(
+            effective_scope(None, Some("tribal.knowledge:read")),
+            "tribal.knowledge:read",
+        );
+    }
+
+    #[test]
+    fn test_effective_scope_treats_empty_and_whitespace_as_absent() {
+        // A blank or whitespace-only requested or registered scope must not
+        // display as nothing while a token still mints the default grant.
+        assert_eq!(effective_scope(Some(""), Some("")), DEFAULT_GRANT_SCOPE);
+        assert_eq!(effective_scope(Some("   "), None), DEFAULT_GRANT_SCOPE);
+        assert_eq!(effective_scope(None, Some("  ")), DEFAULT_GRANT_SCOPE);
+        assert_eq!(effective_scope(None, None), DEFAULT_GRANT_SCOPE);
+    }
+
+    #[test]
+    fn test_grant_or_default_shares_the_emptiness_rule() {
+        assert_eq!(grant_or_default(Some("tribal:write")), "tribal:write");
+        assert_eq!(grant_or_default(Some("")), DEFAULT_GRANT_SCOPE);
+        assert_eq!(grant_or_default(Some("   ")), DEFAULT_GRANT_SCOPE);
+        assert_eq!(grant_or_default(None), DEFAULT_GRANT_SCOPE);
     }
 
     #[test]

--- a/crates/tribal-auth/src/oauth/snapshots/consent-loopback-named.html
+++ b/crates/tribal-auth/src/oauth/snapshots/consent-loopback-named.html
@@ -271,19 +271,24 @@
     <dl class="detail">
       <div class="field">
         <dt>Client</dt>
-        <dd><bdi>Tribal CLI</bdi><span class="note">Self-reported by the client, not verified. Identifier: tribal-cli-7f3a9c2e</span></dd>
+        <dd><bdi>Local MCP Client</bdi><span class="note">Self-reported by the client, not verified. Identifier: s6BhdRkqt3</span></dd>
       </div>
       <div class="field">
         <dt>Redirect host</dt>
-        <dd>mcp.example.com<span class="note">The authorisation code is delivered here.</span></dd>
+        <dd>127.0.0.1:7777<span class="note">The authorisation code is delivered here.</span></dd>
       </div>
       <div class="field">
         <dt>Access granted</dt>
-        <dd>tribal:read tribal:write</dd>
+        <dd>tribal:read</dd>
       </div>
     </dl>
 
-    <a class="approve" id="approve" href="https://mcp.example.com/callback?code=abc123&#38;state=xyz">Authorise</a>
+    <section class="warning" aria-labelledby="warn-title">
+      <h2 id="warn-title">Loopback redirect</h2>
+      <p>Any process listening on this host can receive the code. Only continue if you started a local client expecting it.</p>
+    </section>
+
+    <a class="approve" id="approve" href="http://127.0.0.1:7777/callback?code=abc123&#38;state=xyz">Authorise</a>
     <p class="deny">To deny, close this window.</p>
   </main>
 </body>

--- a/crates/tribal-auth/src/oauth/snapshots/consent-loopback.html
+++ b/crates/tribal-auth/src/oauth/snapshots/consent-loopback.html
@@ -279,7 +279,7 @@
       </div>
       <div class="field">
         <dt>Access granted</dt>
-        <dd>tribal.memory:read</dd>
+        <dd>tribal:read</dd>
       </div>
     </dl>
 

--- a/crates/tribal-auth/src/oauth/snapshots/consent-loopback.html
+++ b/crates/tribal-auth/src/oauth/snapshots/consent-loopback.html
@@ -275,10 +275,10 @@
       </div>
       <div class="field">
         <dt>Redirect host</dt>
-        <dd>127.0.0.1<span class="note">The authorisation code is delivered here.</span></dd>
+        <dd>127.0.0.1:53017<span class="note">The authorisation code is delivered here.</span></dd>
       </div>
       <div class="field">
-        <dt>Requested scope</dt>
+        <dt>Access granted</dt>
         <dd>tribal.memory:read</dd>
       </div>
     </dl>

--- a/crates/tribal-auth/src/oauth/snapshots/consent-loopback.html
+++ b/crates/tribal-auth/src/oauth/snapshots/consent-loopback.html
@@ -10,9 +10,7 @@
        external request. */
     :root {
       --colour-bg: oklch(0.1633 0.0055 355.53);
-      --colour-bg-deep: oklch(0.1391 0.0060 354.68);
       --colour-surface: oklch(0.2042 0.0076 48.33);
-      --colour-surface-raised: oklch(0.2388 0.0073 48.40);
       --colour-surface-code: oklch(0.1818 0.0078 48.27);
 
       --colour-text: oklch(0.9428 0.0076 61.45);
@@ -21,7 +19,6 @@
       --colour-text-subtle: oklch(0.6392 0.0113 48.54);
 
       --colour-rose-base: oklch(0.7800 0.0850 18);
-      --colour-rose-ink: oklch(0.9200 0.0500 18);
       --colour-border-tint: oklch(0.9314 0.0128 48.58);
       --colour-hue-warning: oklch(0.8000 0.1500 70);
 
@@ -276,7 +273,7 @@
         <dt>Client</dt>
         <dd>s6BhdRkqt3</dd>
       </div>
-      <div class="field field--host">
+      <div class="field">
         <dt>Redirect host</dt>
         <dd>127.0.0.1<span class="note">The authorisation code is delivered here.</span></dd>
       </div>
@@ -286,12 +283,10 @@
       </div>
     </dl>
 
-    
     <section class="warning" aria-labelledby="warn-title">
       <h2 id="warn-title">Loopback redirect</h2>
       <p>Any process listening on this host can receive the code. Only continue if you started a local client expecting it.</p>
     </section>
-    
 
     <a class="approve" id="approve" href="http://127.0.0.1:53017/callback?code=abc123&#38;state=xyz">Authorise</a>
     <p class="deny">To deny, close this window.</p>

--- a/crates/tribal-auth/src/oauth/snapshots/consent-loopback.html
+++ b/crates/tribal-auth/src/oauth/snapshots/consent-loopback.html
@@ -1,0 +1,300 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Authorisation request &middot; Tribal</title>
+  <style>
+    /* Colour, type, and rhythm lifted from the Tribal design tokens
+       (oklch). Inlined so the page is self-contained and makes no
+       external request. */
+    :root {
+      --colour-bg: oklch(0.1633 0.0055 355.53);
+      --colour-bg-deep: oklch(0.1391 0.0060 354.68);
+      --colour-surface: oklch(0.2042 0.0076 48.33);
+      --colour-surface-raised: oklch(0.2388 0.0073 48.40);
+      --colour-surface-code: oklch(0.1818 0.0078 48.27);
+
+      --colour-text: oklch(0.9428 0.0076 61.45);
+      --colour-text-dim: oklch(0.8669 0.0106 67.69);
+      --colour-text-muted: oklch(0.7441 0.0126 51.26);
+      --colour-text-subtle: oklch(0.6392 0.0113 48.54);
+
+      --colour-rose-base: oklch(0.7800 0.0850 18);
+      --colour-rose-ink: oklch(0.9200 0.0500 18);
+      --colour-border-tint: oklch(0.9314 0.0128 48.58);
+      --colour-hue-warning: oklch(0.8000 0.1500 70);
+
+      --colour-border: color-mix(in oklch, var(--colour-border-tint) 7%, transparent);
+      --colour-border-strong: color-mix(in oklch, var(--colour-border-tint) 14%, transparent);
+      --colour-focus-ring: color-mix(in oklch, var(--colour-rose-base) 80%, transparent);
+
+      --colour-primary-fg: var(--colour-rose-base);
+      --colour-primary-bg: color-mix(in oklch, var(--colour-rose-base) 14%, transparent);
+      --colour-primary-bg-hover: color-mix(in oklch, var(--colour-rose-base) 22%, transparent);
+      --colour-primary-border: color-mix(in oklch, var(--colour-rose-base) 35%, transparent);
+
+      --colour-warning-fg: var(--colour-hue-warning);
+      --colour-warning-bg: color-mix(in oklch, var(--colour-hue-warning) 12%, transparent);
+      --colour-warning-border: color-mix(in oklch, var(--colour-hue-warning) 30%, transparent);
+
+      --font-sans: "IBM Plex Sans", system-ui, sans-serif;
+      --font-mono: "IBM Plex Mono", ui-monospace, SFMono-Regular, Menlo, monospace;
+
+      --space-snug: 0.75rem;
+      --space-default: 1rem;
+      --space-loose: 1.5rem;
+      --inset-card: 1.75rem;
+      --radius-card: 2px;
+
+      --motion-quick: 160ms;
+      --easing-standard: cubic-bezier(0.2, 0, 0, 1);
+    }
+
+    *,
+    *::before,
+    *::after {
+      box-sizing: border-box;
+    }
+
+    html {
+      -webkit-text-size-adjust: 100%;
+    }
+
+    body {
+      margin: 0;
+      min-height: 100svh;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      padding: var(--space-loose);
+      background-color: var(--colour-bg);
+      color: var(--colour-text);
+      font-family: var(--font-sans);
+      font-size: 1rem;
+      line-height: 1.5;
+      -webkit-font-smoothing: antialiased;
+      text-rendering: optimizeLegibility;
+    }
+
+    .card {
+      width: 100%;
+      max-width: 27rem;
+      background-color: var(--colour-surface);
+      border: 1px solid var(--colour-border-strong);
+      border-radius: var(--radius-card);
+      padding: var(--inset-card);
+    }
+
+    .eyebrow {
+      display: flex;
+      align-items: center;
+      gap: 0.5rem;
+      margin: 0 0 var(--space-default);
+      font-family: var(--font-mono);
+      font-size: 0.75rem;
+      font-weight: 500;
+      letter-spacing: 0.18em;
+      text-transform: uppercase;
+      color: var(--colour-rose-base);
+    }
+
+    .eyebrow .dot {
+      width: 0.4rem;
+      height: 0.4rem;
+      border-radius: 50%;
+      background-color: var(--colour-rose-base);
+    }
+
+    h1 {
+      margin: 0 0 var(--space-snug);
+      font-family: var(--font-sans);
+      font-weight: 500;
+      font-size: 1.728rem;
+      line-height: 1.2;
+      letter-spacing: -0.012em;
+      color: var(--colour-text);
+    }
+
+    .lead {
+      margin: 0 0 var(--space-loose);
+      color: var(--colour-text-muted);
+      font-size: 1rem;
+      line-height: 1.55;
+    }
+
+    .detail {
+      margin: 0 0 var(--space-loose);
+      padding: var(--space-default) var(--space-default) calc(var(--space-default) - 0.25rem);
+      background-color: var(--colour-surface-code);
+      border: 1px solid var(--colour-border);
+      border-radius: var(--radius-card);
+    }
+
+    .field {
+      margin: 0 0 var(--space-default);
+    }
+
+    .field:last-child {
+      margin-bottom: 0;
+    }
+
+    .field dt {
+      margin: 0 0 0.25rem;
+      font-family: var(--font-mono);
+      font-size: 0.75rem;
+      font-weight: 500;
+      letter-spacing: 0.04em;
+      text-transform: uppercase;
+      color: var(--colour-text-subtle);
+    }
+
+    .field dd {
+      margin: 0;
+      font-family: var(--font-mono);
+      font-size: 0.9375rem;
+      line-height: 1.45;
+      color: var(--colour-text);
+      overflow-wrap: anywhere;
+    }
+
+    .field .note {
+      display: block;
+      margin-top: 0.25rem;
+      font-family: var(--font-sans);
+      font-size: 0.8125rem;
+      letter-spacing: 0;
+      text-transform: none;
+      color: var(--colour-text-subtle);
+    }
+
+    .warning {
+      margin: 0 0 var(--space-loose);
+      padding: var(--space-snug) var(--space-default);
+      background-color: var(--colour-warning-bg);
+      border: 1px solid var(--colour-warning-border);
+      border-radius: var(--radius-card);
+    }
+
+    .warning h2 {
+      margin: 0 0 0.25rem;
+      font-family: var(--font-mono);
+      font-size: 0.75rem;
+      font-weight: 500;
+      letter-spacing: 0.04em;
+      text-transform: uppercase;
+      color: var(--colour-warning-fg);
+    }
+
+    .warning p {
+      margin: 0;
+      font-size: 0.875rem;
+      line-height: 1.5;
+      color: var(--colour-text-dim);
+    }
+
+    .approve {
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      min-height: 3rem;
+      padding: 0.75rem 1.25rem;
+      background-color: var(--colour-primary-bg);
+      color: var(--colour-primary-fg);
+      border: 1px solid var(--colour-primary-border);
+      border-radius: var(--radius-card);
+      font-family: var(--font-sans);
+      font-size: 1rem;
+      font-weight: 500;
+      letter-spacing: 0.01em;
+      text-decoration: none;
+      transition:
+        background-color var(--motion-quick) var(--easing-standard),
+        border-color var(--motion-quick) var(--easing-standard);
+    }
+
+    .approve:hover {
+      background-color: var(--colour-primary-bg-hover);
+      border-color: var(--colour-rose-base);
+    }
+
+    .approve:focus-visible {
+      outline: 3px solid var(--colour-focus-ring);
+      outline-offset: 2px;
+    }
+
+    .approve:active {
+      transform: translateY(1px);
+    }
+
+    .deny {
+      margin: var(--space-default) 0 0;
+      text-align: center;
+      font-size: 0.8125rem;
+      color: var(--colour-text-subtle);
+    }
+
+    /* Narrow viewports: tighten the gutters so the card breathes. */
+    @media (max-width: 30rem) {
+      body {
+        padding: var(--space-default);
+      }
+      .card {
+        padding: var(--space-loose);
+      }
+    }
+
+    @media (prefers-reduced-motion: reduce) {
+      .approve {
+        transition: none;
+      }
+      .approve:active {
+        transform: none;
+      }
+    }
+
+    /* Forced-colors (Windows High Contrast): keep the control and its
+       focus state visible once the system palette takes over. */
+    @media (forced-colors: active) {
+      .approve {
+        border-color: ButtonText;
+      }
+      .approve:focus-visible {
+        outline-color: Highlight;
+      }
+    }
+  </style>
+</head>
+<body>
+  <main class="card">
+    <p class="eyebrow"><span class="dot" aria-hidden="true"></span>Tribal</p>
+    <h1>Authorisation request</h1>
+    <p class="lead">A client is asking to connect to your Tribal memory. Check the details below, then authorise only if you started this request.</p>
+
+    <dl class="detail">
+      <div class="field">
+        <dt>Client</dt>
+        <dd>s6BhdRkqt3</dd>
+      </div>
+      <div class="field field--host">
+        <dt>Redirect host</dt>
+        <dd>127.0.0.1<span class="note">The authorisation code is delivered here.</span></dd>
+      </div>
+      <div class="field">
+        <dt>Requested scope</dt>
+        <dd>tribal.memory:read</dd>
+      </div>
+    </dl>
+
+    
+    <section class="warning" aria-labelledby="warn-title">
+      <h2 id="warn-title">Loopback redirect</h2>
+      <p>Any process listening on this host can receive the code. Only continue if you started a local client expecting it.</p>
+    </section>
+    
+
+    <a class="approve" id="approve" href="http://127.0.0.1:53017/callback?code=abc123&#38;state=xyz">Authorise</a>
+    <p class="deny">To deny, close this window.</p>
+  </main>
+</body>
+</html>

--- a/crates/tribal-auth/src/oauth/snapshots/consent-remote.html
+++ b/crates/tribal-auth/src/oauth/snapshots/consent-remote.html
@@ -10,9 +10,7 @@
        external request. */
     :root {
       --colour-bg: oklch(0.1633 0.0055 355.53);
-      --colour-bg-deep: oklch(0.1391 0.0060 354.68);
       --colour-surface: oklch(0.2042 0.0076 48.33);
-      --colour-surface-raised: oklch(0.2388 0.0073 48.40);
       --colour-surface-code: oklch(0.1818 0.0078 48.27);
 
       --colour-text: oklch(0.9428 0.0076 61.45);
@@ -21,7 +19,6 @@
       --colour-text-subtle: oklch(0.6392 0.0113 48.54);
 
       --colour-rose-base: oklch(0.7800 0.0850 18);
-      --colour-rose-ink: oklch(0.9200 0.0500 18);
       --colour-border-tint: oklch(0.9314 0.0128 48.58);
       --colour-hue-warning: oklch(0.8000 0.1500 70);
 
@@ -274,9 +271,9 @@
     <dl class="detail">
       <div class="field">
         <dt>Client</dt>
-        <dd>tribal-cli-7f3a9c2e</dd>
+        <dd>Tribal CLI<span class="note">Self-reported by the client, not verified. Identifier: tribal-cli-7f3a9c2e</span></dd>
       </div>
-      <div class="field field--host">
+      <div class="field">
         <dt>Redirect host</dt>
         <dd>mcp.example.com<span class="note">The authorisation code is delivered here.</span></dd>
       </div>
@@ -285,8 +282,6 @@
         <dd>tribal.memory:read tribal.memory:write</dd>
       </div>
     </dl>
-
-    
 
     <a class="approve" id="approve" href="https://mcp.example.com/callback?code=abc123&#38;state=xyz">Authorise</a>
     <p class="deny">To deny, close this window.</p>

--- a/crates/tribal-auth/src/oauth/snapshots/consent-remote.html
+++ b/crates/tribal-auth/src/oauth/snapshots/consent-remote.html
@@ -1,0 +1,295 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Authorisation request &middot; Tribal</title>
+  <style>
+    /* Colour, type, and rhythm lifted from the Tribal design tokens
+       (oklch). Inlined so the page is self-contained and makes no
+       external request. */
+    :root {
+      --colour-bg: oklch(0.1633 0.0055 355.53);
+      --colour-bg-deep: oklch(0.1391 0.0060 354.68);
+      --colour-surface: oklch(0.2042 0.0076 48.33);
+      --colour-surface-raised: oklch(0.2388 0.0073 48.40);
+      --colour-surface-code: oklch(0.1818 0.0078 48.27);
+
+      --colour-text: oklch(0.9428 0.0076 61.45);
+      --colour-text-dim: oklch(0.8669 0.0106 67.69);
+      --colour-text-muted: oklch(0.7441 0.0126 51.26);
+      --colour-text-subtle: oklch(0.6392 0.0113 48.54);
+
+      --colour-rose-base: oklch(0.7800 0.0850 18);
+      --colour-rose-ink: oklch(0.9200 0.0500 18);
+      --colour-border-tint: oklch(0.9314 0.0128 48.58);
+      --colour-hue-warning: oklch(0.8000 0.1500 70);
+
+      --colour-border: color-mix(in oklch, var(--colour-border-tint) 7%, transparent);
+      --colour-border-strong: color-mix(in oklch, var(--colour-border-tint) 14%, transparent);
+      --colour-focus-ring: color-mix(in oklch, var(--colour-rose-base) 80%, transparent);
+
+      --colour-primary-fg: var(--colour-rose-base);
+      --colour-primary-bg: color-mix(in oklch, var(--colour-rose-base) 14%, transparent);
+      --colour-primary-bg-hover: color-mix(in oklch, var(--colour-rose-base) 22%, transparent);
+      --colour-primary-border: color-mix(in oklch, var(--colour-rose-base) 35%, transparent);
+
+      --colour-warning-fg: var(--colour-hue-warning);
+      --colour-warning-bg: color-mix(in oklch, var(--colour-hue-warning) 12%, transparent);
+      --colour-warning-border: color-mix(in oklch, var(--colour-hue-warning) 30%, transparent);
+
+      --font-sans: "IBM Plex Sans", system-ui, sans-serif;
+      --font-mono: "IBM Plex Mono", ui-monospace, SFMono-Regular, Menlo, monospace;
+
+      --space-snug: 0.75rem;
+      --space-default: 1rem;
+      --space-loose: 1.5rem;
+      --inset-card: 1.75rem;
+      --radius-card: 2px;
+
+      --motion-quick: 160ms;
+      --easing-standard: cubic-bezier(0.2, 0, 0, 1);
+    }
+
+    *,
+    *::before,
+    *::after {
+      box-sizing: border-box;
+    }
+
+    html {
+      -webkit-text-size-adjust: 100%;
+    }
+
+    body {
+      margin: 0;
+      min-height: 100svh;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      padding: var(--space-loose);
+      background-color: var(--colour-bg);
+      color: var(--colour-text);
+      font-family: var(--font-sans);
+      font-size: 1rem;
+      line-height: 1.5;
+      -webkit-font-smoothing: antialiased;
+      text-rendering: optimizeLegibility;
+    }
+
+    .card {
+      width: 100%;
+      max-width: 27rem;
+      background-color: var(--colour-surface);
+      border: 1px solid var(--colour-border-strong);
+      border-radius: var(--radius-card);
+      padding: var(--inset-card);
+    }
+
+    .eyebrow {
+      display: flex;
+      align-items: center;
+      gap: 0.5rem;
+      margin: 0 0 var(--space-default);
+      font-family: var(--font-mono);
+      font-size: 0.75rem;
+      font-weight: 500;
+      letter-spacing: 0.18em;
+      text-transform: uppercase;
+      color: var(--colour-rose-base);
+    }
+
+    .eyebrow .dot {
+      width: 0.4rem;
+      height: 0.4rem;
+      border-radius: 50%;
+      background-color: var(--colour-rose-base);
+    }
+
+    h1 {
+      margin: 0 0 var(--space-snug);
+      font-family: var(--font-sans);
+      font-weight: 500;
+      font-size: 1.728rem;
+      line-height: 1.2;
+      letter-spacing: -0.012em;
+      color: var(--colour-text);
+    }
+
+    .lead {
+      margin: 0 0 var(--space-loose);
+      color: var(--colour-text-muted);
+      font-size: 1rem;
+      line-height: 1.55;
+    }
+
+    .detail {
+      margin: 0 0 var(--space-loose);
+      padding: var(--space-default) var(--space-default) calc(var(--space-default) - 0.25rem);
+      background-color: var(--colour-surface-code);
+      border: 1px solid var(--colour-border);
+      border-radius: var(--radius-card);
+    }
+
+    .field {
+      margin: 0 0 var(--space-default);
+    }
+
+    .field:last-child {
+      margin-bottom: 0;
+    }
+
+    .field dt {
+      margin: 0 0 0.25rem;
+      font-family: var(--font-mono);
+      font-size: 0.75rem;
+      font-weight: 500;
+      letter-spacing: 0.04em;
+      text-transform: uppercase;
+      color: var(--colour-text-subtle);
+    }
+
+    .field dd {
+      margin: 0;
+      font-family: var(--font-mono);
+      font-size: 0.9375rem;
+      line-height: 1.45;
+      color: var(--colour-text);
+      overflow-wrap: anywhere;
+    }
+
+    .field .note {
+      display: block;
+      margin-top: 0.25rem;
+      font-family: var(--font-sans);
+      font-size: 0.8125rem;
+      letter-spacing: 0;
+      text-transform: none;
+      color: var(--colour-text-subtle);
+    }
+
+    .warning {
+      margin: 0 0 var(--space-loose);
+      padding: var(--space-snug) var(--space-default);
+      background-color: var(--colour-warning-bg);
+      border: 1px solid var(--colour-warning-border);
+      border-radius: var(--radius-card);
+    }
+
+    .warning h2 {
+      margin: 0 0 0.25rem;
+      font-family: var(--font-mono);
+      font-size: 0.75rem;
+      font-weight: 500;
+      letter-spacing: 0.04em;
+      text-transform: uppercase;
+      color: var(--colour-warning-fg);
+    }
+
+    .warning p {
+      margin: 0;
+      font-size: 0.875rem;
+      line-height: 1.5;
+      color: var(--colour-text-dim);
+    }
+
+    .approve {
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      min-height: 3rem;
+      padding: 0.75rem 1.25rem;
+      background-color: var(--colour-primary-bg);
+      color: var(--colour-primary-fg);
+      border: 1px solid var(--colour-primary-border);
+      border-radius: var(--radius-card);
+      font-family: var(--font-sans);
+      font-size: 1rem;
+      font-weight: 500;
+      letter-spacing: 0.01em;
+      text-decoration: none;
+      transition:
+        background-color var(--motion-quick) var(--easing-standard),
+        border-color var(--motion-quick) var(--easing-standard);
+    }
+
+    .approve:hover {
+      background-color: var(--colour-primary-bg-hover);
+      border-color: var(--colour-rose-base);
+    }
+
+    .approve:focus-visible {
+      outline: 3px solid var(--colour-focus-ring);
+      outline-offset: 2px;
+    }
+
+    .approve:active {
+      transform: translateY(1px);
+    }
+
+    .deny {
+      margin: var(--space-default) 0 0;
+      text-align: center;
+      font-size: 0.8125rem;
+      color: var(--colour-text-subtle);
+    }
+
+    /* Narrow viewports: tighten the gutters so the card breathes. */
+    @media (max-width: 30rem) {
+      body {
+        padding: var(--space-default);
+      }
+      .card {
+        padding: var(--space-loose);
+      }
+    }
+
+    @media (prefers-reduced-motion: reduce) {
+      .approve {
+        transition: none;
+      }
+      .approve:active {
+        transform: none;
+      }
+    }
+
+    /* Forced-colors (Windows High Contrast): keep the control and its
+       focus state visible once the system palette takes over. */
+    @media (forced-colors: active) {
+      .approve {
+        border-color: ButtonText;
+      }
+      .approve:focus-visible {
+        outline-color: Highlight;
+      }
+    }
+  </style>
+</head>
+<body>
+  <main class="card">
+    <p class="eyebrow"><span class="dot" aria-hidden="true"></span>Tribal</p>
+    <h1>Authorisation request</h1>
+    <p class="lead">A client is asking to connect to your Tribal memory. Check the details below, then authorise only if you started this request.</p>
+
+    <dl class="detail">
+      <div class="field">
+        <dt>Client</dt>
+        <dd>tribal-cli-7f3a9c2e</dd>
+      </div>
+      <div class="field field--host">
+        <dt>Redirect host</dt>
+        <dd>mcp.example.com<span class="note">The authorisation code is delivered here.</span></dd>
+      </div>
+      <div class="field">
+        <dt>Requested scope</dt>
+        <dd>tribal.memory:read tribal.memory:write</dd>
+      </div>
+    </dl>
+
+    
+
+    <a class="approve" id="approve" href="https://mcp.example.com/callback?code=abc123&#38;state=xyz">Authorise</a>
+    <p class="deny">To deny, close this window.</p>
+  </main>
+</body>
+</html>

--- a/crates/tribal-auth/src/oauth/snapshots/consent-remote.html
+++ b/crates/tribal-auth/src/oauth/snapshots/consent-remote.html
@@ -271,14 +271,14 @@
     <dl class="detail">
       <div class="field">
         <dt>Client</dt>
-        <dd>Tribal CLI<span class="note">Self-reported by the client, not verified. Identifier: tribal-cli-7f3a9c2e</span></dd>
+        <dd><bdi>Tribal CLI</bdi><span class="note">Self-reported by the client, not verified. Identifier: tribal-cli-7f3a9c2e</span></dd>
       </div>
       <div class="field">
         <dt>Redirect host</dt>
         <dd>mcp.example.com<span class="note">The authorisation code is delivered here.</span></dd>
       </div>
       <div class="field">
-        <dt>Requested scope</dt>
+        <dt>Access granted</dt>
         <dd>tribal.memory:read tribal.memory:write</dd>
       </div>
     </dl>

--- a/crates/tribal-auth/src/oauth/token.rs
+++ b/crates/tribal-auth/src/oauth/token.rs
@@ -37,7 +37,7 @@ use crate::{
             InvalidTargetReason, OAuthError, require_param,
         },
         pkce::{CodeChallenge, CodeVerifier},
-        scope::{DEFAULT_GRANT_SCOPE, parse_scope_list},
+        scope::{grant_or_default, parse_scope_list},
     },
 };
 
@@ -310,10 +310,10 @@ async fn exchange(
         });
     }
 
-    let scope = code
-        .scope()
-        .filter(|s| !s.is_empty())
-        .map_or_else(|| DEFAULT_GRANT_SCOPE.to_owned(), str::to_owned);
+    // Resolve the minted grant through the shared resolver, the same one
+    // /authorize used when it issued the code, so the token cannot carry a
+    // different scope from the one the consent page displayed.
+    let scope = grant_or_default(code.scope());
 
     let scopes = parse_scope_list(&scope)?;
 

--- a/crates/tribal-auth/templates/consent.html
+++ b/crates/tribal-auth/templates/consent.html
@@ -272,7 +272,7 @@
       <div class="field">
         <dt>Client</dt>
 {%- if let Some(name) = client_name %}
-        <dd>{{ name }}<span class="note">Self-reported by the client, not verified. Identifier: {{ client_id }}</span></dd>
+        <dd><bdi>{{ name }}</bdi><span class="note">Self-reported by the client, not verified. Identifier: {{ client_id }}</span></dd>
 {%- else %}
         <dd>{{ client_id }}</dd>
 {%- endif %}
@@ -282,7 +282,7 @@
         <dd>{{ redirect_host }}<span class="note">The authorisation code is delivered here.</span></dd>
       </div>
       <div class="field">
-        <dt>Requested scope</dt>
+        <dt>Access granted</dt>
         <dd>{{ scope_display }}</dd>
       </div>
     </dl>

--- a/crates/tribal-auth/templates/consent.html
+++ b/crates/tribal-auth/templates/consent.html
@@ -1,0 +1,300 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Authorisation request &middot; Tribal</title>
+  <style>
+    /* Colour, type, and rhythm lifted from the Tribal design tokens
+       (oklch). Inlined so the page is self-contained and makes no
+       external request. */
+    :root {
+      --colour-bg: oklch(0.1633 0.0055 355.53);
+      --colour-bg-deep: oklch(0.1391 0.0060 354.68);
+      --colour-surface: oklch(0.2042 0.0076 48.33);
+      --colour-surface-raised: oklch(0.2388 0.0073 48.40);
+      --colour-surface-code: oklch(0.1818 0.0078 48.27);
+
+      --colour-text: oklch(0.9428 0.0076 61.45);
+      --colour-text-dim: oklch(0.8669 0.0106 67.69);
+      --colour-text-muted: oklch(0.7441 0.0126 51.26);
+      --colour-text-subtle: oklch(0.6392 0.0113 48.54);
+
+      --colour-rose-base: oklch(0.7800 0.0850 18);
+      --colour-rose-ink: oklch(0.9200 0.0500 18);
+      --colour-border-tint: oklch(0.9314 0.0128 48.58);
+      --colour-hue-warning: oklch(0.8000 0.1500 70);
+
+      --colour-border: color-mix(in oklch, var(--colour-border-tint) 7%, transparent);
+      --colour-border-strong: color-mix(in oklch, var(--colour-border-tint) 14%, transparent);
+      --colour-focus-ring: color-mix(in oklch, var(--colour-rose-base) 80%, transparent);
+
+      --colour-primary-fg: var(--colour-rose-base);
+      --colour-primary-bg: color-mix(in oklch, var(--colour-rose-base) 14%, transparent);
+      --colour-primary-bg-hover: color-mix(in oklch, var(--colour-rose-base) 22%, transparent);
+      --colour-primary-border: color-mix(in oklch, var(--colour-rose-base) 35%, transparent);
+
+      --colour-warning-fg: var(--colour-hue-warning);
+      --colour-warning-bg: color-mix(in oklch, var(--colour-hue-warning) 12%, transparent);
+      --colour-warning-border: color-mix(in oklch, var(--colour-hue-warning) 30%, transparent);
+
+      --font-sans: "IBM Plex Sans", system-ui, sans-serif;
+      --font-mono: "IBM Plex Mono", ui-monospace, SFMono-Regular, Menlo, monospace;
+
+      --space-snug: 0.75rem;
+      --space-default: 1rem;
+      --space-loose: 1.5rem;
+      --inset-card: 1.75rem;
+      --radius-card: 2px;
+
+      --motion-quick: 160ms;
+      --easing-standard: cubic-bezier(0.2, 0, 0, 1);
+    }
+
+    *,
+    *::before,
+    *::after {
+      box-sizing: border-box;
+    }
+
+    html {
+      -webkit-text-size-adjust: 100%;
+    }
+
+    body {
+      margin: 0;
+      min-height: 100svh;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      padding: var(--space-loose);
+      background-color: var(--colour-bg);
+      color: var(--colour-text);
+      font-family: var(--font-sans);
+      font-size: 1rem;
+      line-height: 1.5;
+      -webkit-font-smoothing: antialiased;
+      text-rendering: optimizeLegibility;
+    }
+
+    .card {
+      width: 100%;
+      max-width: 27rem;
+      background-color: var(--colour-surface);
+      border: 1px solid var(--colour-border-strong);
+      border-radius: var(--radius-card);
+      padding: var(--inset-card);
+    }
+
+    .eyebrow {
+      display: flex;
+      align-items: center;
+      gap: 0.5rem;
+      margin: 0 0 var(--space-default);
+      font-family: var(--font-mono);
+      font-size: 0.75rem;
+      font-weight: 500;
+      letter-spacing: 0.18em;
+      text-transform: uppercase;
+      color: var(--colour-rose-base);
+    }
+
+    .eyebrow .dot {
+      width: 0.4rem;
+      height: 0.4rem;
+      border-radius: 50%;
+      background-color: var(--colour-rose-base);
+    }
+
+    h1 {
+      margin: 0 0 var(--space-snug);
+      font-family: var(--font-sans);
+      font-weight: 500;
+      font-size: 1.728rem;
+      line-height: 1.2;
+      letter-spacing: -0.012em;
+      color: var(--colour-text);
+    }
+
+    .lead {
+      margin: 0 0 var(--space-loose);
+      color: var(--colour-text-muted);
+      font-size: 1rem;
+      line-height: 1.55;
+    }
+
+    .detail {
+      margin: 0 0 var(--space-loose);
+      padding: var(--space-default) var(--space-default) calc(var(--space-default) - 0.25rem);
+      background-color: var(--colour-surface-code);
+      border: 1px solid var(--colour-border);
+      border-radius: var(--radius-card);
+    }
+
+    .field {
+      margin: 0 0 var(--space-default);
+    }
+
+    .field:last-child {
+      margin-bottom: 0;
+    }
+
+    .field dt {
+      margin: 0 0 0.25rem;
+      font-family: var(--font-mono);
+      font-size: 0.75rem;
+      font-weight: 500;
+      letter-spacing: 0.04em;
+      text-transform: uppercase;
+      color: var(--colour-text-subtle);
+    }
+
+    .field dd {
+      margin: 0;
+      font-family: var(--font-mono);
+      font-size: 0.9375rem;
+      line-height: 1.45;
+      color: var(--colour-text);
+      overflow-wrap: anywhere;
+    }
+
+    .field .note {
+      display: block;
+      margin-top: 0.25rem;
+      font-family: var(--font-sans);
+      font-size: 0.8125rem;
+      letter-spacing: 0;
+      text-transform: none;
+      color: var(--colour-text-subtle);
+    }
+
+    .warning {
+      margin: 0 0 var(--space-loose);
+      padding: var(--space-snug) var(--space-default);
+      background-color: var(--colour-warning-bg);
+      border: 1px solid var(--colour-warning-border);
+      border-radius: var(--radius-card);
+    }
+
+    .warning h2 {
+      margin: 0 0 0.25rem;
+      font-family: var(--font-mono);
+      font-size: 0.75rem;
+      font-weight: 500;
+      letter-spacing: 0.04em;
+      text-transform: uppercase;
+      color: var(--colour-warning-fg);
+    }
+
+    .warning p {
+      margin: 0;
+      font-size: 0.875rem;
+      line-height: 1.5;
+      color: var(--colour-text-dim);
+    }
+
+    .approve {
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      min-height: 3rem;
+      padding: 0.75rem 1.25rem;
+      background-color: var(--colour-primary-bg);
+      color: var(--colour-primary-fg);
+      border: 1px solid var(--colour-primary-border);
+      border-radius: var(--radius-card);
+      font-family: var(--font-sans);
+      font-size: 1rem;
+      font-weight: 500;
+      letter-spacing: 0.01em;
+      text-decoration: none;
+      transition:
+        background-color var(--motion-quick) var(--easing-standard),
+        border-color var(--motion-quick) var(--easing-standard);
+    }
+
+    .approve:hover {
+      background-color: var(--colour-primary-bg-hover);
+      border-color: var(--colour-rose-base);
+    }
+
+    .approve:focus-visible {
+      outline: 3px solid var(--colour-focus-ring);
+      outline-offset: 2px;
+    }
+
+    .approve:active {
+      transform: translateY(1px);
+    }
+
+    .deny {
+      margin: var(--space-default) 0 0;
+      text-align: center;
+      font-size: 0.8125rem;
+      color: var(--colour-text-subtle);
+    }
+
+    /* Narrow viewports: tighten the gutters so the card breathes. */
+    @media (max-width: 30rem) {
+      body {
+        padding: var(--space-default);
+      }
+      .card {
+        padding: var(--space-loose);
+      }
+    }
+
+    @media (prefers-reduced-motion: reduce) {
+      .approve {
+        transition: none;
+      }
+      .approve:active {
+        transform: none;
+      }
+    }
+
+    /* Forced-colors (Windows High Contrast): keep the control and its
+       focus state visible once the system palette takes over. */
+    @media (forced-colors: active) {
+      .approve {
+        border-color: ButtonText;
+      }
+      .approve:focus-visible {
+        outline-color: Highlight;
+      }
+    }
+  </style>
+</head>
+<body>
+  <main class="card">
+    <p class="eyebrow"><span class="dot" aria-hidden="true"></span>Tribal</p>
+    <h1>Authorisation request</h1>
+    <p class="lead">A client is asking to connect to your Tribal memory. Check the details below, then authorise only if you started this request.</p>
+
+    <dl class="detail">
+      <div class="field">
+        <dt>Client</dt>
+        <dd>{{ client_id }}</dd>
+      </div>
+      <div class="field field--host">
+        <dt>Redirect host</dt>
+        <dd>{{ redirect_host }}<span class="note">The authorisation code is delivered here.</span></dd>
+      </div>
+      <div class="field">
+        <dt>Requested scope</dt>
+        <dd>{{ scope_display }}</dd>
+      </div>
+    </dl>
+
+    {% if is_loopback %}
+    <section class="warning" aria-labelledby="warn-title">
+      <h2 id="warn-title">Loopback redirect</h2>
+      <p>Any process listening on this host can receive the code. Only continue if you started a local client expecting it.</p>
+    </section>
+    {% endif %}
+
+    <a class="approve" id="approve" href="{{ target }}">Authorise</a>
+    <p class="deny">To deny, close this window.</p>
+  </main>
+</body>
+</html>

--- a/crates/tribal-auth/templates/consent.html
+++ b/crates/tribal-auth/templates/consent.html
@@ -10,9 +10,7 @@
        external request. */
     :root {
       --colour-bg: oklch(0.1633 0.0055 355.53);
-      --colour-bg-deep: oklch(0.1391 0.0060 354.68);
       --colour-surface: oklch(0.2042 0.0076 48.33);
-      --colour-surface-raised: oklch(0.2388 0.0073 48.40);
       --colour-surface-code: oklch(0.1818 0.0078 48.27);
 
       --colour-text: oklch(0.9428 0.0076 61.45);
@@ -21,7 +19,6 @@
       --colour-text-subtle: oklch(0.6392 0.0113 48.54);
 
       --colour-rose-base: oklch(0.7800 0.0850 18);
-      --colour-rose-ink: oklch(0.9200 0.0500 18);
       --colour-border-tint: oklch(0.9314 0.0128 48.58);
       --colour-hue-warning: oklch(0.8000 0.1500 70);
 
@@ -274,9 +271,13 @@
     <dl class="detail">
       <div class="field">
         <dt>Client</dt>
+{%- if let Some(name) = client_name %}
+        <dd>{{ name }}<span class="note">Self-reported by the client, not verified. Identifier: {{ client_id }}</span></dd>
+{%- else %}
         <dd>{{ client_id }}</dd>
+{%- endif %}
       </div>
-      <div class="field field--host">
+      <div class="field">
         <dt>Redirect host</dt>
         <dd>{{ redirect_host }}<span class="note">The authorisation code is delivered here.</span></dd>
       </div>
@@ -285,13 +286,13 @@
         <dd>{{ scope_display }}</dd>
       </div>
     </dl>
+{%- if is_loopback %}
 
-    {% if is_loopback %}
     <section class="warning" aria-labelledby="warn-title">
       <h2 id="warn-title">Loopback redirect</h2>
       <p>Any process listening on this host can receive the code. Only continue if you started a local client expecting it.</p>
     </section>
-    {% endif %}
+{%- endif %}
 
     <a class="approve" id="approve" href="{{ target }}">Authorise</a>
     <p class="deny">To deny, close this window.</p>

--- a/crates/tribal-auth/tests/oauth_handshake.rs
+++ b/crates/tribal-auth/tests/oauth_handshake.rs
@@ -974,6 +974,104 @@ async fn test_token_blank_scope_falls_back_to_registration() {
 }
 
 #[tokio::test]
+async fn test_token_empty_registered_scope_resolves_to_default() {
+    let ctx = test_context().await;
+    let pool = ctx.create_pool().await.unwrap();
+    ensure_local_principal(&pool).await;
+    let runtime = runtime_config();
+    let client = OAuthClient::new(runtime, pool);
+
+    // A client may register a blank scope. It must not display as nothing on
+    // the consent page while the token still mints the default grant.
+    let register = client
+        .register_raw(serde_json::json!({
+            "redirect_uris": [REDIRECT_URI],
+            "token_endpoint_auth_method": "none",
+            "scope": "",
+        }))
+        .await;
+    assert_eq!(register.status(), StatusCode::CREATED);
+    let register: serde_json::Value = serde_json::from_slice(&read_body(register).await).unwrap();
+    let client_id = register["client_id"].as_str().unwrap().to_owned();
+
+    let query = format!(
+        "response_type=code&client_id={client_id}&redirect_uri={REDIRECT_URI_ENCODED}\
+         &code_challenge={CHALLENGE}&code_challenge_method=S256\
+         &resource={RESOURCE_ENCODED}",
+    );
+    let response = client.authorize(&query).await;
+    assert_eq!(response.status(), StatusCode::OK);
+    let html = String::from_utf8(read_body(response).await).unwrap();
+    assert!(
+        html.contains("tribal:read"),
+        "consent page must show the default grant when the registered scope is blank",
+    );
+    let target = extract_approve_href(&html);
+    let code = Url::parse(&target)
+        .unwrap()
+        .query_pairs()
+        .find(|(k, _)| k == "code")
+        .map(|(_, v)| v.into_owned())
+        .expect("consent page carries the authorisation code");
+
+    let response = client
+        .post_token(token_form(&code, &client_id, VERIFIER, None))
+        .await;
+    assert_eq!(response.status(), StatusCode::OK);
+    let token: serde_json::Value = serde_json::from_slice(&read_body(response).await).unwrap();
+    assert_eq!(token["scope"], "tribal:read");
+}
+
+#[tokio::test]
+async fn test_consent_page_shows_explicit_requested_scope() {
+    let ctx = test_context().await;
+    let pool = ctx.create_pool().await.unwrap();
+    ensure_local_principal(&pool).await;
+    let runtime = runtime_config();
+    let client = OAuthClient::new(runtime, pool);
+
+    let register = client
+        .register_raw(serde_json::json!({
+            "redirect_uris": [REDIRECT_URI],
+            "token_endpoint_auth_method": "none",
+            "scope": "tribal:read tribal:write",
+        }))
+        .await;
+    assert_eq!(register.status(), StatusCode::CREATED);
+    let register: serde_json::Value = serde_json::from_slice(&read_body(register).await).unwrap();
+    let client_id = register["client_id"].as_str().unwrap().to_owned();
+
+    // An explicit request scope must appear on the page and be exactly what
+    // the minted token carries.
+    let query = format!(
+        "response_type=code&client_id={client_id}&redirect_uri={REDIRECT_URI_ENCODED}\
+         &code_challenge={CHALLENGE}&code_challenge_method=S256\
+         &resource={RESOURCE_ENCODED}&scope=tribal%3Aread",
+    );
+    let response = client.authorize(&query).await;
+    assert_eq!(response.status(), StatusCode::OK);
+    let html = String::from_utf8(read_body(response).await).unwrap();
+    assert!(
+        html.contains("tribal:read"),
+        "consent page must show the explicitly requested scope",
+    );
+    let target = extract_approve_href(&html);
+    let code = Url::parse(&target)
+        .unwrap()
+        .query_pairs()
+        .find(|(k, _)| k == "code")
+        .map(|(_, v)| v.into_owned())
+        .expect("consent page carries the authorisation code");
+
+    let response = client
+        .post_token(token_form(&code, &client_id, VERIFIER, None))
+        .await;
+    assert_eq!(response.status(), StatusCode::OK);
+    let token: serde_json::Value = serde_json::from_slice(&read_body(response).await).unwrap();
+    assert_eq!(token["scope"], "tribal:read");
+}
+
+#[tokio::test]
 async fn test_authorize_omits_redirect_uri_with_single_registered() {
     let ctx = test_context().await;
     let pool = ctx.create_pool().await.unwrap();

--- a/crates/tribal-auth/tests/oauth_handshake.rs
+++ b/crates/tribal-auth/tests/oauth_handshake.rs
@@ -301,6 +301,40 @@ async fn test_handshake_dcr_full_round_trip() {
     );
     let authorize_response = client.authorize(&authorize_query).await;
     assert_eq!(authorize_response.status(), StatusCode::OK);
+    // The consent page carries the authorisation code, so it is locked
+    // down: a deny-by-default CSP, unframable, no sniffing, no referrer
+    // leak of the request URL, and never cached.
+    let headers = authorize_response.headers();
+    let csp = headers
+        .get("content-security-policy")
+        .and_then(|v| v.to_str().ok())
+        .unwrap_or_default();
+    assert!(
+        csp.contains("default-src 'none'"),
+        "CSP denies by default: {csp}"
+    );
+    assert!(
+        csp.contains("frame-ancestors 'none'"),
+        "CSP forbids framing: {csp}"
+    );
+    assert_eq!(
+        headers.get("x-frame-options").and_then(|v| v.to_str().ok()),
+        Some("DENY"),
+    );
+    assert_eq!(
+        headers
+            .get("x-content-type-options")
+            .and_then(|v| v.to_str().ok()),
+        Some("nosniff"),
+    );
+    assert_eq!(
+        headers.get("referrer-policy").and_then(|v| v.to_str().ok()),
+        Some("no-referrer"),
+    );
+    assert_eq!(
+        headers.get("cache-control").and_then(|v| v.to_str().ok()),
+        Some("no-store"),
+    );
     let consent_html = String::from_utf8(read_body(authorize_response).await).unwrap();
     assert!(
         consent_html.contains("127.0.0.1"),

--- a/crates/tribal-auth/tests/oauth_handshake.rs
+++ b/crates/tribal-auth/tests/oauth_handshake.rs
@@ -340,6 +340,10 @@ async fn test_handshake_dcr_full_round_trip() {
         consent_html.contains("127.0.0.1"),
         "consent should display the redirect host"
     );
+    assert!(
+        consent_html.contains("Loopback redirect"),
+        "a loopback redirect must show the loopback warning"
+    );
     let target_url = extract_approve_href(&consent_html);
     let target_parsed = Url::parse(&target_url).unwrap();
     let code = target_parsed

--- a/crates/tribal-auth/tests/oauth_handshake.rs
+++ b/crates/tribal-auth/tests/oauth_handshake.rs
@@ -1254,19 +1254,23 @@ async fn test_authorization_code_survives_transaction_rollback() {
 // ---------------------------------------------------------------------------
 
 fn extract_approve_href(html: &str) -> String {
-    // The consent page presents the redirect target as an `<a href>` the
-    // user clicks to authorise; the href carries the full target URL with
-    // its query string intact. Extract it to drive the exchange.
-    let start = html
-        .find(r#"<a id="approve" href=""#)
+    // The consent page presents the redirect target as the approve
+    // anchor's href; it carries the full target URL with its query string
+    // intact. Locate the href within that anchor (independent of the
+    // anchor's other attributes) to drive the exchange.
+    let anchor = html
+        .find(r#"class="approve""#)
         .expect("consent page approve anchor present");
-    let after = &html[start + r#"<a id="approve" href=""#.len()..];
+    let href_marker = r#"href=""#;
+    let href_rel = html[anchor..]
+        .find(href_marker)
+        .expect("approve anchor carries an href");
+    let start = anchor + href_rel + href_marker.len();
+    let after = &html[start..];
     let end = after.find('"').expect("approve href quoted");
-    decode_html_attribute(&after[..end])
-}
-
-fn decode_html_attribute(s: &str) -> String {
-    s.replace("&amp;", "&")
+    // The href is HTML-attribute-escaped; decode every entity form back
+    // to the raw redirect URL rather than special-casing the separator.
+    html_escape::decode_html_entities(&after[..end]).into_owned()
 }
 
 fn base64_encode(input: &str) -> String {

--- a/crates/tribal-auth/tests/oauth_handshake.rs
+++ b/crates/tribal-auth/tests/oauth_handshake.rs
@@ -892,9 +892,29 @@ async fn test_token_omitted_scope_falls_back_to_registration() {
     let register: serde_json::Value = serde_json::from_slice(&read_body(register).await).unwrap();
     let client_id = register["client_id"].as_str().unwrap().to_owned();
 
-    // authorize_code omits the scope parameter; the minted token must carry
-    // the registered scope, not the broader DEFAULT_GRANT_SCOPE.
-    let code = client.authorize_code(&client_id).await;
+    // The scope parameter is omitted entirely. The consent page must show
+    // the effective grant the code carries (the registered scope), and the
+    // minted token must carry it too, not the broader DEFAULT_GRANT_SCOPE.
+    let query = format!(
+        "response_type=code&client_id={client_id}&redirect_uri={REDIRECT_URI_ENCODED}\
+         &code_challenge={CHALLENGE}&code_challenge_method=S256\
+         &resource={RESOURCE_ENCODED}",
+    );
+    let response = client.authorize(&query).await;
+    assert_eq!(response.status(), StatusCode::OK);
+    let html = String::from_utf8(read_body(response).await).unwrap();
+    assert!(
+        html.contains("tribal.knowledge:read"),
+        "consent page must show the effective registered scope when scope is omitted",
+    );
+    let target = extract_approve_href(&html);
+    let code = Url::parse(&target)
+        .unwrap()
+        .query_pairs()
+        .find(|(k, _)| k == "code")
+        .map(|(_, v)| v.into_owned())
+        .expect("consent page carries the authorisation code");
+
     let response = client
         .post_token(token_form(&code, &client_id, VERIFIER, None))
         .await;
@@ -933,6 +953,10 @@ async fn test_token_blank_scope_falls_back_to_registration() {
     let response = client.authorize(&query).await;
     assert_eq!(response.status(), StatusCode::OK);
     let html = String::from_utf8(read_body(response).await).unwrap();
+    assert!(
+        html.contains("tribal.knowledge:read"),
+        "consent page must show the effective registered scope when scope is blank",
+    );
     let target = extract_approve_href(&html);
     let code = Url::parse(&target)
         .unwrap()
@@ -1295,8 +1319,16 @@ fn extract_approve_href(html: &str) -> String {
     let anchor = html
         .find(r#"class="approve""#)
         .expect("consent page approve anchor present");
+    // Bound the href search to the approve anchor's own opening tag, so a
+    // later unrelated link cannot be followed if the anchor ever loses its
+    // href.
+    let tag_end = html[anchor..]
+        .find('>')
+        .map(|rel| anchor + rel)
+        .expect("approve anchor opening tag is closed");
+    let opening_tag = &html[anchor..tag_end];
     let href_marker = r#"href=""#;
-    let href_rel = html[anchor..]
+    let href_rel = opening_tag
         .find(href_marker)
         .expect("approve anchor carries an href");
     let start = anchor + href_rel + href_marker.len();


### PR DESCRIPTION
Closes tribal-memory/cortex#26.

Gives the OAuth consent page, the only human-facing surface in the authorisation flow, a deliberate and trustworthy appearance, and hardens what it renders and how it is served. This goes beyond the ticket's original "cosmetic only" framing; tribal-memory/cortex#26's body owns those decisions under its "Scope reconciliation" section.

## What

- **Typed template and escaping.** The page renders from a compile-checked askama template; the two hand-rolled escape helpers are gone, replaced by the engine's audited auto-escaper. Every interpolation is escaped and none is marked safe.
- **Response hardening.** The consent response sets a strict CSP (`default-src 'none'`), `X-Frame-Options`, `X-Content-Type-Options`, `Referrer-Policy`, and `Cache-Control: no-store`.
- **Display correctness.** The page shows the effective grant the token will actually carry, resolved once in a shared resolver used by both `/authorize` and `/token`, so the displayed scope, the stored code, and the minted token cannot disagree (including for omitted, blank, or empty-registered scopes). The registered client name is shown when present, with the opaque `client_id` demoted to a self-reported, not-verified note.
- **Adversarial metadata.** A registered client name is validated at registration (rejected by Unicode general category: control, format, line and paragraph separator) and wrapped in `<bdi>`, so a self-asserted name cannot reorder its own disclaimer, force line breaks, or push the redirect host below the fold. A blank or whitespace-only scope or name normalises to absent rather than persisting empty.
- **Authority and ordering.** The page shows the full `host:port` the code is delivered to. The page is built before the code is persisted, so a render failure leaves no orphaned code behind.

## Invariants preserved

Script-free, no auto-advance, navigation by an anchor rather than a form, the loopback warning shown only for loopback hosts, and self-contained (no external resource, `@import`, or `url()`). Each is asserted by a test.

## Verification

`tribal-auth` lib 102/0 and handshake integration 33/0 against a real Postgres, clippy `-D warnings` clean, nightly fmt clean, snapshot goldens regenerated.