### PR TITLE
[CHORE] Publish to the MCP Registry on release

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -25,9 +25,8 @@ ANTHROPIC_API_KEY=
 # pipeline on OpenAI instead, uncomment below and set OPENAI_API_KEY
 # above. Stages are independent (you can mix, e.g. Ollama embedding +
 # cloud inference); base_url must be set too, or requests route to the
-# local Ollama. Embedding is currently fixed at 768 dims, which
-# text-embedding-3-small fits (Tribal requests 768 via the dimensions
-# parameter).
+# local Ollama. The embedding dimension follows the model unless you set
+# TRIBAL_INIT__EMBEDDING__DIMENSIONS; text-embedding-3-small works as-is.
 #
 # TRIBAL_INIT__EMBEDDING__PROVIDER=openai
 # TRIBAL_INIT__EMBEDDING__MODEL=text-embedding-3-small

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -192,3 +192,47 @@ jobs:
       - name: Inspect image
         run: |
           docker buildx imagetools inspect "${IMAGE_NAME}:${VERSION}"
+
+  publish-mcp-registry:
+    name: Publish to the MCP Registry
+    needs: [validate-tag, merge]
+    if: startsWith(github.ref, 'refs/tags/')
+    runs-on: ubuntu-latest
+    # The registry is in preview; never let a registry hiccup or a CLI
+    # regression turn a successful build-and-push into a red tagged release.
+    continue-on-error: true
+    permissions:
+      contents: read
+      # OIDC lets mcp-publisher prove this repo owns the io.github.tribal-memory
+      # namespace; no stored secret is needed.
+      id-token: write
+    env:
+      VERSION: ${{ needs.validate-tag.outputs.version }}
+    steps:
+      - uses: actions/checkout@v6
+      # Stamp the release version into the metadata so the registry entry can
+      # never drift from the tag: server.version and the image tag in the OCI
+      # identifier both follow VERSION. An OCI package must not carry a package
+      # `version` field (the registry rejects it; the version lives in the
+      # identifier tag). The committed identifier tag is just a default; this
+      # overwrites it at publish time.
+      - name: Stamp the release version into server.json
+        run: |
+          jq --arg v "$VERSION" '
+            .version = $v
+            | .packages[0].identifier |= sub(":[^:]+$"; ":\($v)")
+          ' server.json > server.json.tmp && mv server.json.tmp server.json
+          echo "Publishing at $VERSION:"; jq -r '.version, .packages[0].identifier' server.json
+      - name: Install mcp-publisher
+        run: |
+          # Pinned, not `latest`: the CLI ships fast and a regression has broken
+          # valid publishes before. Bump deliberately.
+          curl -fsSL "https://github.com/modelcontextprotocol/registry/releases/download/v1.7.9/mcp-publisher_$(uname -s | tr '[:upper:]' '[:lower:]')_$(uname -m | sed 's/x86_64/amd64/;s/aarch64/arm64/').tar.gz" | tar xz mcp-publisher
+      - name: Validate server.json
+        run: ./mcp-publisher validate server.json
+      - name: Authenticate via GitHub OIDC
+        run: ./mcp-publisher login github-oidc
+      - name: Publish to the MCP Registry
+        # The registry pulls the public GHCR image to verify the ownership label,
+        # so the package must stay public.
+        run: ./mcp-publisher publish

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -226,11 +226,26 @@ jobs:
             | .packages[0].identifier |= sub(":[^:]+$"; ":\($v)")
           ' server.json > server.json.tmp && mv server.json.tmp server.json
           echo "Publishing at $VERSION:"; jq -r '.version, .packages[0].identifier' server.json
-      - name: Install mcp-publisher
+      - name: Install cosign
+        uses: sigstore/cosign-installer@v3
+      - name: Install mcp-publisher (Sigstore-verified)
+        env:
+          MCP_PUBLISHER_VERSION: v1.7.9
         run: |
-          # Pinned, not `latest`: the CLI ships fast and a regression has broken
-          # valid publishes before. Bump deliberately.
-          curl -fsSL "https://github.com/modelcontextprotocol/registry/releases/download/v1.7.9/mcp-publisher_$(uname -s | tr '[:upper:]' '[:lower:]')_$(uname -m | sed 's/x86_64/amd64/;s/aarch64/arm64/').tar.gz" | tar xz mcp-publisher
+          # Pinned version, verified against the release's Sigstore bundle:
+          # cosign confirms the binary's bytes and that the registry's release
+          # workflow signed it via GitHub OIDC, rather than trusting a bare TLS
+          # download. Bump the version deliberately.
+          asset="mcp-publisher_$(uname -s | tr '[:upper:]' '[:lower:]')_$(uname -m | sed 's/x86_64/amd64/;s/aarch64/arm64/').tar.gz"
+          base="https://github.com/modelcontextprotocol/registry/releases/download/${MCP_PUBLISHER_VERSION}"
+          curl -fsSL -O "${base}/${asset}"
+          curl -fsSL -O "${base}/${asset}.sigstore.json"
+          cosign verify-blob \
+            --bundle "${asset}.sigstore.json" \
+            --certificate-identity-regexp '^https://github\.com/modelcontextprotocol/registry/\.github/workflows/release\.yml@refs/tags/v.+$' \
+            --certificate-oidc-issuer 'https://token.actions.githubusercontent.com' \
+            "${asset}"
+          tar xzf "${asset}" mcp-publisher
       - name: Validate server.json
         run: ./mcp-publisher validate server.json
       - name: Authenticate via GitHub OIDC

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -199,7 +199,10 @@ jobs:
     if: startsWith(github.ref, 'refs/tags/')
     runs-on: ubuntu-latest
     # The registry is in preview; never let a registry hiccup or a CLI
