### PR TITLE
[FIX] Tolerate an empty cursor and drop structured content from error results

### DIFF
--- a/crates/tribal-mcp/src/error.rs
+++ b/crates/tribal-mcp/src/error.rs
@@ -67,15 +67,13 @@ pub trait IntoCallToolResult {
 
 impl IntoCallToolResult for McpToolError {
     fn into_call_tool_result(self) -> CallToolResult {
-        let structured = serde_json::json!({
-            "code": self.code,
-            "message": self.message,
-            "details": self.details,
-        });
-
-        let mut result = CallToolResult::error(vec![Content::text(&self.message)]);
-        result.structured_content = Some(structured);
-        result
+        // Error results carry the message in the text content and `is_error`
+        // only; they deliberately omit `structured_content`. A tool declares a
+        // success output schema, and a strict harness validates ANY returned
+        // structured content against it, so an error-shaped payload would fail
+        // that validation and mask the real message. MCP has no error output
+        // schema, so the text content is the portable channel.
+        CallToolResult::error(vec![Content::text(&self.message)])
     }
 }
 
@@ -143,11 +141,13 @@ mod tests {
         assert_eq!(result.is_error, Some(true));
         assert_eq!(result.content.len(), 1);
 
-        let structured = result
-            .structured_content
-            .expect("structured_content is present");
-        assert_eq!(structured["code"], "not_found");
-        assert_eq!(structured["message"], "No job found with ID job_abc");
+        // Error results must omit structured content: a strict harness validates
+        // any structured content against the tool's success output schema, so an
+        // error-shaped payload there would mask the real message.
+        assert!(
+            result.structured_content.is_none(),
+            "error results must not carry structured content"
+        );
     }
 
     #[test]

--- a/crates/tribal-mcp/src/error.rs
+++ b/crates/tribal-mcp/src/error.rs
@@ -58,9 +58,14 @@ pub trait IntoMcpError {
 // IntoCallToolResult
 // ---------------------------------------------------------------------------
 
-/// Converts a value into an rmcp `CallToolResult` following the structured
-/// content convention: every response includes both a `content` text block
-/// and a `structured_content` JSON value.
+/// Converts a value into an rmcp `CallToolResult`.
+///
+/// A success mapping includes a `content` text summary and a `structured_content`
+/// value conforming to the tool's output schema. An error mapping
+/// ([`McpToolError`]) carries the message in the `content` text block with
+/// `is_error` set and no `structured_content`, because a tool's output schema
+/// describes only the success shape and a strict harness validates any returned
+/// structured content against it.
 pub trait IntoCallToolResult {
     fn into_call_tool_result(self) -> CallToolResult;
 }
@@ -140,6 +145,13 @@ mod tests {
 
         assert_eq!(result.is_error, Some(true));
         assert_eq!(result.content.len(), 1);
+
+        // The message lives in the text content; it is the only client-visible
+        // error payload, so it must carry the error verbatim.
+        assert_eq!(
+            crate::test_utils::first_text_content(&result),
+            "No job found with ID job_abc"
+        );
 
         // Error results must omit structured content: a strict harness validates
         // any structured content against the tool's success output schema, so an

--- a/crates/tribal-mcp/src/handlers/discover.rs
+++ b/crates/tribal-mcp/src/handlers/discover.rs
@@ -324,9 +324,9 @@ impl TribalServerHandler {
 
 /// Normalises an incoming pagination cursor: a present-but-empty (or blank)
 /// cursor is treated as absent (first page) rather than handed to the strict
-/// 48-hex validator. Some harnesses auto-fill an optional `cursor` with `""`
-/// instead of omitting it; treating that as "no cursor" keeps the first-page
-/// path working while real tokens stay strictly validated.
+/// cursor validator (`decode_cursor`). Some harnesses auto-fill an optional
+/// `cursor` with `""` instead of omitting it; treating that as "no cursor"
+/// keeps the first-page path working while real tokens stay strictly validated.
 fn normalise_cursor(cursor: Option<String>) -> Option<String> {
     cursor.filter(|c| !c.trim().is_empty())
 }
@@ -595,13 +595,12 @@ mod tests {
     use super::*;
     use crate::{
         config::HandlerConfig,
-        test_utils::{TestHandler, first_text_content, test_repositories},
+        test_utils::{NO_STRUCTURED_CONTENT, TestHandler, first_text_content, test_repositories},
     };
 
     // -- Constants ---------------------------------------------------------
 
     const NO_PROTOCOL_ERROR: &str = "should not return a protocol error";
-    const NO_STRUCTURED_CONTENT: &str = "error results carry no structured content";
 
     // -- Helpers -----------------------------------------------------------
 
@@ -887,8 +886,9 @@ mod tests {
     #[test]
     fn test_normalise_cursor_treats_empty_or_blank_as_first_page() {
         // A harness that auto-fills the optional cursor with "" must not trip
-        // the strict 48-hex validator; empty or blank normalises to first page,
-        // while a real token is passed through untouched.
+        // the strict cursor validator (`decode_cursor`); empty or blank
+        // normalises to first page, while a real token is passed through
+        // untouched.
         assert_eq!(normalise_cursor(None), None);
         assert_eq!(normalise_cursor(Some(String::new())), None);
         assert_eq!(normalise_cursor(Some("   ".into())), None);
@@ -1207,6 +1207,69 @@ mod tests {
             "{NO_STRUCTURED_CONTENT}"
         );
         assert!(first_text_content(&result).contains("embedding generation failed"));
+    }
+
+    #[tokio::test]
+    async fn test_empty_cursor_reaches_search_as_first_page() {
+        // End-to-end wiring guard for `normalise_cursor`: a harness that
+        // auto-fills the optional cursor with "" must reach the search as a
+        // first-page request (`cursor.is_none()`), not as a raw "" that the
+        // strict validator would reject. The search mock only responds when the
+        // cursor arrives absent, so a regression would surface as a missing
+        // response rather than a silent pass.
+        let ctx = TestContext::new().await.expect("dedicated test database");
+        let pool = ctx.pool().clone();
+        let active = {
+            let mut seed = ctx.raw_connection().await.expect("seed connection");
+            ensure_genesis_profile(&mut seed, "model-a", 768).await
+        };
+
+        let mut repos = test_repositories();
+        repos.knowledge_item = Arc::new(
+            MockKnowledgeItemRepository::builder()
+                .when_semantic_search(|params| params.cursor.is_none())
+                .respond_with(a_search_response(vec![]), None)
+                .build(),
+        );
+
+        let handler = TestHandler::builder()
+            .pool(pool)
+            .repositories(repos)
+            .build();
+        handler
+            .state
+            .provider_registry
+            .register_building(
+                ProviderKey::new(
+                    ProviderKind::Ollama.to_string(),
+                    ProviderKind::DEFAULT_OLLAMA_BASE_URL,
+                    RequestClass::Embedding,
+                )
+                .expect("embedding provider key"),
+                &ProviderLimits {
+                    max_in_flight: 1,
+                    request_timeout: Duration::from_secs(5),
+                },
+            )
+            .expect("register the embedding endpoint");
+        handler
+            .state
+            .embedding_providers
+            .insert(active.id(), profile_provider("model-a", test_vector()));
+
+        // The search mock only responds when the cursor arrives absent, so a
+        // successful result is itself the proof that "" normalised to a
+        // first-page request before reaching the search.
+        let result = handler
+            .apply_discover(serde_json::json!({"query": "test", "cursor": ""}))
+            .await
+            .expect(NO_PROTOCOL_ERROR);
+
+        assert_ne!(result.is_error, Some(true));
+        assert!(
+            result.structured_content.is_some(),
+            "a successful discover result carries structured content"
+        );
     }
 
     // -- Service: overfetch behaviour ----------------------------------------

--- a/crates/tribal-mcp/src/handlers/discover.rs
+++ b/crates/tribal-mcp/src/handlers/discover.rs
@@ -270,7 +270,7 @@ impl TribalServerHandler {
             original_limit: limit,
             overfetch_limit: limit.saturating_mul(self.config.discovery.overfetch_multiplier),
             similarity_threshold: self.config.discovery.similarity_threshold,
-            cursor: request.cursor,
+            cursor: normalise_cursor(request.cursor),
         };
 
         let result = match execute_discover(
@@ -321,6 +321,15 @@ impl TribalServerHandler {
 // ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------
+
+/// Normalises an incoming pagination cursor: a present-but-empty (or blank)
+/// cursor is treated as absent (first page) rather than handed to the strict
+/// 48-hex validator. Some harnesses auto-fill an optional `cursor` with `""`
+/// instead of omitting it; treating that as "no cursor" keeps the first-page
+/// path working while real tokens stay strictly validated.
+fn normalise_cursor(cursor: Option<String>) -> Option<String> {
+    cursor.filter(|c| !c.trim().is_empty())
+}
 
 /// Resolved project scope for a discover query.
 enum ProjectScope {
@@ -586,13 +595,13 @@ mod tests {
     use super::*;
     use crate::{
         config::HandlerConfig,
-        test_utils::{TestHandler, test_repositories},
+        test_utils::{TestHandler, first_text_content, test_repositories},
     };
 
     // -- Constants ---------------------------------------------------------
 
-    const STRUCTURED_CONTENT: &str = "structured_content must be present";
     const NO_PROTOCOL_ERROR: &str = "should not return a protocol error";
+    const NO_STRUCTURED_CONTENT: &str = "error results carry no structured content";
 
     // -- Helpers -----------------------------------------------------------
 
@@ -875,6 +884,20 @@ mod tests {
         assert!(result.is_ok());
     }
 
+    #[test]
+    fn test_normalise_cursor_treats_empty_or_blank_as_first_page() {
+        // A harness that auto-fills the optional cursor with "" must not trip
+        // the strict 48-hex validator; empty or blank normalises to first page,
+        // while a real token is passed through untouched.
+        assert_eq!(normalise_cursor(None), None);
+        assert_eq!(normalise_cursor(Some(String::new())), None);
+        assert_eq!(normalise_cursor(Some("   ".into())), None);
+        assert_eq!(
+            normalise_cursor(Some("realtoken".into())).as_deref(),
+            Some("realtoken"),
+        );
+    }
+
     #[tokio::test]
     async fn test_filters_passed_to_search_params() {
         let from = Utc::now();
@@ -1070,8 +1093,11 @@ mod tests {
             .expect(NO_PROTOCOL_ERROR);
 
         assert_eq!(result.is_error, Some(true));
-        let structured = result.structured_content.expect(STRUCTURED_CONTENT);
-        assert_eq!(structured["code"], "invalid_argument");
+        assert!(
+            result.structured_content.is_none(),
+            "{NO_STRUCTURED_CONTENT}"
+        );
+        assert!(first_text_content(&result).contains("limit must be between"));
     }
 
     #[tokio::test]
@@ -1085,8 +1111,11 @@ mod tests {
             .expect(NO_PROTOCOL_ERROR);
 
         assert_eq!(result.is_error, Some(true));
-        let structured = result.structured_content.expect(STRUCTURED_CONTENT);
-        assert_eq!(structured["code"], "invalid_argument");
+        assert!(
+            result.structured_content.is_none(),
+            "{NO_STRUCTURED_CONTENT}"
+        );
+        assert!(first_text_content(&result).contains("limit must be between"));
     }
 
     #[tokio::test]
@@ -1100,8 +1129,11 @@ mod tests {
             .expect("should return Ok with error result, not Err");
 
         assert_eq!(result.is_error, Some(true));
-        let structured = result.structured_content.expect(STRUCTURED_CONTENT);
-        assert_eq!(structured["code"], "invalid_argument");
+        assert!(
+            result.structured_content.is_none(),
+            "{NO_STRUCTURED_CONTENT}"
+        );
+        assert!(first_text_content(&result).contains("expected prefix"));
     }
 
     #[tokio::test]
@@ -1170,8 +1202,11 @@ mod tests {
             .expect(NO_PROTOCOL_ERROR);
 
         assert_eq!(result.is_error, Some(true));
-        let structured = result.structured_content.expect(STRUCTURED_CONTENT);
-        assert_eq!(structured["code"], "internal");
+        assert!(
+            result.structured_content.is_none(),
+            "{NO_STRUCTURED_CONTENT}"
+        );
+        assert!(first_text_content(&result).contains("embedding generation failed"));
     }
 
     // -- Service: overfetch behaviour ----------------------------------------

--- a/crates/tribal-mcp/src/handlers/explore.rs
+++ b/crates/tribal-mcp/src/handlers/explore.rs
@@ -474,14 +474,13 @@ mod tests {
     use super::*;
     use crate::{
         config::HandlerConfig,
-        test_utils::{TestHandler, first_text_content, test_repositories},
+        test_utils::{NO_STRUCTURED_CONTENT, TestHandler, first_text_content, test_repositories},
     };
 
     // -- Constants ---------------------------------------------------------
 
     const STRUCTURED_CONTENT: &str = "structured_content must be present";
     const NO_PROTOCOL_ERROR: &str = "should not return a protocol error";
-    const NO_STRUCTURED_CONTENT: &str = "error results carry no structured content";
 
     // -- Helpers -----------------------------------------------------------
 

--- a/crates/tribal-mcp/src/handlers/explore.rs
+++ b/crates/tribal-mcp/src/handlers/explore.rs
@@ -474,13 +474,14 @@ mod tests {
     use super::*;
     use crate::{
         config::HandlerConfig,
-        test_utils::{TestHandler, test_repositories},
+        test_utils::{TestHandler, first_text_content, test_repositories},
     };
 
     // -- Constants ---------------------------------------------------------
 
     const STRUCTURED_CONTENT: &str = "structured_content must be present";
     const NO_PROTOCOL_ERROR: &str = "should not return a protocol error";
+    const NO_STRUCTURED_CONTENT: &str = "error results carry no structured content";
 
     // -- Helpers -----------------------------------------------------------
 
@@ -1264,8 +1265,11 @@ mod tests {
             .expect(NO_PROTOCOL_ERROR);
 
         assert_eq!(result.is_error, Some(true));
-        let structured = result.structured_content.expect(STRUCTURED_CONTENT);
-        assert_eq!(structured["code"], "invalid_argument");
+        assert!(
+            result.structured_content.is_none(),
+            "{NO_STRUCTURED_CONTENT}"
+        );
+        assert!(first_text_content(&result).contains("expected prefix"));
     }
 
     #[tokio::test]
@@ -1279,8 +1283,11 @@ mod tests {
             .expect(NO_PROTOCOL_ERROR);
 
         assert_eq!(result.is_error, Some(true));
-        let structured = result.structured_content.expect(STRUCTURED_CONTENT);
-        assert_eq!(structured["code"], "invalid_argument");
+        assert!(
+            result.structured_content.is_none(),
+            "{NO_STRUCTURED_CONTENT}"
+        );
+        assert!(first_text_content(&result).contains("invalid direction 'sideways'"));
     }
 
     #[tokio::test]
@@ -1294,8 +1301,11 @@ mod tests {
             .expect(NO_PROTOCOL_ERROR);
 
         assert_eq!(result.is_error, Some(true));
-        let structured = result.structured_content.expect(STRUCTURED_CONTENT);
-        assert_eq!(structured["code"], "invalid_argument");
+        assert!(
+            result.structured_content.is_none(),
+            "{NO_STRUCTURED_CONTENT}"
+        );
+        assert!(first_text_content(&result).contains("invalid relation type 'causes'"));
     }
 
     #[tokio::test]
@@ -1309,8 +1319,11 @@ mod tests {
             .expect(NO_PROTOCOL_ERROR);
 
         assert_eq!(result.is_error, Some(true));
-        let structured = result.structured_content.expect(STRUCTURED_CONTENT);
-        assert_eq!(structured["code"], "invalid_argument");
+        assert!(
+            result.structured_content.is_none(),
+            "{NO_STRUCTURED_CONTENT}"
+        );
+        assert!(first_text_content(&result).contains("depth must be between"));
     }
 
     #[tokio::test]
@@ -1325,8 +1338,11 @@ mod tests {
             .expect(NO_PROTOCOL_ERROR);
 
         assert_eq!(result.is_error, Some(true));
-        let structured = result.structured_content.expect(STRUCTURED_CONTENT);
-        assert_eq!(structured["code"], "invalid_argument");
+        assert!(
+            result.structured_content.is_none(),
+            "{NO_STRUCTURED_CONTENT}"
+        );
+        assert!(first_text_content(&result).contains("depth must be between"));
     }
 
     #[tokio::test]
@@ -1340,8 +1356,11 @@ mod tests {
             .expect(NO_PROTOCOL_ERROR);
 
         assert_eq!(result.is_error, Some(true));
-        let structured = result.structured_content.expect(STRUCTURED_CONTENT);
-        assert_eq!(structured["code"], "invalid_argument");
+        assert!(
+            result.structured_content.is_none(),
+            "{NO_STRUCTURED_CONTENT}"
+        );
+        assert!(first_text_content(&result).contains("limit must be between"));
     }
 
     #[tokio::test]
@@ -1356,8 +1375,11 @@ mod tests {
             .expect(NO_PROTOCOL_ERROR);
 
         assert_eq!(result.is_error, Some(true));
-        let structured = result.structured_content.expect(STRUCTURED_CONTENT);
-        assert_eq!(structured["code"], "invalid_argument");
+        assert!(
+            result.structured_content.is_none(),
+            "{NO_STRUCTURED_CONTENT}"
+        );
+        assert!(first_text_content(&result).contains("limit must be between"));
     }
 
     #[tokio::test]
@@ -1541,8 +1563,11 @@ mod tests {
             .expect(NO_PROTOCOL_ERROR);
 
         assert_eq!(result.is_error, Some(true));
-        let structured = result.structured_content.expect(STRUCTURED_CONTENT);
-        assert_eq!(structured["code"], "invalid_argument");
+        assert!(
+            result.structured_content.is_none(),
+            "{NO_STRUCTURED_CONTENT}"
+        );
+        assert!(first_text_content(&result).contains(tribal_telemetry::INVALID_SESSION_TRACE_ID));
     }
 
     #[tokio::test]
@@ -1559,7 +1584,10 @@ mod tests {
             .expect(NO_PROTOCOL_ERROR);
 
         assert_eq!(result.is_error, Some(true));
-        let structured = result.structured_content.expect(STRUCTURED_CONTENT);
-        assert_eq!(structured["code"], "invalid_argument");
+        assert!(
+            result.structured_content.is_none(),
+            "{NO_STRUCTURED_CONTENT}"
+        );
+        assert!(first_text_content(&result).contains(tribal_telemetry::INVALID_SESSION_TRACE_ID));
     }
 }

--- a/crates/tribal-mcp/src/handlers/feedback.rs
+++ b/crates/tribal-mcp/src/handlers/feedback.rs
@@ -346,14 +346,14 @@ mod tests {
 
     use super::*;
     use crate::test_utils::{
-        TestHandler, configure_fingerprint_mocks, test_active_prompt_versions,
+        TestHandler, configure_fingerprint_mocks, first_text_content, test_active_prompt_versions,
         test_provider_identities, test_repositories,
     };
 
     // -- Constants ---------------------------------------------------------
 
-    const STRUCTURED_CONTENT: &str = "structured_content must be present";
     const NO_PROTOCOL_ERROR: &str = "should not return a protocol error";
+    const NO_STRUCTURED_CONTENT: &str = "error results carry no structured content";
 
     // -- Helpers -----------------------------------------------------------
 
@@ -428,8 +428,11 @@ mod tests {
             .expect(NO_PROTOCOL_ERROR);
 
         assert_eq!(result.is_error, Some(true));
-        let structured = result.structured_content.expect(STRUCTURED_CONTENT);
-        assert_eq!(structured["code"], "invalid_argument");
+        assert!(
+            result.structured_content.is_none(),
+            "{NO_STRUCTURED_CONTENT}"
+        );
+        assert!(first_text_content(&result).contains(tribal_telemetry::INVALID_TRACE_ID));
     }
 
     /// Verifies that an uppercase `trace_id` is normalised to lowercase
@@ -577,8 +580,11 @@ mod tests {
             .expect(NO_PROTOCOL_ERROR);
 
         assert_eq!(result.is_error, Some(true));
-        let structured = result.structured_content.expect(STRUCTURED_CONTENT);
-        assert_eq!(structured["code"], "invalid_argument");
+        assert!(
+            result.structured_content.is_none(),
+            "{NO_STRUCTURED_CONTENT}"
+        );
+        assert!(first_text_content(&result).contains(tribal_telemetry::INVALID_TRACE_ID));
     }
 
     #[tokio::test]
@@ -600,8 +606,11 @@ mod tests {
             .expect(NO_PROTOCOL_ERROR);
 
         assert_eq!(result.is_error, Some(true));
-        let structured = result.structured_content.expect(STRUCTURED_CONTENT);
-        assert_eq!(structured["code"], "invalid_argument");
+        assert!(
+            result.structured_content.is_none(),
+            "{NO_STRUCTURED_CONTENT}"
+        );
+        assert!(first_text_content(&result).contains(EMPTY_QUERY_TEXT));
     }
 
     #[tokio::test]
@@ -622,8 +631,11 @@ mod tests {
             .expect(NO_PROTOCOL_ERROR);
 
         assert_eq!(result.is_error, Some(true));
-        let structured = result.structured_content.expect(STRUCTURED_CONTENT);
-        assert_eq!(structured["code"], "invalid_argument");
+        assert!(
+            result.structured_content.is_none(),
+            "{NO_STRUCTURED_CONTENT}"
+        );
+        assert!(first_text_content(&result).contains(EMPTY_RETURNED_ITEMS));
     }
 
     #[tokio::test]
@@ -645,8 +657,11 @@ mod tests {
             .expect(NO_PROTOCOL_ERROR);
 
         assert_eq!(result.is_error, Some(true));
-        let structured = result.structured_content.expect(STRUCTURED_CONTENT);
-        assert_eq!(structured["code"], "invalid_argument");
+        assert!(
+            result.structured_content.is_none(),
+            "{NO_STRUCTURED_CONTENT}"
+        );
+        assert!(first_text_content(&result).contains("expected prefix"));
     }
 
     #[tokio::test]
@@ -670,8 +685,11 @@ mod tests {
             .expect(NO_PROTOCOL_ERROR);
 
         assert_eq!(result.is_error, Some(true));
-        let structured = result.structured_content.expect(STRUCTURED_CONTENT);
-        assert_eq!(structured["code"], "invalid_argument");
+        assert!(
+            result.structured_content.is_none(),
+            "{NO_STRUCTURED_CONTENT}"
+        );
+        assert!(first_text_content(&result).contains("expected prefix"));
     }
 
     #[tokio::test]
@@ -693,8 +711,11 @@ mod tests {
             .expect(NO_PROTOCOL_ERROR);
 
         assert_eq!(result.is_error, Some(true));
-        let structured = result.structured_content.expect(STRUCTURED_CONTENT);
-        assert_eq!(structured["code"], "invalid_argument");
+        assert!(
+            result.structured_content.is_none(),
+            "{NO_STRUCTURED_CONTENT}"
+        );
+        assert!(first_text_content(&result).contains(INVALID_RATING));
     }
 
     #[tokio::test]
@@ -717,14 +738,17 @@ mod tests {
             .expect(NO_PROTOCOL_ERROR);
 
         assert_eq!(result.is_error, Some(true));
-        let structured = result.structured_content.expect(STRUCTURED_CONTENT);
-        assert_eq!(structured["code"], "invalid_argument");
+        assert!(
+            result.structured_content.is_none(),
+            "{NO_STRUCTURED_CONTENT}"
+        );
+        assert!(first_text_content(&result).contains("expected prefix"));
     }
 
     /// `lazy_pool` cannot open connections, so the call fails at the
-    /// pool acquisition phase. We assert `is_error` to confirm validation
-    /// passed and the error originates from the pool, not from input
-    /// validation.
+    /// transaction-begin phase. We assert the error message is a downstream
+    /// pool/connection failure rather than any input-validation message, which
+    /// confirms validation passed and the error originates from the pool.
     #[tokio::test]
     async fn test_apply_feedback_lazy_pool_fails_after_validation() {
         let handler = TestHandler::builder().build();
@@ -744,11 +768,22 @@ mod tests {
             .expect(NO_PROTOCOL_ERROR);
 
         assert_eq!(result.is_error, Some(true));
-        let structured = result.structured_content.expect(STRUCTURED_CONTENT);
-        assert_ne!(
-            structured["code"], "invalid_argument",
-            "error should originate from pool, not input validation",
+        assert!(
+            result.structured_content.is_none(),
+            "{NO_STRUCTURED_CONTENT}"
         );
+
+        let message = first_text_content(&result);
+        // The error must come from the pool layer, not input validation: the
+        // transaction-begin failure surfaces as either a pool-exhaustion or a
+        // query-failed message, never one of the validation messages.
+        assert!(
+            message.contains("pool") || message.contains("query failed"),
+            "error should originate from the pool, not input validation: {message}",
+        );
+        assert!(!message.contains(EMPTY_QUERY_TEXT));
+        assert!(!message.contains(EMPTY_RETURNED_ITEMS));
+        assert!(!message.contains(INVALID_RATING));
     }
 
     #[tokio::test]

--- a/crates/tribal-mcp/src/handlers/feedback.rs
+++ b/crates/tribal-mcp/src/handlers/feedback.rs
@@ -346,14 +346,13 @@ mod tests {
 
     use super::*;
     use crate::test_utils::{
-        TestHandler, configure_fingerprint_mocks, first_text_content, test_active_prompt_versions,
-        test_provider_identities, test_repositories,
+        NO_STRUCTURED_CONTENT, TestHandler, configure_fingerprint_mocks, first_text_content,
+        test_active_prompt_versions, test_provider_identities, test_repositories,
     };
 
     // -- Constants ---------------------------------------------------------
 
     const NO_PROTOCOL_ERROR: &str = "should not return a protocol error";
-    const NO_STRUCTURED_CONTENT: &str = "error results carry no structured content";
 
     // -- Helpers -----------------------------------------------------------
 

--- a/crates/tribal-mcp/src/handlers/get_item.rs
+++ b/crates/tribal-mcp/src/handlers/get_item.rs
@@ -353,12 +353,13 @@ mod tests {
     };
 
     use super::*;
-    use crate::test_utils::{TestHandler, test_repositories};
+    use crate::test_utils::{TestHandler, first_text_content, test_repositories};
 
     // -- Constants ---------------------------------------------------------
 
     const STRUCTURED_CONTENT: &str = "structured_content must be present";
     const NO_PROTOCOL_ERROR: &str = "should not return a protocol error";
+    const NO_STRUCTURED_CONTENT: &str = "error results carry no structured content";
 
     // -- Helpers -----------------------------------------------------------
 
@@ -720,14 +721,11 @@ mod tests {
             .expect(NO_PROTOCOL_ERROR);
 
         assert_eq!(result.is_error, Some(true));
-        let structured = result.structured_content.expect(STRUCTURED_CONTENT);
-        assert_eq!(structured["code"], "invalid_argument");
         assert!(
-            structured["message"]
-                .as_str()
-                .unwrap()
-                .contains("at least 1")
+            result.structured_content.is_none(),
+            "{NO_STRUCTURED_CONTENT}"
         );
+        assert!(first_text_content(&result).contains("at least 1"));
     }
 
     #[tokio::test]
@@ -744,14 +742,11 @@ mod tests {
             .expect(NO_PROTOCOL_ERROR);
 
         assert_eq!(result.is_error, Some(true));
-        let structured = result.structured_content.expect(STRUCTURED_CONTENT);
-        assert_eq!(structured["code"], "invalid_argument");
         assert!(
-            structured["message"]
-                .as_str()
-                .unwrap()
-                .contains("at most 20")
+            result.structured_content.is_none(),
+            "{NO_STRUCTURED_CONTENT}"
         );
+        assert!(first_text_content(&result).contains("at most 20"));
     }
 
     #[tokio::test]
@@ -765,8 +760,11 @@ mod tests {
             .expect(NO_PROTOCOL_ERROR);
 
         assert_eq!(result.is_error, Some(true));
-        let structured = result.structured_content.expect(STRUCTURED_CONTENT);
-        assert_eq!(structured["code"], "invalid_argument");
+        assert!(
+            result.structured_content.is_none(),
+            "{NO_STRUCTURED_CONTENT}"
+        );
+        assert!(first_text_content(&result).contains("expected prefix"));
     }
 
     #[tokio::test]

--- a/crates/tribal-mcp/src/handlers/get_item.rs
+++ b/crates/tribal-mcp/src/handlers/get_item.rs
@@ -353,13 +353,14 @@ mod tests {
     };
 
     use super::*;
-    use crate::test_utils::{TestHandler, first_text_content, test_repositories};
+    use crate::test_utils::{
+        NO_STRUCTURED_CONTENT, TestHandler, first_text_content, test_repositories,
+    };
 
     // -- Constants ---------------------------------------------------------
 
     const STRUCTURED_CONTENT: &str = "structured_content must be present";
     const NO_PROTOCOL_ERROR: &str = "should not return a protocol error";
-    const NO_STRUCTURED_CONTENT: &str = "error results carry no structured content";
 
     // -- Helpers -----------------------------------------------------------
 
@@ -746,7 +747,7 @@ mod tests {
             result.structured_content.is_none(),
             "{NO_STRUCTURED_CONTENT}"
         );
-        assert!(first_text_content(&result).contains("at most 20"));
+        assert!(first_text_content(&result).contains(&format!("at most {MAX_ITEM_IDS}")));
     }
 
     #[tokio::test]

--- a/crates/tribal-mcp/src/handlers/ingest.rs
+++ b/crates/tribal-mcp/src/handlers/ingest.rs
@@ -316,14 +316,14 @@ mod tests {
 
     use super::*;
     use crate::test_utils::{
-        TestHandler, configure_fingerprint_mocks, session_with_project,
+        TestHandler, configure_fingerprint_mocks, first_text_content, session_with_project,
         test_active_prompt_versions, test_provider_identities, test_repositories,
     };
 
     // -- Constants ---------------------------------------------------------
 
-    const STRUCTURED_CONTENT: &str = "structured_content must be present";
     const NO_PROTOCOL_ERROR: &str = "should not return a protocol error";
+    const NO_STRUCTURED_CONTENT: &str = "error results carry no structured content";
 
     // -- Helpers -----------------------------------------------------------
 
@@ -376,8 +376,11 @@ mod tests {
             .expect(NO_PROTOCOL_ERROR);
 
         assert_eq!(result.is_error, Some(true));
-        let structured = result.structured_content.expect(STRUCTURED_CONTENT);
-        assert_eq!(structured["code"], "failed_precondition");
+        assert!(
+            result.structured_content.is_none(),
+            "{NO_STRUCTURED_CONTENT}"
+        );
+        assert!(first_text_content(&result).contains(NO_PROJECT));
     }
 
     #[tokio::test]
@@ -394,15 +397,19 @@ mod tests {
             .expect(NO_PROTOCOL_ERROR);
 
         assert_eq!(result.is_error, Some(true));
-        let structured = result.structured_content.expect(STRUCTURED_CONTENT);
-        assert_eq!(structured["code"], "invalid_argument");
+        assert!(
+            result.structured_content.is_none(),
+            "{NO_STRUCTURED_CONTENT}"
+        );
+        assert!(first_text_content(&result).contains("expected prefix"));
     }
 
     /// With a session project set and no `project_id` in the request, the
     /// handler should resolve the session project and continue past the
     /// precondition check. `lazy_pool` cannot open connections, so the
-    /// call fails at the pool phase — we assert the error is NOT
-    /// `failed_precondition` to confirm project resolution succeeded.
+    /// call fails at the pool phase — we assert the error message is NOT the
+    /// missing-project precondition message to confirm project resolution
+    /// succeeded and the failure originates downstream at the pool.
     #[tokio::test]
     async fn test_apply_ingest_uses_session_project_when_request_omits_it() {
         let handler = TestHandler::builder()
@@ -418,10 +425,20 @@ mod tests {
             .expect(NO_PROTOCOL_ERROR);
 
         assert_eq!(result.is_error, Some(true));
-        let structured = result.structured_content.expect(STRUCTURED_CONTENT);
-        assert_ne!(
-            structured["code"], "failed_precondition",
-            "session project should be used when request omits project_id",
+        assert!(
+            result.structured_content.is_none(),
+            "{NO_STRUCTURED_CONTENT}"
+        );
+
+        let message = first_text_content(&result);
+        assert!(
+            !message.contains(NO_PROJECT),
+            "session project should be used when request omits project_id: {message}",
+        );
+        // The failure must come from the pool layer downstream of resolution.
+        assert!(
+            message.contains("pool") || message.contains("query failed"),
+            "error should originate from the pool, not the precondition check: {message}",
         );
     }
 

--- a/crates/tribal-mcp/src/handlers/ingest.rs
+++ b/crates/tribal-mcp/src/handlers/ingest.rs
@@ -316,14 +316,14 @@ mod tests {
 
     use super::*;
     use crate::test_utils::{
-        TestHandler, configure_fingerprint_mocks, first_text_content, session_with_project,
-        test_active_prompt_versions, test_provider_identities, test_repositories,
+        NO_STRUCTURED_CONTENT, TestHandler, configure_fingerprint_mocks, first_text_content,
+        session_with_project, test_active_prompt_versions, test_provider_identities,
+        test_repositories,
     };
 
     // -- Constants ---------------------------------------------------------
 
     const NO_PROTOCOL_ERROR: &str = "should not return a protocol error";
-    const NO_STRUCTURED_CONTENT: &str = "error results carry no structured content";
 
     // -- Helpers -----------------------------------------------------------
 

--- a/crates/tribal-mcp/src/handlers/job_status.rs
+++ b/crates/tribal-mcp/src/handlers/job_status.rs
@@ -349,14 +349,13 @@ mod tests {
     use super::*;
     use crate::{
         polling::{ImmediatePollScheduler, YieldingPollScheduler},
-        test_utils::{TestHandler, first_text_content, test_repositories},
+        test_utils::{NO_STRUCTURED_CONTENT, TestHandler, first_text_content, test_repositories},
     };
 
     // -- Constants ---------------------------------------------------------
 
     const STRUCTURED_CONTENT: &str = "structured_content must be present";
     const NO_PROTOCOL_ERROR: &str = "should not return a protocol error";
-    const NO_STRUCTURED_CONTENT: &str = "error results carry no structured content";
 
     // -- Helpers -----------------------------------------------------------
 

--- a/crates/tribal-mcp/src/handlers/job_status.rs
+++ b/crates/tribal-mcp/src/handlers/job_status.rs
@@ -349,15 +349,31 @@ mod tests {
     use super::*;
     use crate::{
         polling::{ImmediatePollScheduler, YieldingPollScheduler},
-        test_utils::{TestHandler, test_repositories},
+        test_utils::{TestHandler, first_text_content, test_repositories},
     };
 
     // -- Constants ---------------------------------------------------------
 
     const STRUCTURED_CONTENT: &str = "structured_content must be present";
     const NO_PROTOCOL_ERROR: &str = "should not return a protocol error";
+    const NO_STRUCTURED_CONTENT: &str = "error results carry no structured content";
 
     // -- Helpers -----------------------------------------------------------
+
+    /// Asserts that a `wait_seconds` value was accepted: the error result must
+    /// come from the downstream pool layer (`lazy_pool` cannot connect), not
+    /// from the `wait_seconds` validation check.
+    fn assert_accepted_wait_seconds(result: &CallToolResult, message: &str) {
+        let text = first_text_content(result);
+        assert!(
+            !text.contains("wait_seconds must be between"),
+            "{message}: {text}",
+        );
+        assert!(
+            text.contains("pool") || text.contains("query failed"),
+            "error should originate from the pool, not wait_seconds validation: {text}",
+        );
+    }
 
     async fn call_execute(
         repos: &ConnectionRepositories,
@@ -420,8 +436,11 @@ mod tests {
             .expect(NO_PROTOCOL_ERROR);
 
         assert_eq!(result.is_error, Some(true));
-        let structured = result.structured_content.expect(STRUCTURED_CONTENT);
-        assert_eq!(structured["code"], "invalid_argument");
+        assert!(
+            result.structured_content.is_none(),
+            "{NO_STRUCTURED_CONTENT}"
+        );
+        assert!(first_text_content(&result).contains("expected prefix"));
     }
 
     #[tokio::test]
@@ -437,15 +456,18 @@ mod tests {
             .expect(NO_PROTOCOL_ERROR);
 
         assert_eq!(result.is_error, Some(true));
-        let structured = result.structured_content.expect(STRUCTURED_CONTENT);
-        assert_eq!(structured["code"], "invalid_argument");
+        assert!(
+            result.structured_content.is_none(),
+            "{NO_STRUCTURED_CONTENT}"
+        );
+        assert!(first_text_content(&result).contains("wait_seconds must be between"));
     }
 
     /// With `wait_seconds=30` (the upper boundary), the handler should
     /// pass validation and proceed to the pool phase. `lazy_pool` cannot
     /// open connections, so the call fails at pool acquisition — we assert
-    /// the error is NOT `invalid_argument` to confirm the boundary is
-    /// accepted.
+    /// the error message is NOT the `wait_seconds` validation message to confirm
+    /// the boundary is accepted and the failure originates at the pool.
     #[tokio::test]
     async fn test_apply_job_status_wait_seconds_at_boundary_30_accepted() {
         let handler = TestHandler::builder().build();
@@ -459,11 +481,11 @@ mod tests {
             .expect(NO_PROTOCOL_ERROR);
 
         assert_eq!(result.is_error, Some(true));
-        let structured = result.structured_content.expect(STRUCTURED_CONTENT);
-        assert_ne!(
-            structured["code"], "invalid_argument",
-            "wait_seconds=30 should be accepted",
+        assert!(
+            result.structured_content.is_none(),
+            "{NO_STRUCTURED_CONTENT}"
         );
+        assert_accepted_wait_seconds(&result, "wait_seconds=30 should be accepted");
     }
 
     /// With `wait_seconds=0`, the handler should pass validation and
@@ -481,11 +503,11 @@ mod tests {
             .expect(NO_PROTOCOL_ERROR);
 
         assert_eq!(result.is_error, Some(true));
-        let structured = result.structured_content.expect(STRUCTURED_CONTENT);
-        assert_ne!(
-            structured["code"], "invalid_argument",
-            "wait_seconds=0 should be accepted",
+        assert!(
+            result.structured_content.is_none(),
+            "{NO_STRUCTURED_CONTENT}"
         );
+        assert_accepted_wait_seconds(&result, "wait_seconds=0 should be accepted");
     }
 
     /// With `wait_seconds` absent from the request, the handler should
@@ -503,11 +525,11 @@ mod tests {
             .expect(NO_PROTOCOL_ERROR);
 
         assert_eq!(result.is_error, Some(true));
-        let structured = result.structured_content.expect(STRUCTURED_CONTENT);
-        assert_ne!(
-            structured["code"], "invalid_argument",
-            "absent wait_seconds should be accepted",
+        assert!(
+            result.structured_content.is_none(),
+            "{NO_STRUCTURED_CONTENT}"
         );
+        assert_accepted_wait_seconds(&result, "absent wait_seconds should be accepted");
     }
 
     // -- Service: happy paths ----------------------------------------------
@@ -725,8 +747,11 @@ mod tests {
             .expect(NO_PROTOCOL_ERROR);
 
         assert_eq!(result.is_error, Some(true));
-        let structured = result.structured_content.expect(STRUCTURED_CONTENT);
-        assert_eq!(structured["code"], "not_found");
+        assert!(
+            result.structured_content.is_none(),
+            "{NO_STRUCTURED_CONTENT}"
+        );
+        assert!(first_text_content(&result).contains("job not found"));
     }
 
     // -- Polling behaviour -------------------------------------------------

--- a/crates/tribal-mcp/src/handlers/reindex.rs
+++ b/crates/tribal-mcp/src/handlers/reindex.rs
@@ -250,7 +250,7 @@ mod tests {
     use tribal_test_utils::{a_new_embedding_profile, a_new_principal, test_context};
 
     use super::*;
-    use crate::test_utils::TestHandler;
+    use crate::test_utils::{TestHandler, first_text_content};
 
     #[tokio::test]
     async fn test_reindex_cancel_aborts_the_live_run() {
@@ -376,8 +376,11 @@ mod tests {
             .expect("no protocol error");
 
         assert_eq!(result.is_error, Some(true));
-        let structured = result.structured_content.expect("structured content");
-        assert_eq!(structured["code"], "invalid_argument");
+        assert!(
+            result.structured_content.is_none(),
+            "error results carry no structured content"
+        );
+        assert!(first_text_content(&result).contains("unknown embedding provider"));
     }
 
     #[tokio::test]
@@ -399,8 +402,11 @@ mod tests {
             .expect("no protocol error");
 
         assert_eq!(result.is_error, Some(true));
-        let structured = result.structured_content.expect("structured content");
-        assert_eq!(structured["code"], "failed_precondition");
+        assert!(
+            result.structured_content.is_none(),
+            "error results carry no structured content"
+        );
+        assert!(first_text_content(&result).contains("resolving the target provider"));
     }
 
     #[tokio::test]

--- a/crates/tribal-mcp/src/handlers/reindex.rs
+++ b/crates/tribal-mcp/src/handlers/reindex.rs
@@ -250,7 +250,7 @@ mod tests {
     use tribal_test_utils::{a_new_embedding_profile, a_new_principal, test_context};
 
     use super::*;
-    use crate::test_utils::{TestHandler, first_text_content};
+    use crate::test_utils::{NO_STRUCTURED_CONTENT, TestHandler, first_text_content};
 
     #[tokio::test]
     async fn test_reindex_cancel_aborts_the_live_run() {
@@ -378,7 +378,7 @@ mod tests {
         assert_eq!(result.is_error, Some(true));
         assert!(
             result.structured_content.is_none(),
-            "error results carry no structured content"
+            "{NO_STRUCTURED_CONTENT}"
         );
         assert!(first_text_content(&result).contains("unknown embedding provider"));
     }
@@ -404,7 +404,7 @@ mod tests {
         assert_eq!(result.is_error, Some(true));
         assert!(
             result.structured_content.is_none(),
-            "error results carry no structured content"
+            "{NO_STRUCTURED_CONTENT}"
         );
         assert!(first_text_content(&result).contains("resolving the target provider"));
     }

--- a/crates/tribal-mcp/src/handlers/set_context.rs
+++ b/crates/tribal-mcp/src/handlers/set_context.rs
@@ -177,13 +177,14 @@ mod tests {
     use crate::{
         server_handler::ConnectionRepositories,
         session::SessionProject,
-        test_utils::{TestHandler, test_repositories},
+        test_utils::{TestHandler, first_text_content, test_repositories},
     };
 
     // -- Constants ---------------------------------------------------------
 
     const STRUCTURED_CONTENT: &str = "structured_content must be present";
     const NO_PROTOCOL_ERROR: &str = "should not return a protocol error";
+    const NO_STRUCTURED_CONTENT: &str = "error results carry no structured content";
 
     // -- Helpers -----------------------------------------------------------
 
@@ -432,9 +433,11 @@ mod tests {
 
         assert!(!mutated);
         assert_eq!(result.is_error, Some(true));
-
-        let structured = result.structured_content.expect(STRUCTURED_CONTENT);
-        assert_eq!(structured["code"], "invalid_argument");
+        assert!(
+            result.structured_content.is_none(),
+            "{NO_STRUCTURED_CONTENT}"
+        );
+        assert!(first_text_content(&result).contains("expected prefix"));
     }
 
     #[tokio::test]
@@ -451,9 +454,11 @@ mod tests {
 
         assert!(!mutated);
         assert_eq!(result.is_error, Some(true));
-
-        let structured = result.structured_content.expect(STRUCTURED_CONTENT);
-        assert_eq!(structured["code"], "invalid_argument");
+        assert!(
+            result.structured_content.is_none(),
+            "{NO_STRUCTURED_CONTENT}"
+        );
+        assert!(first_text_content(&result).contains("invalid UUID"));
     }
 
     #[tokio::test]

--- a/crates/tribal-mcp/src/handlers/set_context.rs
+++ b/crates/tribal-mcp/src/handlers/set_context.rs
@@ -177,14 +177,13 @@ mod tests {
     use crate::{
         server_handler::ConnectionRepositories,
         session::SessionProject,
-        test_utils::{TestHandler, first_text_content, test_repositories},
+        test_utils::{NO_STRUCTURED_CONTENT, TestHandler, first_text_content, test_repositories},
     };
 
     // -- Constants ---------------------------------------------------------
 
     const STRUCTURED_CONTENT: &str = "structured_content must be present";
     const NO_PROTOCOL_ERROR: &str = "should not return a protocol error";
-    const NO_STRUCTURED_CONTENT: &str = "error results carry no structured content";
 
     // -- Helpers -----------------------------------------------------------
 

--- a/crates/tribal-mcp/src/test_utils.rs
+++ b/crates/tribal-mcp/src/test_utils.rs
@@ -2,7 +2,7 @@ use std::sync::Arc;
 
 use dashmap::DashMap;
 use rmcp::{
-    model::{Extensions as RmcpExtensions, Meta, RequestId},
+    model::{CallToolResult, Extensions as RmcpExtensions, Meta, RawContent, RequestId},
     service::{RequestContext, RoleServer, serve_directly_with_ct},
 };
 use sqlx::PgPool;
@@ -157,6 +157,26 @@ pub(crate) fn session_with_project() -> SessionContext {
             .expect("valid test git remote"),
     };
     SessionContext::new(Some(project))
+}
+
+// ---------------------------------------------------------------------------
+// first_text_content
+// ---------------------------------------------------------------------------
+
+/// Returns the first text content block of a [`CallToolResult`] as `&str`.
+///
+/// Error results carry their message in the text `content` rather than in
+/// `structured_content`, so error-path tests read the message through this
+/// helper to assert on which error occurred.
+///
+/// # Panics
+///
+/// Panics if there is no content or the first block is not a text block.
+pub(crate) fn first_text_content(result: &CallToolResult) -> &str {
+    let RawContent::Text(text) = &result.content.first().expect("content present").raw else {
+        panic!("expected the first content block to be text");
+    };
+    &text.text
 }
 
 // ---------------------------------------------------------------------------

--- a/crates/tribal-mcp/src/test_utils.rs
+++ b/crates/tribal-mcp/src/test_utils.rs
@@ -160,6 +160,14 @@ pub(crate) fn session_with_project() -> SessionContext {
 }
 
 // ---------------------------------------------------------------------------
+// Assertion messages
+// ---------------------------------------------------------------------------
+
+/// Assertion message for the shared error-result invariant: error results
+/// carry their message in the text content and omit `structured_content`.
+pub(crate) const NO_STRUCTURED_CONTENT: &str = "error results carry no structured content";
+
+// ---------------------------------------------------------------------------
 // first_text_content
 // ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## What

Makes Tribal's MCP tools robust to strict harnesses, the kind that auto-fill optional arguments with zero-states and validate every returned `structured_content` against a tool's success output schema. Two fixes, plus the error-path test updates the second one entails.

## Fixes

**1. An empty pagination cursor is the first page.** `tribal_discover` ran a strict 48-hex validator on a present-but-empty `cursor`, so a harness that auto-fills the optional arg with `""` (rather than omitting it) failed every paginated call with "invalid cursor". An empty or blank cursor now normalises to `None` (first page) before reaching the validator, via a small `normalise_cursor` helper; real tokens are still validated strictly, and the cursor-to-`exact` derivation is unaffected (an absent cursor is the normal first-page case).

**2. Error results no longer carry `structured_content`.** Every error result previously attached a `{code, message, details}` payload. A tool declares a *success* output schema, and a strict harness validates any returned `structured_content` against it, so the error shape failed that validation and the harness surfaced a generic schema mismatch, masking the real error message. Error results now carry the message in the text content with `is_error` only (MCP has no error output schema, so the text content is the portable channel). This protects every tool, not just discover.

## Tests

- A unit test for `normalise_cursor` (empty/blank to first page; a real token passed through unchanged).
- The error-result test asserts no `structured_content` on errors.
- The error-path tests across the handlers were updated to assert the error via the message text, referencing the production message constants where they exist rather than duplicating strings, and preserving each test's original error-discrimination (including the "input accepted, fails downstream" cases). Full `tribal-mcp` suite green (285), clippy clean.

## Context

Surfaced in an OpenCode + Docker onboarding smoke. Pairs with the Ollama dialect and fence-stripping fixes already on `main`: those make Tribal robust to non-conforming *models*; this makes it robust to non-conforming *harnesses*. Intended for the 0.3.1 patch.
