### PR TITLE
[FIX] Apply grammar-subset dialect to Ollama schemas

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ## [Unreleased]
 
+### Fixed
+
+- Ollama structured-output ingestion. The Ollama JSON Schema dialect now shares the grammar subset with Anthropic, rewriting the single-element `allOf`-with-`$ref` and `oneOf` enum forms `schemars` emits into shapes llama.cpp's grammar builder compiles. The extraction, triage, and relation stages no longer dead-letter with a parse error against local models. ([#195](https://github.com/tribal-memory/tribal/issues/195))
+
 ## [0.3.0] - 2026-06-01
 
 This release makes the embedding geometry configurable and adds zero-downtime reindexing of the embedding space. It is a breaking release: the initial database schema is revised for the embedding-profile model and the embedding configuration keys have moved, so there is no in-place upgrade from 0.2.x. Provision a fresh database and update the configuration (see Changed).

--- a/crates/tribal-inference/src/ollama/inference.rs
+++ b/crates/tribal-inference/src/ollama/inference.rs
@@ -494,6 +494,8 @@ mod tests {
         let server = MockServer::start().await;
         let schema =
             serde_json::json!({"type": "object", "properties": {"name": {"type": "string"}}});
+        // Ollama receives the grammar-subset dialect of the caller schema.
+        let expected_format = apply_dialect(ProviderKind::Ollama, schema.clone());
 
         Mock::given(method("POST"))
             .and(path(CHAT_PATH))
@@ -501,7 +503,7 @@ mod tests {
                 "model": "llama3.2:3b",
                 "messages": [{"role": "user", "content": "test"}],
                 "stream": false,
-                "format": schema.clone(),
+                "format": expected_format,
             })))
             .respond_with(ResponseTemplate::new(200).set_body_json(a_valid_response_json()))
             .expect(1)

--- a/crates/tribal-inference/src/schema_dialect.rs
+++ b/crates/tribal-inference/src/schema_dialect.rs
@@ -23,8 +23,9 @@
 //!   `oneOf`/`allOf`-with-`$ref` rewritten away, but optionals left omitted from
 //!   `required` (the subset accepts optional-by-omission) and `$ref` annotations
 //!   retained. Both enforce the schema by compiling it to a grammar (Anthropic
-//!   server-side, Ollama through llama.cpp), which rejects the single-element
-//!   `allOf`-with-`$ref` and `oneOf` enum forms `schemars` emits, so the subset
+//!   server-side, Ollama through llama.cpp), which cannot compile the
+//!   single-element `allOf`-with-`$ref` and `oneOf` enum forms `schemars` emits
+//!   (Anthropic rejects them; llama.cpp emits malformed output), so the subset
 //!   serves both and no per-request flag is sent.
 //!
 //! # Provenance
@@ -36,6 +37,7 @@
 //!
 //! - `OpenAI`: <https://platform.openai.com/docs/guides/structured-outputs>
 //! - `Anthropic`: <https://platform.claude.com/docs/en/build-with-claude/structured-outputs>
+//! - `Ollama` (llama.cpp grammar builder): <https://github.com/ggml-org/llama.cpp/blob/master/grammars/README.md>
 //!
 //! A subset can drift as a provider extends support; the documented live probe
 //! and issue reports are the safety net for that drift.
