### PR TITLE
[CHORE] Cut 0.3.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,10 +6,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ## [Unreleased]
 
+## [0.3.1] - 2026-06-07
+
 ### Fixed
 
 - Ollama structured-output ingestion. The Ollama JSON Schema dialect now shares the grammar subset with Anthropic, rewriting the single-element `allOf`-with-`$ref` and `oneOf` enum forms `schemars` emits into shapes llama.cpp's grammar builder compiles. The extraction, triage, and relation stages no longer dead-letter with a parse error against local models. ([#195](https://github.com/tribal-memory/tribal/issues/195))
 - Pipeline responses wrapped in a Markdown code fence now parse. The extraction, triage, and relation stages deserialise strictly first and retry once with the fence stripped only when that fails, so a provider that ignores the structured-output schema and fences its JSON no longer dead-letters, while a valid payload, including one whose strings contain backticks, is never altered. ([#195](https://github.com/tribal-memory/tribal/issues/195))
+- Strict-harness interop for the MCP tools. `tribal_discover` now treats an empty pagination cursor as the first page rather than rejecting it, and tool error results no longer carry structured content, so a harness that validates structured content against a tool's success output schema surfaces the real error message instead of a generic schema mismatch. ([#200](https://github.com/tribal-memory/tribal/pull/200))
 
 ## [0.3.0] - 2026-06-01
 
@@ -87,7 +90,8 @@ This release makes the embedding geometry configurable and adds zero-downtime re
 
 - Docker Compose provider configuration through `.env`, letting the containerised path target a cloud provider (OpenAI, Anthropic) instead of only a local Ollama.
 
-[Unreleased]: https://github.com/tribal-memory/tribal/compare/v0.3.0...HEAD
+[Unreleased]: https://github.com/tribal-memory/tribal/compare/v0.3.1...HEAD
+[0.3.1]: https://github.com/tribal-memory/tribal/compare/v0.3.0...v0.3.1
 [0.3.0]: https://github.com/tribal-memory/tribal/compare/v0.2.5...v0.3.0
 [0.2.5]: https://github.com/tribal-memory/tribal/compare/v0.2.4...v0.2.5
 [0.2.4]: https://github.com/tribal-memory/tribal/compare/v0.2.3...v0.2.4

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5355,7 +5355,7 @@ dependencies = [
 
 [[package]]
 name = "tribal"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "anstream 1.0.0",
  "axum",
@@ -5405,7 +5405,7 @@ dependencies = [
 
 [[package]]
 name = "tribal-auth"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "askama",
  "async-trait",
@@ -5437,7 +5437,7 @@ dependencies = [
 
 [[package]]
 name = "tribal-common"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "dashmap",
  "rand 0.10.1",
@@ -5448,7 +5448,7 @@ dependencies = [
 
 [[package]]
 name = "tribal-config"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "dirs",
  "figment",
@@ -5464,7 +5464,7 @@ dependencies = [
 
 [[package]]
 name = "tribal-db"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "async-trait",
  "chrono",
@@ -5484,7 +5484,7 @@ dependencies = [
 
 [[package]]
 name = "tribal-domain"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "chrono",
  "schemars 0.8.22",
@@ -5499,7 +5499,7 @@ dependencies = [
 
 [[package]]
 name = "tribal-e2e"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "chrono",
  "dashmap",
@@ -5527,7 +5527,7 @@ dependencies = [
 
 [[package]]
 name = "tribal-inference"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "async-trait",
  "reqwest 0.13.2",
@@ -5544,7 +5544,7 @@ dependencies = [
 
 [[package]]
 name = "tribal-mcp"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "axum",
  "chrono",
@@ -5579,7 +5579,7 @@ dependencies = [
 
 [[package]]
 name = "tribal-telemetry"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "opentelemetry",
  "opentelemetry-otlp",
@@ -5600,7 +5600,7 @@ dependencies = [
 
 [[package]]
 name = "tribal-test-utils"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "anstream 1.0.0",
  "async-trait",
@@ -5624,7 +5624,7 @@ dependencies = [
 
 [[package]]
 name = "tribal-ui"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "anstream 1.0.0",
  "anstyle",
@@ -5639,7 +5639,7 @@ dependencies = [
 
 [[package]]
 name = "tribal-worker"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "async-trait",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ members = [
 
 [workspace.package]
 edition = "2024"
-version = "0.3.0"
+version = "0.3.1"
 license = "Elastic-2.0"
 rust-version = "1.93"
 publish = false

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -19,7 +19,7 @@ services:
         max-file: "3"
 
   tribal:
-    image: ghcr.io/tribal-memory/tribal:0.3.0
+    image: ghcr.io/tribal-memory/tribal:0.3.1
     depends_on:
       postgres:
         condition: service_healthy


### PR DESCRIPTION
Cuts the 0.3.1 patch release.

- `CHANGELOG.md`: `[Unreleased]` becomes `[0.3.1]`, with a fresh empty `[Unreleased]` and updated compare links.
- `workspace.package.version` bumped to `0.3.1`, `Cargo.lock` synced.
- `docker-compose.yml` image tag pinned to `0.3.1` (the README and the install skill fetch the compose file from the release tag, so it must reference the image that tag publishes).

0.3.1 is a robustness patch on top of 0.3.0:

- Ollama structured-output ingestion (grammar-subset dialect).
- Markdown code-fence tolerance in stage parsing.
- Strict-harness MCP interop: an empty `tribal_discover` cursor is treated as the first page, and error results carry no structured content.

After this merges, tag the merge commit `v0.3.1` and push the tag to trigger the release (cargo-dist binaries/installers/Homebrew formula, the Docker image, and the first live run of the MCP Registry publish job).
