### PR TITLE
[CHORE] Add glama.json to claim the Glama MCP registry listing

### DIFF
--- a/glama.json
+++ b/glama.json
@@ -1,0 +1,4 @@
+{
+  "$schema": "https://glama.ai/mcp/schemas/server.json",
+  "maintainers": ["samfolo"]
+}


### PR DESCRIPTION
Adds `glama.json` at the repo root to declare maintainership for Tribal's listing on the [Glama](https://glama.ai/mcp/servers) MCP registry.

This is the minimal valid shape per Glama's schema, where `maintainers` (an array of GitHub usernames) is the only required field:

```json
{
  "$schema": "https://glama.ai/mcp/schemas/server.json",
  "maintainers": ["samfolo"]
}
```

The file declares the maintainer; associating the listing still needs the one-time "Claim ownership" flow on glama.ai (authenticating as `samfolo`), since the repository is under the `tribal-memory` org rather than a personal account. Re-running that flow after this merges picks up the file.