@@ -116,6 +118,13 @@ fn apply_openai_strict(mut schema: Value) -> Value {
 
 /// Normalises a schema into the grammar-based structured-output subset shared by
 /// `Anthropic` and `Ollama` (llama.cpp). See the module-level Provenance note.
+///
+/// A constraint this transform relies on but does not itself enforce: llama.cpp's
+/// grammar builder mis-generates when a `$ref` targets a definition emitted later
+/// in `definitions` that itself nests a `$ref` (Ollama issue #8444). `schemars`
+/// emits `definitions` alphabetically, so the response schemas stay safe by
+/// keeping every forward-referenced definition a leaf (an enum or an all-scalar
+/// object); a dialect test guards that shape.
 fn apply_grammar_subset(mut schema: Value) -> Value {
     strip_unsupported_keywords(&mut schema);
     unwrap_described_refs(&mut schema);

--- a/crates/tribal-inference/src/schema_dialect.rs
+++ b/crates/tribal-inference/src/schema_dialect.rs
@@ -11,20 +11,21 @@
 //! accommodated by adding one arm to [`apply_dialect`]; existing call sites are
 //! unchanged.
 //!
-//! Three policies:
+//! Two policies:
 //!
-//! - **`OpenAI`**: every object closed (`additionalProperties: false`) and
-//!   all-required, optionals expressed as a nullable type union, internally
-//!   tagged enums rewritten from `oneOf` to `anyOf` with a `const` discriminator,
-//!   string enums collapsed to a single `enum`, `$ref` reduced to a bare
-//!   reference (the subset rejects sibling keywords on `$ref`), and the
+//! - **`OpenAI`** (strict subset): every object closed (`additionalProperties:
+//!   false`) and all-required, optionals expressed as a nullable type union,
+//!   internally tagged enums rewritten from `oneOf` to `anyOf` with a `const`
+//!   discriminator, string enums collapsed to a single `enum`, `$ref` reduced to
+//!   a bare reference (the subset rejects sibling keywords on `$ref`), and the
 //!   validation leaf keywords the subset rejects stripped.
-//! - **`Anthropic`**: every object closed and `oneOf`/`allOf`-with-`$ref`
-//!   rewritten away, but optionals left omitted from `required` (the subset
-//!   accepts optional-by-omission) and `$ref` annotations retained. Enforcement
-//!   is grammar-based, so no per-request flag is sent.
-//! - **`Ollama`**: identity. The local llama.cpp path accepts the canonical
-//!   schema unchanged.
+//! - **`Anthropic` and `Ollama`** (grammar subset): every object closed and
+//!   `oneOf`/`allOf`-with-`$ref` rewritten away, but optionals left omitted from
+//!   `required` (the subset accepts optional-by-omission) and `$ref` annotations
+//!   retained. Both enforce the schema by compiling it to a grammar (Anthropic
+//!   server-side, Ollama through llama.cpp), which rejects the single-element
+//!   `allOf`-with-`$ref` and `oneOf` enum forms `schemars` emits, so the subset
+//!   serves both and no per-request flag is sent.
 //!
 //! # Provenance
 //!
@@ -91,14 +92,12 @@ const FORBIDDEN_VALIDATION_KEYWORDS: &[&str] = &[
 /// Rewrites a canonical `schemars` schema into the dialect `provider`'s
 /// structured-output endpoint accepts.
 ///
-/// `Ollama` accepts the canonical schema unchanged; the cloud providers each
-/// have their own transform. A provider that shares a policy reuses the same
-/// transform function.
+/// The grammar-based backends (`Anthropic` and `Ollama`) share one transform;
+/// `OpenAI`'s strict subset has its own.
 #[must_use]
 pub fn apply_dialect(provider: ProviderKind, schema: Value) -> Value {
     match provider {
-        ProviderKind::Ollama => schema,
-        ProviderKind::Anthropic => apply_anthropic_subset(schema),
+        ProviderKind::Anthropic | ProviderKind::Ollama => apply_grammar_subset(schema),
         ProviderKind::OpenAi => apply_openai_strict(schema),
     }
 }
@@ -115,9 +114,9 @@ fn apply_openai_strict(mut schema: Value) -> Value {
     schema
 }
 
-/// Normalises a schema into the `Anthropic` structured-output subset. See the
-/// module-level Provenance note for the subset reference.
-fn apply_anthropic_subset(mut schema: Value) -> Value {
+/// Normalises a schema into the grammar-based structured-output subset shared by
+/// `Anthropic` and `Ollama` (llama.cpp). See the module-level Provenance note.
+fn apply_grammar_subset(mut schema: Value) -> Value {
     strip_unsupported_keywords(&mut schema);
     unwrap_described_refs(&mut schema);
     rewrite_enums(&mut schema);
@@ -677,14 +676,59 @@ mod tests {
         apply_dialect(ProviderKind::Anthropic, schema)
     }
 
+    fn apply_ollama(schema: Value) -> Value {
+        apply_dialect(ProviderKind::Ollama, schema)
+    }
+
     #[test]
-    fn test_ollama_dialect_is_identity() {
+    fn test_ollama_shares_the_grammar_subset_with_anthropic() {
+        let schema = representative_schema();
+        assert_eq!(apply_ollama(schema.clone()), apply_anthropic(schema));
+    }
+
+    #[test]
+    fn test_ollama_rewrites_described_ref_and_enum() {
+        // llama.cpp's grammar builder compiles neither a described `$ref` wrapped
+        // in `allOf` nor the `oneOf` enum forms; the subset rewrites both away.
         let schema = json!({
             "type": "object",
-            "properties": { "name": { "type": "string" } },
-            "oneOf": [{ "enum": ["a"], "type": "string" }],
+            "properties": {
+                "kind": {
+                    "description": "the kind of knowledge this item records",
+                    "allOf": [{ "$ref": "#/definitions/KnowledgeKind" }],
+                },
+            },
+            "required": ["kind"],
+            "definitions": {
+                "KnowledgeKind": {
+                    "oneOf": [
+                        { "enum": ["fact"], "type": "string" },
+                        { "enum": ["heuristic"], "type": "string" },
+                    ],
+                },
+            },
         });
-        assert_eq!(apply_dialect(ProviderKind::Ollama, schema.clone()), schema);
+        let result = apply_ollama(schema);
+
+        let kind = &result["properties"]["kind"];
+        assert_eq!(kind["$ref"], json!("#/definitions/KnowledgeKind"));
+        assert_eq!(
+            kind["description"],
+            json!("the kind of knowledge this item records")
+        );
+        assert!(kind.get("allOf").is_none());
+        assert_eq!(
+            result["definitions"]["KnowledgeKind"],
+            json!({ "type": "string", "enum": ["fact", "heuristic"] })
+        );
+        assert_dialect_invariants(&result, false);
+    }
+
+    #[test]
+    fn test_ollama_dialect_is_idempotent() {
+        let once = apply_ollama(representative_schema());
+        let twice = apply_ollama(once.clone());
+        assert_eq!(once, twice);
     }
 
     #[test]

--- a/crates/tribal-worker/src/parsing/schema_dialect_snapshots.rs
+++ b/crates/tribal-worker/src/parsing/schema_dialect_snapshots.rs
@@ -176,23 +176,39 @@ fn test_anthropic_triage_schema_validates_created_instance() {
 }
 
 #[test]
-fn test_ollama_extraction_schema_validates_a_candidate_instance() {
-    // The transformed schema must compile and accept a well-formed extraction
-    // output, the shape llama.cpp's grammar then constrains generation to.
+fn test_ollama_extraction_schema_is_valid_jsonschema_and_accepts_an_instance() {
+    // Proves the transformed schema is valid draft-07 JSON Schema and accepts a
+    // populated extraction output. It does not prove llama.cpp grammar
+    // compilability (a separate engine), which is exercised out of band by a
+    // manual end-to-end run, not in CI. The instance populates the nullable
+    // reference `description` (present and null) and a relation hint, the shapes
+    // a minimal instance would skip.
     let schema = apply_dialect(ProviderKind::Ollama, canonical_schema::<ExtractionOutput>());
     let validator = Validator::new(&schema).expect("transformed schema compiles");
     let instance = json!({
-        "candidates": [{
-            "content": "The rate limiter threshold was raised to 500 and never reverted.",
-            "kind": "fact",
-            "suggested_tags": ["api rate limiting"],
-            "suggested_references": [],
-        }],
-        "relation_hints": [],
+        "candidates": [
+            {
+                "content": "The rate limiter threshold was raised to 500 and never reverted.",
+                "kind": "fact",
+                "suggested_tags": ["api rate limiting"],
+                "suggested_references": [
+                    { "reference_type": "symbol", "value": "RateLimiter", "description": "the guard that was widened" },
+                    { "reference_type": "file_path", "value": "src/limit.rs", "description": null },
+                ],
+            },
+            {
+                "content": "The 500 threshold came from the incident retro, not a load test.",
+                "kind": "decision_record",
+                "suggested_tags": ["api rate limiting"],
+            },
+        ],
+        "relation_hints": [
+            { "hint_type": "derived_from", "source_index": 1, "target_index": 0 },
+        ],
     });
     assert!(
         validator.is_valid(&instance),
-        "the grammar-subset extraction schema must accept a correct instance"
+        "the grammar-subset extraction schema must accept a populated instance"
     );
 }
 
@@ -209,6 +225,164 @@ fn test_openai_triage_schema_rejects_bare_string_outcome() {
     assert!(
         !validator.is_valid(&off_shape),
         "the strict triage schema must reject a bare-string outcome"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Grammar-subset hardening (Ollama)
+// ---------------------------------------------------------------------------
+
+/// Every schema node within `value`, including `value` itself. One recursion the
+/// structural checks below share, rather than a bespoke walk apiece.
+fn nodes(value: &Value) -> Vec<&Value> {
+    let mut out = vec![value];
+    match value {
+        Value::Object(map) => map.values().for_each(|v| out.extend(nodes(v))),
+        Value::Array(items) => items.iter().for_each(|v| out.extend(nodes(v))),
+        _ => {}
+    }
+    out
+}
+
+/// Whether `node` is a single-element `allOf` wrapping a `$ref` (the
+/// described-`$ref` form `schemars` emits and the subset rewrites away).
+fn is_single_allof_ref(node: &Value) -> bool {
+    match node.get("allOf").and_then(Value::as_array) {
+        Some(branches) => branches.len() == 1 && branches[0].get("$ref").is_some(),
+        None => false,
+    }
+}
+
+/// The definition names (`#/definitions/<name>`) referenced anywhere in `value`.
+fn refs_in(value: &Value) -> Vec<&str> {
+    nodes(value)
+        .into_iter()
+        .filter_map(|node| node.get("$ref").and_then(Value::as_str))
+        .filter_map(|pointer| pointer.strip_prefix("#/definitions/"))
+        .collect()
+}
+
+/// Asserts no definition references a later-emitted definition that itself nests
+/// a `$ref`. Emitted order is what llama.cpp's grammar builder parses, and a
+/// forward ref to a non-leaf is the Ollama #8444 trigger.
+fn assert_forward_refs_are_leaves(schema: &Value) {
+    let Some(defs) = schema.get("definitions").and_then(Value::as_object) else {
+        return;
+    };
+    let order: Vec<&str> = defs.keys().map(String::as_str).collect();
+    for (pos, (name, body)) in defs.iter().enumerate() {
+        for target in refs_in(body) {
+            let forward = matches!(order.iter().position(|k| *k == target), Some(t) if t > pos);
+            let nests_ref = defs.get(target).is_some_and(|t| !refs_in(t).is_empty());
+            assert!(
+                !(forward && nests_ref),
+                "definition `{name}` forward-references `{target}`, which nests a $ref \
+                 (Ollama #8444); keep forward-referenced definitions leaf-only."
+            );
+        }
+    }
+}
+
+#[test]
+fn test_ollama_dialect_eliminates_the_forms_llama_cpp_cannot_compile() {
+    // Anchors the fix to the concrete defect: the canonical schema carries the
+    // single-element `allOf`-with-`$ref` and `oneOf` forms the grammar builder
+    // cannot compile, and the Ollama dialect removes both. Without this anchor
+    // the instance tests would also pass against the old identity transform.
+    let canonical = canonical_schema::<TriageClassification>();
+    assert!(
+        nodes(&canonical).into_iter().any(is_single_allof_ref),
+        "canonical schema should carry a single-element allOf-with-$ref"
+    );
+    assert!(
+        nodes(&canonical)
+            .into_iter()
+            .any(|node| node.get("oneOf").is_some()),
+        "canonical schema should carry a oneOf form"
+    );
+
+    let transformed = apply_dialect(ProviderKind::Ollama, canonical);
+    let combinators_gone = nodes(&transformed)
+        .into_iter()
+        .all(|node| node.get("allOf").is_none() && node.get("oneOf").is_none());
+    assert!(
+        combinators_gone,
+        "the Ollama dialect must remove every allOf and oneOf"
+    );
+}
+
+#[test]
+fn test_ollama_dialect_keeps_forward_referenced_definitions_as_leaves() {
+    // Guard against Ollama #8444: a forward `$ref` to a definition that nests a
+    // `$ref` silently corrupts the grammar. The schemas are safe today only
+    // because every forward-referenced definition is a leaf; this fails loudly
+    // the moment that stops holding.
+    for schema in [
+        apply_dialect(ProviderKind::Ollama, canonical_schema::<ExtractionOutput>()),
+        apply_dialect(
+            ProviderKind::Ollama,
+            canonical_schema::<TriageClassification>(),
+        ),
+        apply_dialect(ProviderKind::Ollama, canonical_schema::<RelationOutput>()),
+    ] {
+        assert_forward_refs_are_leaves(&schema);
+    }
+}
+
+#[test]
+fn test_ollama_relation_schema_accepts_present_and_null_justification() {
+    // Exercises the nullable optional union (`justification`: `["string","null"]`)
+    // on the relation edge, present in one edge and null in another.
+    let schema = apply_dialect(ProviderKind::Ollama, canonical_schema::<RelationOutput>());
+    let validator = Validator::new(&schema).expect("transformed schema compiles");
+    let instance = json!({
+        "relations": [
+            {
+                "relation_type": "supports",
+                "source": { "kind": "context_index", "context_index": 0 },
+                "target": { "kind": "context_index", "context_index": 1 },
+                "justification": "both describe the same widened threshold",
+            },
+            {
+                "relation_type": "derived_from",
+                "source": { "kind": "context_index", "context_index": 1 },
+                "target": { "kind": "context_index", "context_index": 0 },
+                "justification": null,
+            },
+        ],
+    });
+    assert!(
+        validator.is_valid(&instance),
+        "the grammar-subset relation schema must accept present and null justification"
+    );
+}
+
+#[test]
+fn test_ollama_triage_schema_accepts_duplicate_branch_and_decisions() {
+    // Exercises the second `anyOf` branch (`duplicate` with `matched_item`) and a
+    // populated `similar_item_decisions`, which the minimal `created` instance
+    // never reaches.
+    let schema = apply_dialect(
+        ProviderKind::Ollama,
+        canonical_schema::<TriageClassification>(),
+    );
+    let validator = Validator::new(&schema).expect("transformed schema compiles");
+    let instance = json!({
+        "outcome": {
+            "decision": "duplicate",
+            "matched_item": { "kind": "context_index", "context_index": 0 },
+        },
+        "similar_item_decisions": [
+            {
+                "item": { "kind": "context_index", "context_index": 0 },
+                "justification": "restates the existing claim verbatim",
+                "suggested_relation": "supports",
+            },
+        ],
+    });
+    assert!(
+        validator.is_valid(&instance),
+        "the grammar-subset triage schema must accept the duplicate branch"
     );
 }
 

--- a/crates/tribal-worker/src/parsing/schema_dialect_snapshots.rs
+++ b/crates/tribal-worker/src/parsing/schema_dialect_snapshots.rs
@@ -109,6 +109,43 @@ fn test_anthropic_dialect_relation_snapshot() {
 }
 
 // ---------------------------------------------------------------------------
+// Ollama dialect snapshots
+// ---------------------------------------------------------------------------
+
+#[test]
+fn test_ollama_dialect_extraction_snapshot() {
+    let schema = apply_dialect(ProviderKind::Ollama, canonical_schema::<ExtractionOutput>());
+    assert_dialect_invariants(&schema, false);
+    assert_json_snapshot!(
+        &schema,
+        "src/parsing/snapshots/dialect/ollama/extraction_output.json"
+    );
+}
+
+#[test]
+fn test_ollama_dialect_triage_snapshot() {
+    let schema = apply_dialect(
+        ProviderKind::Ollama,
+        canonical_schema::<TriageClassification>(),
+    );
+    assert_dialect_invariants(&schema, false);
+    assert_json_snapshot!(
+        &schema,
+        "src/parsing/snapshots/dialect/ollama/triage_classification.json"
+    );
+}
+
+#[test]
+fn test_ollama_dialect_relation_snapshot() {
+    let schema = apply_dialect(ProviderKind::Ollama, canonical_schema::<RelationOutput>());
+    assert_dialect_invariants(&schema, false);
+    assert_json_snapshot!(
+        &schema,
+        "src/parsing/snapshots/dialect/ollama/relation_output.json"
+    );
+}
+
+// ---------------------------------------------------------------------------
 // Instance validation
 // ---------------------------------------------------------------------------
 
@@ -135,6 +172,27 @@ fn test_anthropic_triage_schema_validates_created_instance() {
     assert!(
         validator.is_valid(&created_triage_instance()),
         "the subset triage schema must accept a correct created instance"
+    );
+}
+
+#[test]
+fn test_ollama_extraction_schema_validates_a_candidate_instance() {
+    // The transformed schema must compile and accept a well-formed extraction
+    // output, the shape llama.cpp's grammar then constrains generation to.
+    let schema = apply_dialect(ProviderKind::Ollama, canonical_schema::<ExtractionOutput>());
+    let validator = Validator::new(&schema).expect("transformed schema compiles");
+    let instance = json!({
+        "candidates": [{
+            "content": "The rate limiter threshold was raised to 500 and never reverted.",
+            "kind": "fact",
+            "suggested_tags": ["api rate limiting"],
+            "suggested_references": [],
+        }],
+        "relation_hints": [],
+    });
+    assert!(
+        validator.is_valid(&instance),
+        "the grammar-subset extraction schema must accept a correct instance"
     );
 }
 

--- a/crates/tribal-worker/src/parsing/snapshots/dialect/ollama/extraction_output.json
+++ b/crates/tribal-worker/src/parsing/snapshots/dialect/ollama/extraction_output.json
@@ -1,0 +1,128 @@
+{
+  "additionalProperties": false,
+  "definitions": {
+    "Candidate": {
+      "additionalProperties": false,
+      "description": "A single self-contained knowledge item extracted from the input.",
+      "properties": {
+        "content": {
+          "description": "The captured tacit knowledge as one self-contained, atomic claim. Include the reasoning, constraints, or rejected alternatives when they are part of the knowledge being captured.",
+          "type": "string"
+        },
+        "kind": {
+          "$ref": "#/definitions/KnowledgeKind",
+          "description": "The kind of knowledge this item records."
+        },
+        "suggested_references": {
+          "description": "External anchors the item refers to, used to connect it to related knowledge even when wording differs.",
+          "items": {
+            "$ref": "#/definitions/SuggestedReference"
+          },
+          "type": "array"
+        },
+        "suggested_tags": {
+          "description": "Categorisation tags for the item.",
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        }
+      },
+      "required": [
+        "content",
+        "kind",
+        "suggested_tags"
+      ],
+      "type": "object"
+    },
+    "KnowledgeKind": {
+      "description": "The kind of knowledge captured.",
+      "enum": [
+        "fact",
+        "heuristic",
+        "procedure",
+        "decision_record"
+      ],
+      "type": "string"
+    },
+    "RelationHint": {
+      "additionalProperties": false,
+      "description": "A relation between two candidates in this batch, referenced by their array indices.",
+      "properties": {
+        "hint_type": {
+          "$ref": "#/definitions/RelationHintType",
+          "description": "The type of relation hinted at."
+        },
+        "source_index": {
+          "description": "Index of the source candidate in the batch.",
+          "type": "integer"
+        },
+        "target_index": {
+          "description": "Index of the target candidate in the batch.",
+          "type": "integer"
+        }
+      },
+      "required": [
+        "hint_type",
+        "source_index",
+        "target_index"
+      ],
+      "type": "object"
+    },
+    "RelationHintType": {
+      "description": "How two candidates relate within this batch. Currently `derived_from`: the source candidate was produced using the target candidate as input or premise.",
+      "enum": [
+        "derived_from"
+      ],
+      "type": "string"
+    },
+    "SuggestedReference": {
+      "additionalProperties": false,
+      "description": "An external anchor a candidate refers to (a URL, file path, code symbol, or concept) that can connect items even when their wording differs.",
+      "properties": {
+        "description": {
+          "description": "Optional human-readable context for the anchor.",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "reference_type": {
+          "description": "What kind of anchor this is. Use one of `file_path`, `url`, `symbol`, or `concept`.",
+          "type": "string"
+        },
+        "value": {
+          "description": "The anchor itself: the URL, path, symbol, or concept.",
+          "type": "string"
+        }
+      },
+      "required": [
+        "reference_type",
+        "value"
+      ],
+      "type": "object"
+    }
+  },
+  "description": "Extracted knowledge items and optional intra-batch relationship hints.",
+  "properties": {
+    "candidates": {
+      "description": "Knowledge items extracted from the input, each an atomic, self-contained claim. Empty when the input contains no extractable knowledge.",
+      "items": {
+        "$ref": "#/definitions/Candidate"
+      },
+      "type": "array"
+    },
+    "relation_hints": {
+      "description": "Derivation links between candidates in this batch. Empty unless one candidate is genuinely derived from another.",
+      "items": {
+        "$ref": "#/definitions/RelationHint"
+      },
+      "type": "array"
+    }
+  },
+  "required": [
+    "candidates"
+  ],
+  "title": "ExtractionOutput",
+  "type": "object"
+}

--- a/crates/tribal-worker/src/parsing/snapshots/dialect/ollama/relation_output.json
+++ b/crates/tribal-worker/src/parsing/snapshots/dialect/ollama/relation_output.json
@@ -1,0 +1,78 @@
+{
+  "additionalProperties": false,
+  "definitions": {
+    "IngestionRelationKind": {
+      "description": "How the source claim relates to the target claim.",
+      "enum": [
+        "supports",
+        "contradicts",
+        "derived_from"
+      ],
+      "type": "string"
+    },
+    "RelationEdge": {
+      "additionalProperties": false,
+      "description": "A directed relationship between two claims.",
+      "properties": {
+        "justification": {
+          "description": "Why this relationship holds, grounded in the content of both claims.",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "relation_type": {
+          "$ref": "#/definitions/IngestionRelationKind",
+          "description": "How the source relates to the target."
+        },
+        "source": {
+          "$ref": "#/definitions/RelationTarget",
+          "description": "The claim asserting the relationship."
+        },
+        "target": {
+          "$ref": "#/definitions/RelationTarget",
+          "description": "The claim the relationship is asserted about."
+        }
+      },
+      "required": [
+        "relation_type",
+        "source",
+        "target"
+      ],
+      "type": "object"
+    },
+    "RelationTarget": {
+      "additionalProperties": false,
+      "description": "A reference to a knowledge item by its context index.",
+      "properties": {
+        "context_index": {
+          "type": "integer"
+        },
+        "kind": {
+          "const": "context_index",
+          "type": "string"
+        }
+      },
+      "required": [
+        "context_index",
+        "kind"
+      ],
+      "type": "object"
+    }
+  },
+  "description": "The relationship edges to create. Empty when no genuine relationship holds between the claims.",
+  "properties": {
+    "relations": {
+      "description": "Directed edges, each connecting a source claim to a target claim. Only edges grounded in the content of both claims.",
+      "items": {
+        "$ref": "#/definitions/RelationEdge"
+      },
+      "type": "array"
+    }
+  },
+  "required": [
+    "relations"
+  ],
+  "title": "RelationOutput",
+  "type": "object"
+}

--- a/crates/tribal-worker/src/parsing/snapshots/dialect/ollama/triage_classification.json
+++ b/crates/tribal-worker/src/parsing/snapshots/dialect/ollama/triage_classification.json
@@ -1,0 +1,114 @@
+{
+  "additionalProperties": false,
+  "definitions": {
+    "RelationSuggestion": {
+      "description": "How the candidate relates to an existing similar item, assessed during triage independently of the novel-or-duplicate decision.",
+      "enum": [
+        "supports",
+        "contradicts",
+        "unrelated"
+      ],
+      "type": "string"
+    },
+    "SimilarItemClassification": {
+      "additionalProperties": false,
+      "description": "An independent assessment of one existing claim's relationship to the candidate.",
+      "properties": {
+        "item": {
+          "$ref": "#/definitions/TriageItemReference",
+          "description": "The existing claim being assessed, referenced by its context index."
+        },
+        "justification": {
+          "description": "Why this assessment was chosen, grounded in the content of both claims.",
+          "type": "string"
+        },
+        "suggested_relation": {
+          "$ref": "#/definitions/RelationSuggestion",
+          "description": "How the candidate relates to the existing claim."
+        }
+      },
+      "required": [
+        "item",
+        "justification",
+        "suggested_relation"
+      ],
+      "type": "object"
+    },
+    "TriageDecision": {
+      "anyOf": [
+        {
+          "additionalProperties": false,
+          "description": "The candidate records knowledge not already captured by an existing claim. Default to this when the candidate adds any new context, or when uncertain.",
+          "properties": {
+            "decision": {
+              "const": "created",
+              "type": "string"
+            }
+          },
+          "required": [
+            "decision"
+          ],
+          "type": "object"
+        },
+        {
+          "additionalProperties": false,
+          "description": "The candidate restates an existing claim, adding no meaningful new information. A candidate that contradicts an existing claim is never a duplicate.",
+          "properties": {
+            "decision": {
+              "const": "duplicate",
+              "type": "string"
+            },
+            "matched_item": {
+              "$ref": "#/definitions/TriageItemReference",
+              "description": "The existing claim this candidate duplicates, referenced by its context index."
+            }
+          },
+          "required": [
+            "decision",
+            "matched_item"
+          ],
+          "type": "object"
+        }
+      ],
+      "description": "Whether the candidate records new knowledge or duplicates an existing claim."
+    },
+    "TriageItemReference": {
+      "additionalProperties": false,
+      "description": "A reference to one of the provided similar items by its context index.",
+      "properties": {
+        "context_index": {
+          "type": "integer"
+        },
+        "kind": {
+          "const": "context_index",
+          "type": "string"
+        }
+      },
+      "required": [
+        "context_index",
+        "kind"
+      ],
+      "type": "object"
+    }
+  },
+  "description": "The triage classification for a single candidate. Contains the novel/duplicate decision and independent per-claim relationship assessments.",
+  "properties": {
+    "outcome": {
+      "$ref": "#/definitions/TriageDecision",
+      "description": "Whether the candidate is novel or duplicates an existing claim."
+    },
+    "similar_item_decisions": {
+      "description": "One assessment per provided similar claim, each made independently of the novel/duplicate outcome.",
+      "items": {
+        "$ref": "#/definitions/SimilarItemClassification"
+      },
+      "type": "array"
+    }
+  },
+  "required": [
+    "outcome",
+    "similar_item_decisions"
+  ],
+  "title": "TriageClassification",
+  "type": "object"
+}


### PR DESCRIPTION
## Summary

Every `tribal_ingest` against an **Ollama** inference model dead-letters at the extraction stage (and triage/relation) with `parse error during deserialising extraction output: expected value at line N`; `items_created` is always 0.

This is the **Ollama-grammar** manifestation of #195. It is a distinct failure mode from the deepseek/mimo path that issue primarily documents — see [Scope](#scope) below.

## Root cause

`apply_dialect` (`crates/tribal-inference/src/schema_dialect.rs`) rewrites the canonical `schemars` schema into each provider's accepted JSON-Schema subset. The `Ollama` arm was **identity** — Ollama received the raw draft-07 schema.

Ollama enforces structured output by compiling the schema to a grammar (llama.cpp's JSON-Schema-to-grammar), which cannot compile two forms `schemars` emits:

- a described `$ref` wrapped in a single-element `allOf` — `{"description": .., "allOf": [{"$ref": ..}]}`, and
- the `oneOf` encodings of Rust enums.

Given those, llama.cpp emits malformed JSON — e.g. `"kind": { },` (an empty object in place of the constrained field) — which fails to deserialise at a fixed position.

The OpenAI and Anthropic dialects already rewrite both forms away (`unwrap_described_refs`, `rewrite_enums`).

## Reproduction

Replaying the real extraction prompts against a local Ollama (`qwen3:30b-a3b-instruct-2507`):

| `format` sent | Output |
|---|---|
| omitted | valid JSON |
| Anthropic-dialect schema | **correct** structured output |
| canonical schema (`allOf`-wrapped `$ref` + `oneOf` enum) | `"kind": { },` → parse error |

## Fix

Route `ProviderKind::Ollama` through the same grammar subset as `ProviderKind::Anthropic` (`apply_grammar_subset`). Both backends enforce a caller schema by compiling it to a grammar (Anthropic server-side, Ollama via llama.cpp), so the subset and transform are shared.

## Tests

- `schema_dialect`: Ollama now matches the Anthropic transform; a regression test asserts the described-`$ref` and `oneOf` enum forms are rewritten away; idempotence.
- Updated the Ollama `format` wire test to assert the dialected schema is sent.
- Added Ollama dialect golden snapshots (extraction/triage/relation) + an instance-validation test that compiles the transformed extraction schema and accepts a correct instance.
- Full `tribal-inference` (278) and `tribal-worker --lib` (150) suites pass; clippy clean.

## End-to-end verification

Built this branch into an image and ran live ingests against a local Ollama (embeddinggemma + qwen3:30b-a3b-instruct-2507). Before: every job dead-lettered with the parse error. After: the full extraction → triage → relation pipeline completes (`outcome: success`, `tasks_failed: 0`), items are created, and relations (`supports`, `derived_from`) are laid down.

## Scope

This PR covers **only the Ollama-grammar path**. #195 also documents a second failure mode — deepseek / mimo via Anthropic-format APIs that **silently ignore** the schema, where the model free-forms from the prompt and fails on field-name mismatches and markdown code fences. Those deserialisation-boundary fixes (field aliases + fence stripping) are a separate workstream and are **not** addressed here, so this PR references but does not satisfy #195.

Refs #195