-    # regression turn a successful build-and-push into a red tagged release.
+    # regression turn a successful build-and-push into a red tagged release. The
+    # "Report the registry outcome" step surfaces a failed publish as a run
+    # warning so it is not silent. Drop continue-on-error and that step once the
+    # registry leaves preview.
     continue-on-error: true
     permissions:
       contents: read
@@ -233,6 +236,16 @@ jobs:
       - name: Authenticate via GitHub OIDC
         run: ./mcp-publisher login github-oidc
       - name: Publish to the MCP Registry
+        id: publish
         # The registry pulls the public GHCR image to verify the ownership label,
         # so the package must stay public.
         run: ./mcp-publisher publish
+      - name: Report the registry outcome
+        if: always()
+        run: |
+          if [ "${{ steps.publish.outcome }}" = "success" ]; then
+            echo "MCP Registry: published ${VERSION}." >> "$GITHUB_STEP_SUMMARY"
+          else
+            echo "::warning title=MCP Registry publish failed::Image shipped for ${VERSION}; the registry entry was NOT updated. See this job's log."
+            echo "MCP Registry: publish did not succeed for ${VERSION}. The image is published; the registry entry was not updated." >> "$GITHUB_STEP_SUMMARY"
+          fi

--- a/Dockerfile
+++ b/Dockerfile
@@ -40,5 +40,9 @@ RUN apt-get update \
 COPY --from=builder /app/target/release/tribal /usr/local/bin/tribal
 COPY --chmod=0755 scripts/tribal-entrypoint /usr/local/bin/tribal-entrypoint
 USER tribal:tribal
+# MCP Registry ownership: this value must equal server.json's `name`, so the
+# registry can verify we own the published image (see server.json + the
+# publish-mcp-registry job in .github/workflows/docker.yml).
+LABEL io.modelcontextprotocol.server.name="io.github.tribal-memory/tribal"
 EXPOSE 8725
 ENTRYPOINT ["/usr/local/bin/tribal-entrypoint"]

