### PR TITLE
[FIX] Tolerate Markdown code fences in stage response parsing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ## [Unreleased]
 
+### Fixed
+
+- Pipeline responses wrapped in a Markdown code fence now parse. The extraction, triage, and relation stages deserialise strictly first and retry once with the fence stripped only when that fails, so a provider that ignores the structured-output schema and fences its JSON no longer dead-letters, while a valid payload — including one whose strings contain backticks — is never altered. ([#195](https://github.com/tribal-memory/tribal/issues/195))
+
 ## [0.3.0] - 2026-06-01
 
 This release makes the embedding geometry configurable and adds zero-downtime reindexing of the embedding space. It is a breaking release: the initial database schema is revised for the embedding-profile model and the embedding configuration keys have moved, so there is no in-place upgrade from 0.2.x. Provision a fresh database and update the configuration (see Changed).

--- a/crates/tribal-worker/src/parsing.rs
+++ b/crates/tribal-worker/src/parsing.rs
@@ -1,5 +1,6 @@
 //! Response parsing for pipeline stages.
 
+mod deserialise;
 mod extraction;
 mod relation;
 mod triage;

--- a/crates/tribal-worker/src/parsing/deserialise.rs
+++ b/crates/tribal-worker/src/parsing/deserialise.rs
@@ -2,8 +2,8 @@
 //!
 //! A model that does not honour the structured-output schema may wrap its JSON
 //! in a Markdown code fence. [`tolerant`] parses strictly first and unwraps a
-//! fence only when that parse fails, so a payload that is already valid JSON —
-//! including one whose string values contain backticks — is never altered.
+//! fence only when that parse fails, so a payload that is already valid JSON,
+//! including one whose string values contain backticks, is never altered.
 
 use serde::de::DeserializeOwned;
 

--- a/crates/tribal-worker/src/parsing/deserialise.rs
+++ b/crates/tribal-worker/src/parsing/deserialise.rs
@@ -1,0 +1,109 @@
+//! Shared deserialisation helpers for stage responses.
+//!
+//! A model that does not honour the structured-output schema may wrap its JSON
+//! in a Markdown code fence. [`tolerant`] parses strictly first and unwraps a
+//! fence only when that parse fails, so a payload that is already valid JSON —
+//! including one whose string values contain backticks — is never altered.
+
+use serde::de::DeserializeOwned;
+
+/// Deserialises `text` as JSON, retrying once without a wrapping Markdown code
+/// fence if the first parse fails.
+///
+/// A valid payload deserialises on the first attempt and is returned untouched.
+/// Only on failure is a surrounding fence stripped and the parse retried; if the
+/// retry also fails, the original error is returned so diagnostics reflect the
+/// response as received.
+pub(crate) fn tolerant<T: DeserializeOwned>(text: &str) -> Result<T, serde_json::Error> {
+    match serde_json::from_str::<T>(text) {
+        Ok(value) => Ok(value),
+        Err(original) => match strip_code_fence(text) {
+            Some(unwrapped) => serde_json::from_str::<T>(&unwrapped).or(Err(original)),
+            None => Err(original),
+        },
+    }
+}
+
+/// Returns the contents of a Markdown code fence wrapping the whole of `text`,
+/// or `None` when `text` is not fence-wrapped.
+///
+/// Handles a triple-backtick fence with an optional info string (` ```json `,
+/// ` ``` `) and a single-backtick wrap; surrounding whitespace is ignored. A
+/// fence with no matching close is left intact.
+fn strip_code_fence(text: &str) -> Option<String> {
+    let trimmed = text.trim();
+    if let Some(rest) = trimmed.strip_prefix("```") {
+        let body = rest.strip_suffix("```")?;
+        // Drop the optional info string on the opening line.
+        let inner = body.split_once('\n').map_or(body, |(_info, after)| after);
+        return Some(inner.trim().to_owned());
+    }
+    let inner = trimmed.strip_prefix('`')?.strip_suffix('`')?;
+    Some(inner.trim().to_owned())
+}
+
+#[cfg(test)]
+mod tests {
+    use serde_json::{Value, json};
+
+    use super::*;
+
+    #[test]
+    fn test_parses_plain_json_unchanged() {
+        let value: Value = tolerant(r#"{"a": 1}"#).unwrap();
+        assert_eq!(value, json!({ "a": 1 }));
+    }
+
+    #[test]
+    fn test_parses_json_fenced_with_tag() {
+        let value: Value = tolerant("```json\n{\"a\": 1}\n```").unwrap();
+        assert_eq!(value, json!({ "a": 1 }));
+    }
+
+    #[test]
+    fn test_parses_json_fenced_without_tag() {
+        let value: Value = tolerant("```\n{\"a\": 1}\n```").unwrap();
+        assert_eq!(value, json!({ "a": 1 }));
+    }
+
+    #[test]
+    fn test_parses_single_backtick_wrap() {
+        let value: Value = tolerant("`{\"a\": 1}`").unwrap();
+        assert_eq!(value, json!({ "a": 1 }));
+    }
+
+    #[test]
+    fn test_parses_fence_with_surrounding_whitespace() {
+        let value: Value = tolerant("  ```json\n{\"a\": 1}\n```  \n").unwrap();
+        assert_eq!(value, json!({ "a": 1 }));
+    }
+
+    #[test]
+    fn test_preserves_backticks_inside_valid_payload() {
+        // A valid payload whose string value contains a code fence parses on the
+        // first attempt, so the fence stripper never runs and cannot corrupt it.
+        let source = r#"{"content": "```rust\nlet x = 1;\n```"}"#;
+        let value: Value = tolerant(source).unwrap();
+        assert_eq!(value["content"], json!("```rust\nlet x = 1;\n```"));
+    }
+
+    #[test]
+    fn test_returns_error_for_malformed_non_fenced_json() {
+        assert!(tolerant::<Value>(r#"{"a":"#).is_err());
+    }
+
+    #[test]
+    fn test_returns_error_when_fence_unwrap_is_still_invalid() {
+        assert!(tolerant::<Value>("```json\nnot json\n```").is_err());
+    }
+
+    #[test]
+    fn test_strip_leaves_non_fenced_text_untouched() {
+        assert_eq!(strip_code_fence(r#"{"a": 1}"#), None);
+    }
+
+    #[test]
+    fn test_strip_leaves_unterminated_fence_intact() {
+        assert_eq!(strip_code_fence("```json\n{\"a\": 1}"), None);
+    }
+}

--- a/crates/tribal-worker/src/parsing/extraction.rs
+++ b/crates/tribal-worker/src/parsing/extraction.rs
@@ -4,6 +4,7 @@ use serde::Deserialize;
 use tribal_domain::{Candidate, RelationHint};
 use tribal_inference::CompletionResponse;
 
+use super::deserialise;
 use crate::error::StageError;
 
 // ---------------------------------------------------------------------------
@@ -46,7 +47,7 @@ pub(crate) struct ExtractionOutput {
 pub(crate) fn parse_extraction_response(
     response: &CompletionResponse,
 ) -> Result<ExtractionOutput, StageError> {
-    serde_json::from_str::<ExtractionOutput>(&response.text).map_err(|e| StageError::Parse {
+    deserialise::tolerant::<ExtractionOutput>(&response.text).map_err(|e| StageError::Parse {
         context: format!("deserialising extraction output: {e}"),
         raw_response: Some(response.text.clone()),
     })

--- a/crates/tribal-worker/src/parsing/relation.rs
+++ b/crates/tribal-worker/src/parsing/relation.rs
@@ -6,6 +6,7 @@ use serde::Deserialize;
 use tribal_domain::RelationKind;
 use tribal_inference::CompletionResponse;
 
+use super::deserialise;
 use crate::error::StageError;
 
 // ---------------------------------------------------------------------------
@@ -139,7 +140,7 @@ pub(crate) fn parse_relation_response(
     response: &CompletionResponse,
 ) -> Result<RelationOutput, StageError> {
     let raw: RawRelationOutput =
-        serde_json::from_str(&response.text).map_err(|e| StageError::Parse {
+        deserialise::tolerant(&response.text).map_err(|e| StageError::Parse {
             context: format!("deserialising relation output: {e}"),
             raw_response: Some(response.text.clone()),
         })?;

--- a/crates/tribal-worker/src/parsing/triage.rs
+++ b/crates/tribal-worker/src/parsing/triage.rs
@@ -4,6 +4,7 @@ use serde::Deserialize;
 use tribal_domain::RelationSuggestion;
 use tribal_inference::CompletionResponse;
 
+use super::deserialise;
 use crate::error::StageError;
 
 // ---------------------------------------------------------------------------
@@ -157,7 +158,7 @@ pub(crate) struct SimilarItemClassification {
 pub(crate) fn parse_triage_response(
     response: &CompletionResponse,
 ) -> Result<TriageClassification, StageError> {
-    serde_json::from_str::<TriageClassification>(&response.text).map_err(|e| StageError::Parse {
+    deserialise::tolerant::<TriageClassification>(&response.text).map_err(|e| StageError::Parse {
         context: format!("deserialising triage classification: {e}"),
         raw_response: Some(response.text.clone()),
     })


### PR DESCRIPTION
## Summary

A provider that silently ignores the structured-output schema (e.g. deepseek, mimo via Anthropic-format endpoints — see #195) may wrap its JSON response in a Markdown code fence. `serde_json::from_str` then fails with `expected value at line 1 column 1` and the extraction/triage/relation job dead-letters.

## Design — safe by construction

A new shared helper, `parsing::deserialise::tolerant<T>`:

1. parses the response strictly (`serde_json::from_str`) **first**;
2. **only if that fails**, strips a wrapping fence and parses again;
3. if the retry also fails, returns the **original** error (diagnostics reflect the response as received).

The parse-first gate is what makes this safe: **any response that is already valid JSON exits at step 1 and never reaches the stripper.** So a payload whose string values legitimately contain backticks — e.g. a knowledge item *about* code fences — cannot be corrupted (covered by a test). A mis-strip can only turn a previously-failing parse into another failure, never break a passing one.

Because failure is free, the stripper handles the fence variants liberally: ` ```json `, ` ```JSON `, **no info string**, single-backtick wraps, and surrounding whitespace. An unterminated fence is left intact.

## Why in core, when field-name aliases were declined

Per the discussion on #195: serde aliases are open-ended, model-specific *guesses* at field names and don't belong in the agnostic core. Fence-stripping is different in kind — a single, bounded, universal transport artifact, applied only as a parse-failure fallback — and it delivers the *parsing guarantee* the issue's AC asks for, which a prompt instruction ("no fences") cannot promise. Models that ignore the schema's field names remain the user's responsibility, handled via configurable disk prompts.

## Tests

`parsing::deserialise` unit tests cover: plain JSON unchanged; fenced with/without info string; single-backtick wrap; surrounding whitespace; **backticks inside a valid payload preserved**; malformed non-fenced input errors; fenced-but-still-invalid returns an error; non-fenced and unterminated-fence inputs are left untouched. Full `tribal-worker` lib suite (156) passes; clippy clean.

## Scope

Covers the **code-fence** acceptance criterion of #195. Field-name aliases are intentionally **not** included (declined as model-specific accommodations). Independent of #196 (Ollama schema dialect) — disjoint files.

Refs #195