--- a/crates/tribal-server/src/cli/command.rs
+++ b/crates/tribal-server/src/cli/command.rs
@@ -809,7 +809,8 @@ impl TokenRevokeAllArgs {
 #[derive(Debug, Subcommand)]
 pub enum ReindexCommand {
     /// Create a reindex run that migrates the corpus to a new embedding
-    /// identity. Use `--dry-run` to estimate cost without spending.
+    /// identity; a running server's worker drives it to completion. Use
+    /// `--dry-run` to estimate the work (item and tag counts) first.
     Run {
         /// Arguments for the reindex run.
         #[command(flatten)]
@@ -852,7 +853,7 @@ pub struct ReindexRunArgs {
     #[arg(long = "base-url", help_heading = "Reindex")]
     pub base_url: Option<String>,
 
-    /// Estimate the cost (item and tag counts) without creating a run.
+    /// Report how many items and tags would be re-embedded, without creating a run.
     #[arg(long, help_heading = "Reindex")]
     pub dry_run: bool,
 

--- a/server.json
+++ b/server.json
@@ -19,12 +19,22 @@
       },
       "runtimeHint": "docker",
       "runtimeArguments": [
-        { "type": "named", "name": "-p", "value": "8725:8725" }
+        { "type": "named", "name": "-p", "value": "127.0.0.1:8725:8725" }
       ],
       "environmentVariables": [
         {
           "name": "TRIBAL_DATABASE__URL",
-          "description": "Postgres (pgvector) connection string. Tribal is self-hosted; you provide the database (the docker-compose path bundles one).",
+          "description": "Postgres (pgvector) connection string. Tribal is self-hosted; you provide the database. The supported, complete deployment is docker-compose.yml.",
+          "isRequired": true
+        },
+        {
+          "name": "TRIBAL_PROJECT_REMOTE",
+          "description": "First-run only: the git remote that identifies the project bootstrapped on first start.",
+          "isRequired": true
+        },
+        {
+          "name": "TRIBAL_PROJECT_NAME",
+          "description": "First-run only: the name of the project bootstrapped on first start.",
           "isRequired": true
         },
         {

--- a/server.json
+++ b/server.json
@@ -1,0 +1,63 @@
+{
+  "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
+  "name": "io.github.tribal-memory/tribal",
+  "title": "Tribal",
+  "description": "Self-hosted semantic memory over MCP for an engineering team's tacit knowledge. Needs Postgres.",
+  "version": "0.3.0",
+  "repository": {
+    "url": "https://github.com/tribal-memory/tribal",
+    "source": "github"
+  },
+  "websiteUrl": "https://tribal.build",
+  "packages": [
+    {
+      "registryType": "oci",
+      "identifier": "ghcr.io/tribal-memory/tribal:0.3.0",
+      "transport": {
+        "type": "streamable-http",
+        "url": "http://127.0.0.1:8725/mcp"
+      },
+      "runtimeHint": "docker",
+      "runtimeArguments": [
+        { "type": "named", "name": "-p", "value": "8725:8725" }
+      ],
+      "environmentVariables": [
+        {
+          "name": "TRIBAL_DATABASE__URL",
+          "description": "Postgres (pgvector) connection string. Tribal is self-hosted; you provide the database (the docker-compose path bundles one).",
+          "isRequired": true
+        },
+        {
+          "name": "TRIBAL_SERVER__TRANSPORT",
+          "description": "Containerised transport: http or sse. The Docker image does not serve stdio; install the binary for stdio.",
+          "default": "http",
+          "isRequired": false
+        },
+        {
+          "name": "TRIBAL_SERVER__BIND_ADDRESS",
+          "description": "Address the server binds inside the container. Must be 0.0.0.0 (not the loopback default) for the published port to be reachable.",
+          "default": "0.0.0.0:8725",
+          "isRequired": false
+        },
+        {
+          "name": "TRIBAL_PUBLIC_MCP_URL",
+          "description": "The URL clients use to reach the server (for example http://127.0.0.1:8725/mcp). Needed for OAuth dynamic client registration once the server binds a routable interface.",
+          "default": "http://127.0.0.1:8725/mcp",
+          "isRequired": false
+        },
+        {
+          "name": "OPENAI_API_KEY",
+          "description": "Optional; only if an ingest or retrieval stage is configured to use OpenAI (defaults target a local Ollama).",
+          "isSecret": true,
+          "isRequired": false
+        },
+        {
+          "name": "ANTHROPIC_API_KEY",
+          "description": "Optional; only if a stage is configured to use Anthropic.",
+          "isSecret": true,
+          "isRequired": false
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
## What

Lists Tribal on the [MCP Registry](https://registry.modelcontextprotocol.io) and publishes a fresh entry automatically on each tagged release.

- `server.json` (repo root): the registry manifest for the OCI package `ghcr.io/tribal-memory/tribal`.
- `Dockerfile`: an `io.modelcontextprotocol.server.name` label so the registry can verify image ownership. Its value matches `server.json`'s `name` exactly.
- `.github/workflows/docker.yml`: a tag-gated `publish-mcp-registry` job that stamps the release version into `server.json`, validates it, authenticates via GitHub OIDC (no stored secret), and publishes, once the multi-arch image has been built and pushed.

A second commit corrects two stale wording artefacts left by the 0.3.0 work: the `.env.example` embedding-dimension note and the `tribal reindex` `--help` text.

## How it works on a release

On a `v*` tag: `validate-tag` then build then `merge` (pushes the labelled multi-arch `:VERSION` image) then `publish-mcp-registry` (stamp, validate, OIDC login, publish). The `io.github.tribal-memory/*` namespace is authorised from the `repository_owner` OIDC claim, so no manual registration is needed.

## Scope and decisions

- **Discovery entry, not auto-launch.** Tribal is a self-hosted, Postgres-backed server with a first-run project bootstrap (see `docker-compose.yml`), so it cannot be brought up from the manifest with a bare `docker run`. The entry is for discoverability and documents the real run requirements. `environmentVariables` mirrors the supported compose deployment, including `TRIBAL_SERVER__BIND_ADDRESS` (`0.0.0.0:8725`, required for the published port to be reachable rather than the loopback default) and `TRIBAL_PUBLIC_MCP_URL` (keeps OAuth dynamic client registration working once the server binds a routable interface).
- **No package `version` field.** An OCI package carries its version only in the identifier tag; the registry rejects a package-level `version` (the pinned schema still allows it, so this only surfaces server-side at publish). The stamp sets `.version` and the identifier tag.
- **`description`** fits the schema's 100-character limit.
- **`mcp-publisher` is pinned** to `v1.7.9` rather than `latest`, a pre-publish `validate` step catches manifest drift at release time, and the job is `continue-on-error` because the registry is in preview, so a registry hiccup never reds an otherwise-good release.

## First entry lands at the next release

The published 0.3.0 image was built before the ownership label existed, so it cannot be retro-validated, and the publish job is tag-gated. The inaugural registry entry therefore appears at the next tagged release; 0.3.0 is intentionally not backfilled. A late-failing publish job on a pre-label image would not be a workflow bug.

## Verification

`server.json` checked against the 2025-12-11 schema shape (description length, no package `version`, transport and environment shapes); the ownership chain (OIDC namespace, label-equals-name, public GHCR image, identifier-equals-image) verified against the registry's validator source; the version stamp confirmed to leave a clean identifier without re-introducing `version`; the workflow YAML parses.
