### PR TITLE
[CHORE] Instrument the agentic runtime's success-path observability

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5647,6 +5647,7 @@ dependencies = [
  "thiserror 2.0.18",
  "tokio",
  "tracing",
+ "tracing-subscriber",
  "tribal-db",
  "tribal-domain",
  "tribal-inference",

--- a/crates/tribal-agent-runtime/src/driver.rs
+++ b/crates/tribal-agent-runtime/src/driver.rs
@@ -40,7 +40,7 @@ use tribal_db::{
 use tribal_domain::{
     AgentBindingVersionId, AgentDriverTaskId, AgentDriverTaskKind, AgentThread, AgentThreadId,
     AgentThreadRecordKind, AgentThreadRecordSeq, AgentThreadStatus, AgentThreadSuspension,
-    AgentThreadTerminal, CompletionResponse, JobId, PrincipalId, TaskId, TaskType,
+    AgentThreadTerminal, CompletionResponse, JobId, PrincipalId, TaskId, TaskType, span_attrs,
 };
 use tribal_telemetry::{current_span_id, current_trace_id};
 
@@ -228,6 +228,17 @@ pub async fn suspend_with_child(
         })?;
 
     commit(txn, "committing the suspend-with-child transaction").await?;
+    tracing::info!(
+        { span_attrs::SUSPENSION_REASON } = suspension.reason_label(),
+        { span_attrs::REQUESTING_SEQ } = requesting_seq.inner(),
+        "agentic thread suspended on a deferred tool result",
+    );
+    tracing::info!(
+        { span_attrs::CHILD_BINDING_VERSION } = %launch.binding_version_id,
+        { span_attrs::CHILD_STAGE } = launch.pipeline_stage.as_str(),
+        { span_attrs::REQUESTING_SEQ } = requesting_seq.inner(),
+        "agentic verifier child launched",
+    );
     Ok(SuspendWithChildOutcome::Launched(LaunchedChild {
         thread_id: child.id(),
         driver_task_id,
@@ -247,6 +258,16 @@ pub enum ChildTerminalOutcome {
     /// the child and driver completed, the hand-back discarded under the
     /// parent row lock.
     ParentNotWaiting,
+}
+
+impl ChildTerminalOutcome {
+    /// The telemetry label for a child terminal's outcome for its parent.
+    fn label(self) -> &'static str {
+        match self {
+            Self::HandedBack => span_attrs::CHILD_TERMINAL_HANDED_BACK,
+            Self::ParentNotWaiting => span_attrs::CHILD_TERMINAL_PARENT_NOT_WAITING,
+        }
+    }
 }
 
 /// The parent a child resolves into: the suspended thread, the call its
@@ -313,10 +334,21 @@ pub async fn commit_child_terminal(
                 remaining -= 1;
                 tracing::warn!(
                     child_thread_id = %child.id(),
+                    { span_attrs::CONFLICT_RETRY_REMAINING } = remaining,
                     "child-terminal commit hit a transient conflict; retrying in place",
                 );
             }
-            outcome => return outcome,
+            Ok(outcome) => {
+                tracing::info!(
+                    child_thread_id = %child.id(),
+                    { span_attrs::CHILD_TERMINAL_OUTCOME } = outcome.label(),
+                    { span_attrs::DRIVER_ATTEMPT } = attempt,
+                    { span_attrs::TERMINAL_IS_ERROR } = false,
+                    "agentic child terminal committed",
+                );
+                return Ok(outcome);
+            }
+            err => return err,
         }
     }
 }
@@ -403,6 +435,12 @@ pub async fn commit_deferred_death(
     .await?;
 
     commit(txn, "committing the deferred-death transaction").await?;
+    tracing::warn!(
+        child_thread_id = %child.id(),
+        { span_attrs::CHILD_TERMINAL_OUTCOME } = outcome.label(),
+        { span_attrs::TERMINAL_IS_ERROR } = true,
+        "agentic child deferred death committed",
+    );
     Ok(outcome)
 }
 

--- a/crates/tribal-agent-runtime/src/turn_loop.rs
+++ b/crates/tribal-agent-runtime/src/turn_loop.rs
@@ -25,6 +25,7 @@ use async_trait::async_trait;
 use chrono::Utc;
 use futures_util::StreamExt;
 use sqlx::PgConnection;
+use tracing::Instrument;
 use tribal_db::{
     AgentThreadRecordRepository, AgentThreadRepository, DbError, NewAgentThreadRecord,
     PgAgentThreadRecordRepository, PgAgentThreadRepository, PgTaskRepository,
@@ -33,7 +34,8 @@ use tribal_db::{
 use tribal_domain::{
     AgentThread, AgentThreadRecord, AgentThreadRecordKind, AgentThreadRecordSeq, AgentThreadStatus,
     AgentThreadSuspension, AgentThreadTerminal, CompletionResponse, ExecutionBudgets,
-    ExecutionSpend, InferenceEvent, TaskId, TaskType, ToolDescriptor, ToolFailure,
+    ExecutionSpend, InferenceEvent, StageExecutorKind, TaskId, TaskType, ToolDescriptor,
+    ToolFailure, gen_ai, span_attrs,
 };
 use tribal_inference::{
     CompletionRequest, InferenceGateway, Message, PermitWait, ToolWireDefinition, UsageAttribution,
@@ -170,6 +172,16 @@ pub enum SubmissionOutcome {
         /// The model-facing rejection, held to the prompt bar.
         diagnostics: String,
     },
+}
+
+impl SubmissionOutcome {
+    /// The telemetry label for a submission evaluation, content-free.
+    fn label(&self) -> &'static str {
+        match self {
+            Self::Accepted { .. } => span_attrs::SUBMISSION_OUTCOME_ACCEPTED,
+            Self::Bounced { .. } => span_attrs::SUBMISSION_OUTCOME_BOUNCED,
+        }
+    }
 }
 
 /// The stage's submission pipeline: schema parse, then the deterministic
@@ -348,6 +360,17 @@ pub enum AdmissionDecision {
     Exhausted(BudgetFailure),
 }
 
+impl AdmissionDecision {
+    /// The telemetry label for a pre-call admission decision.
+    fn label(&self) -> &'static str {
+        match self {
+            Self::Proceed => span_attrs::BUDGET_DECISION_ADMITTED,
+            Self::Suspend { .. } => span_attrs::BUDGET_DECISION_SUSPEND,
+            Self::Exhausted(_) => span_attrs::BUDGET_DECISION_FAILED,
+        }
+    }
+}
+
 /// Runs the token admission and folds in the bounded-recheck
 /// accounting: the decision both executors share before an inference
 /// call. The caller commits the suspension (or the failure), so each
@@ -451,6 +474,18 @@ pub enum LoopOutcome {
         /// Which budget, with its numbers.
         cause: BudgetFailure,
     },
+}
+
+impl LoopOutcome {
+    /// The telemetry label for the loop's concluding outcome.
+    fn label(&self) -> &'static str {
+        match self {
+            Self::Submitted(_) => span_attrs::LOOP_OUTCOME_SUBMITTED,
+            Self::Suspended => span_attrs::LOOP_OUTCOME_SUSPENDED,
+            Self::CancelIntent => span_attrs::LOOP_OUTCOME_CANCEL_INTENT,
+            Self::BudgetFailed { .. } => span_attrs::LOOP_OUTCOME_BUDGET_FAILED,
+        }
+    }
 }
 
 /// The budget exhaustions that fail a thread rather than suspend it.
@@ -571,6 +606,26 @@ pub struct TurnLoopDependencies<'a> {
 pub async fn run_turn_loop(
     deps: TurnLoopDependencies<'_>,
 ) -> Result<LoopOutcome, AgentRuntimeError> {
+    // The runtime root for one thread-advancing execution: the per-claim
+    // stage span (created in the worker) encloses this, and the inference,
+    // tool, and embedding spans nest under it. The thread id rides
+    // `gen_ai.conversation.id`, stitching a thread's fresh-per-claim traces.
+    let span = tracing::info_span!(
+        "invoke_agent",
+        { gen_ai::OPERATION_NAME } = gen_ai::OPERATION_INVOKE_AGENT,
+        { gen_ai::CONVERSATION_ID } = %deps.thread.id(),
+        { span_attrs::STAGE } = deps.stage.as_str(),
+        { span_attrs::TASK_ID } = %deps.task_id,
+        { span_attrs::RETRY_COUNT } = deps.attempt,
+        { span_attrs::EXECUTOR } = StageExecutorKind::BuiltInLoop.as_str(),
+        { span_attrs::THREAD_RESUMED } = tracing::field::Empty,
+    );
+    run_turn_loop_inner(deps).instrument(span).await
+}
+
+async fn run_turn_loop_inner(
+    deps: TurnLoopDependencies<'_>,
+) -> Result<LoopOutcome, AgentRuntimeError> {
     let mut conn = acquire(deps.pool).await?;
 
     // The committed log decides whether this attempt renders the
@@ -578,10 +633,23 @@ pub async fn run_turn_loop(
     // a resumed entry can never write a duplicate whatever the caller
     // believes about prior attempts.
     let mut records = read_log(&mut conn, deps.thread).await?;
-    if !records
+    let resumed = records
         .iter()
-        .any(|record| is_rendered_conversation(record.content()))
-    {
+        .any(|record| is_rendered_conversation(record.content()));
+    tracing::Span::current().record(span_attrs::THREAD_RESUMED, resumed);
+    if resumed {
+        // The committed log is a re-derivation, not a re-execution, so the
+        // replay is one event at the boundary, never one per replayed turn.
+        tracing::info!(
+            { span_attrs::RESUMED_AT_SEQ } =
+                records.last().map_or(0, |record| record.seq().inner()),
+            { span_attrs::TURNS_REPLAYED } = records
+                .iter()
+                .filter(|record| record.kind() == AgentThreadRecordKind::AssistantMessage)
+                .count(),
+            "agentic thread resumed from its committed log",
+        );
+    } else {
         begin_turn(
             &mut conn,
             deps.thread,
@@ -594,7 +662,7 @@ pub async fn run_turn_loop(
     }
     let mut projection = project(deps.thread, &records)?;
 
-    loop {
+    let outcome = loop {
         // A returned verifier verdict resolves before the unanswered tail
         // and before any boundary: an accepted-and-still-valid submission
         // terminates without a further call, and any call the model issued
@@ -609,7 +677,7 @@ pub async fn run_turn_loop(
             if let Some(accepted) =
                 resolve_verdict(&mut conn, &deps, &mut projection, resolved).await?
             {
-                return Ok(LoopOutcome::Submitted(accepted));
+                break LoopOutcome::Submitted(accepted);
             }
             continue;
         }
@@ -617,9 +685,9 @@ pub async fn run_turn_loop(
         if let Some(batch) = projection.tail.take() {
             match execute_batch(&mut conn, &deps, &mut projection, batch).await? {
                 BatchOutcome::Completed => {}
-                BatchOutcome::Submitted(accepted) => return Ok(LoopOutcome::Submitted(accepted)),
-                BatchOutcome::Suspended => return Ok(LoopOutcome::Suspended),
-                BatchOutcome::CancelIntervened => return Ok(LoopOutcome::CancelIntent),
+                BatchOutcome::Submitted(accepted) => break LoopOutcome::Submitted(accepted),
+                BatchOutcome::Suspended => break LoopOutcome::Suspended,
+                BatchOutcome::CancelIntervened => break LoopOutcome::CancelIntent,
                 BatchOutcome::Reproject => {
                     projection = read_projection(&mut conn, deps.thread).await?;
                 }
@@ -641,61 +709,66 @@ pub async fn run_turn_loop(
                 task_id: deps.task_id,
             })?;
         if current.cancel_requested_at().is_some() {
-            return Ok(LoopOutcome::CancelIntent);
+            break LoopOutcome::CancelIntent;
         }
 
         // 2. The turn cap, against committed turns.
         if let Some(cap) = deps.budgets.max_turns
             && projection.assistant_turns >= cap
         {
-            return Ok(LoopOutcome::BudgetFailed {
+            break LoopOutcome::BudgetFailed {
                 cause: BudgetFailure::TurnCap {
                     turns: projection.assistant_turns,
                     cap,
                 },
-            });
+            };
         }
 
         // 3. The execution deadline, against thread age.
         if let Some(seconds) = deps.budgets.execution_deadline_seconds
             && Utc::now() - deps.thread.created_at() > chrono::Duration::seconds(i64::from(seconds))
         {
-            return Ok(LoopOutcome::BudgetFailed {
+            break LoopOutcome::BudgetFailed {
                 cause: BudgetFailure::Deadline { seconds },
-            });
+            };
         }
 
         // 4. Ledger-side token admission, with the bounded re-check
         //    accounting.
-        match decide_admission(
+        let decision = decide_admission(
             &mut conn,
             deps.thread,
             &deps.budgets,
             deps.recheck,
             carried_rechecks,
         )
-        .await?
-        {
+        .await?;
+        emit_budget_admission(decision);
+        match decision {
             AdmissionDecision::Proceed => {}
             AdmissionDecision::Exhausted(cause) => {
-                return Ok(LoopOutcome::BudgetFailed { cause });
+                break LoopOutcome::BudgetFailed { cause };
             }
             AdmissionDecision::Suspend { unchanged_rechecks } => {
                 deps.pump.abort();
                 let wake_at =
                     Utc::now() + chrono::Duration::seconds(i64::from(deps.recheck.delay_seconds));
-                return match suspend_stage_thread(
+                let suspension = AgentThreadSuspension::BudgetExhaustion { unchanged_rechecks };
+                break match suspend_stage_thread(
                     &mut conn,
                     deps.thread,
                     deps.task_id,
                     deps.claim_token,
-                    &AgentThreadSuspension::BudgetExhaustion { unchanged_rechecks },
+                    &suspension,
                     Some(wake_at),
                 )
                 .await?
                 {
-                    SuspendOutcome::Suspended => Ok(LoopOutcome::Suspended),
-                    SuspendOutcome::CancelIntervened => Ok(LoopOutcome::CancelIntent),
+                    SuspendOutcome::Suspended => {
+                        emit_suspension(&suspension, Some(wake_at), Some(unchanged_rechecks));
+                        LoopOutcome::Suspended
+                    }
+                    SuspendOutcome::CancelIntervened => LoopOutcome::CancelIntent,
                 };
             }
         }
@@ -708,7 +781,74 @@ pub async fn run_turn_loop(
         //    spend projection, and progress reset.
         let (record, calls) = commit_assistant_turn(&mut conn, &deps, &response).await?;
         projection.append_assistant(&response, record.seq(), calls);
+        tracing::info!(
+            { span_attrs::TURN_INDEX } = record.seq().inner(),
+            { span_attrs::ASSISTANT_TURNS } = projection.assistant_turns,
+            { gen_ai::USAGE_INPUT_TOKENS } = response.usage.input_tokens,
+            { gen_ai::USAGE_OUTPUT_TOKENS } = response.usage.output_tokens,
+            "agentic turn committed",
+        );
+    };
+
+    tracing::info!(
+        { span_attrs::LOOP_OUTCOME } = outcome.label(),
+        "agentic loop reached an outcome",
+    );
+    Ok(outcome)
+}
+
+/// Emits the pre-call budget admission event, carrying the decision and
+/// its numbers (never content).
+fn emit_budget_admission(decision: AdmissionDecision) {
+    match decision {
+        AdmissionDecision::Proceed => {
+            tracing::debug!(
+                { span_attrs::BUDGET_DECISION } = decision.label(),
+                "budget admitted"
+            );
+        }
+        AdmissionDecision::Suspend { unchanged_rechecks } => {
+            tracing::info!(
+                { span_attrs::BUDGET_DECISION } = decision.label(),
+                { span_attrs::UNCHANGED_RECHECKS } = unchanged_rechecks,
+                "budget exhausted; suspending",
+            );
+        }
+        AdmissionDecision::Exhausted(BudgetFailure::RecheckExhausted {
+            spent,
+            cap,
+            rechecks,
+        }) => {
+            tracing::warn!(
+                { span_attrs::BUDGET_DECISION } = decision.label(),
+                { span_attrs::BUDGET_SPENT } = spent,
+                { span_attrs::BUDGET_CAP } = cap,
+                { span_attrs::UNCHANGED_RECHECKS } = rechecks,
+                "budget re-checks ran dry; failing the thread",
+            );
+        }
+        AdmissionDecision::Exhausted(_) => {
+            tracing::warn!(
+                { span_attrs::BUDGET_DECISION } = decision.label(),
+                "budget exhausted; failing the thread",
+            );
+        }
     }
+}
+
+/// Emits a suspension-committed event with the typed reason and, for a
+/// budget wake, its wake instant and re-check count.
+fn emit_suspension(
+    suspension: &AgentThreadSuspension,
+    wake_at: Option<chrono::DateTime<Utc>>,
+    unchanged_rechecks: Option<u32>,
+) {
+    tracing::info!(
+        { span_attrs::SUSPENSION_REASON } = suspension.reason_label(),
+        { span_attrs::WAKE_AT } = wake_at.map(|at| at.to_rfc3339()),
+        { span_attrs::UNCHANGED_RECHECKS } = unchanged_rechecks,
+        "agentic thread suspended",
+    );
 }
 
 /// Dispositions a returned verifier verdict. `Some` terminates the stage;
@@ -1270,6 +1410,7 @@ async fn commit_assistant_turn(
 }
 
 /// What a fenced tool-result commit concluded.
+#[derive(Clone, Copy)]
 enum ResultCommit {
     Committed,
     /// The fence refused the append: another actor answered this call.
@@ -1411,7 +1552,36 @@ enum BatchOutcome {
     Reproject,
 }
 
-/// Executes a batch's unanswered calls sequentially, in call order.
+/// What handling one call concluded, before the batch maps it to its own
+/// outcome.
+enum CallStep {
+    /// A result committed (ordinary, bounce, or error); the batch continues.
+    Committed,
+    /// The fence refused the append; the in-memory reading is stale.
+    FenceConflict,
+    /// `submit_result` was accepted with no verifier; exit to the terminal.
+    Submitted(AcceptedSubmission),
+    /// `submit_result` was accepted and a verifier launched; suspended.
+    Suspended,
+    /// A durable cancellation intent intervened at the verifier suspend.
+    CancelIntervened,
+}
+
+impl CallStep {
+    /// The telemetry label for an `execute_tool` span's outcome.
+    fn label(&self) -> &'static str {
+        match self {
+            Self::Committed => span_attrs::TOOL_OUTCOME_COMMITTED,
+            Self::FenceConflict => span_attrs::TOOL_OUTCOME_FENCE_CONFLICT,
+            Self::Submitted(_) => span_attrs::TOOL_OUTCOME_SUBMITTED,
+            Self::Suspended => span_attrs::TOOL_OUTCOME_SUSPENDED,
+            Self::CancelIntervened => span_attrs::TOOL_OUTCOME_CANCEL_INTERVENED,
+        }
+    }
+}
+
+/// Executes a batch's unanswered calls sequentially, in call order, each
+/// under its own `execute_tool` span.
 ///
 /// A bounced submission commits its diagnostics and the batch continues;
 /// an accepted submission stops the batch, so any calls the model issued
@@ -1428,105 +1598,106 @@ async fn execute_batch(
         if batch.answered.contains(&call.id) {
             continue;
         }
-        let commit = if call.name == SUBMIT_RESULT_TOOL {
+        let is_submit = call.name == SUBMIT_RESULT_TOOL;
+        // The model authors the call name, so an unrecognised one is
+        // arbitrary text that must never reach telemetry. Record the fixed
+        // submit name, a matched registered name (a fixed identifier), or a
+        // constant `unknown` classification, never the raw name.
+        let tool_label = if is_submit {
+            SUBMIT_RESULT_TOOL
+        } else if deps.registry.lookup(&call.name).is_ok() {
+            call.name.as_str()
+        } else {
+            "unknown"
+        };
+        let span = tracing::info_span!(
+            "execute_tool",
+            { gen_ai::OPERATION_NAME } = gen_ai::OPERATION_EXECUTE_TOOL,
+            { span_attrs::OTEL_NAME } = %format!("execute_tool {tool_label}"),
+            { span_attrs::TOOL_NAME } = tool_label,
+            { span_attrs::TOOL_CALL_ID } = %call.id,
+            { span_attrs::TOOL_IS_SUBMIT } = is_submit,
+            { span_attrs::TOOL_OUTCOME } = tracing::field::Empty,
+        );
+        let step = handle_call(conn, deps, projection, &batch, call)
+            .instrument(span)
+            .await?;
+        match step {
+            CallStep::Committed => {}
+            CallStep::FenceConflict => {
+                tracing::warn!(
+                    thread_id = %deps.thread.id(),
+                    call_id = %call.id,
+                    "the tool-result fence refused an append; re-reading the log",
+                );
+                return Ok(BatchOutcome::Reproject);
+            }
+            CallStep::Submitted(accepted) => return Ok(BatchOutcome::Submitted(accepted)),
+            CallStep::Suspended => return Ok(BatchOutcome::Suspended),
+            CallStep::CancelIntervened => return Ok(BatchOutcome::CancelIntervened),
+        }
+    }
+    projection.tail = None;
+    Ok(BatchOutcome::Completed)
+}
+
+/// Handles one unanswered call, recording its outcome on the enclosing
+/// `execute_tool` span: the submission pipeline for `submit_result`, the
+/// two-phase ordinary path otherwise.
+async fn handle_call(
+    conn: &mut PgConnection,
+    deps: &TurnLoopDependencies<'_>,
+    projection: &mut Projection,
+    batch: &PendingBatch,
+    call: &RecordedToolCall,
+) -> Result<CallStep, AgentRuntimeError> {
+    let step = if call.name == SUBMIT_RESULT_TOOL {
+        handle_submission(conn, deps, projection, batch, call).await?
+    } else {
+        commit_to_step(execute_ordinary(conn, deps, projection, batch.requesting_seq, call).await?)
+    };
+    tracing::Span::current().record(span_attrs::TOOL_OUTCOME, step.label());
+    Ok(step)
+}
+
+/// Evaluates a `submit_result` call through the submission pipeline, then
+/// either commits, launches a verifier child, or returns the diagnostics
+/// in-band. Emits the submission-evaluated event at the pipeline boundary.
+async fn handle_submission(
+    conn: &mut PgConnection,
+    deps: &TurnLoopDependencies<'_>,
+    projection: &mut Projection,
+    batch: &PendingBatch,
+    call: &RecordedToolCall,
+) -> Result<CallStep, AgentRuntimeError> {
+    let evaluation = deps
+        .pipeline
+        .evaluate(conn, deps.thread, &projection.corpus, &call.arguments)
+        .await;
+    if let Ok(outcome) = &evaluation {
+        tracing::info!(
+            { span_attrs::SUBMISSION_OUTCOME } = outcome.label(),
+            "submission evaluated",
+        );
+    }
+    match evaluation {
+        Ok(SubmissionOutcome::Accepted { payload }) => {
+            // Validators passed; the binding decides whether a verifier
+            // child must agree before the commit.
             match deps
                 .pipeline
-                .evaluate(conn, deps.thread, &projection.corpus, &call.arguments)
+                .verifier_launch(conn, deps.thread, &payload)
                 .await
             {
-                Ok(SubmissionOutcome::Accepted { payload }) => {
-                    // Validators passed; the binding decides whether a
-                    // verifier child must agree before the commit.
-                    match deps
-                        .pipeline
-                        .verifier_launch(conn, deps.thread, &payload)
-                        .await
-                    {
-                        Ok(None) => {
-                            return Ok(BatchOutcome::Submitted(AcceptedSubmission {
-                                payload,
-                                requesting_seq: batch.requesting_seq,
-                                tool_call_id: call.id.clone(),
-                            }));
-                        }
-                        Ok(Some(launch)) => {
-                            // The verify budget bounds how many verifier
-                            // children one thread launches. Once spent, the
-                            // validated submission commits on the validators
-                            // alone: they are the correctness gate and the
-                            // verifier the quality lever, so a spent budget
-                            // degrades to a direct commit rather than
-                            // failing the thread.
-                            if deps
-                                .budgets
-                                .max_child_launches
-                                .is_some_and(|cap| projection.child_launches >= cap)
-                            {
-                                return Ok(BatchOutcome::Submitted(AcceptedSubmission {
-                                    payload,
-                                    requesting_seq: batch.requesting_seq,
-                                    tool_call_id: call.id.clone(),
-                                }));
-                            }
-                            // The heartbeat stops before the suspension
-                            // clears the claim, lest a beat in flight race
-                            // a spurious ownership-lost signal.
-                            deps.pump.abort();
-                            let child = ChildLaunch {
-                                pipeline_stage: launch.pipeline_stage,
-                                binding_version_id: launch.binding_version_id,
-                                principal_id: deps.thread.principal_id(),
-                                // The parent's job, so the child's spend
-                                // meters to it without a lineage walk.
-                                job_id: deps.attribution.owner.job_id(),
-                                format_version: deps.thread.format_version(),
-                            };
-                            return match suspend_with_child(
-                                conn,
-                                deps.thread,
-                                deps.task_id,
-                                deps.claim_token,
-                                batch.requesting_seq,
-                                &call.id,
-                                child,
-                                &launch.child_input,
-                            )
-                            .await?
-                            {
-                                SuspendWithChildOutcome::Launched(_) => Ok(BatchOutcome::Suspended),
-                                SuspendWithChildOutcome::CancelIntervened => {
-                                    Ok(BatchOutcome::CancelIntervened)
-                                }
-                            };
-                        }
-                        Err(ToolFailure::Recoverable(recoverable)) => {
-                            error_result(
-                                conn,
-                                deps,
-                                projection,
-                                batch.requesting_seq,
-                                call,
-                                recoverable.render(),
-                            )
-                            .await?
-                        }
-                        Err(ToolFailure::System { context }) => {
-                            return Err(AgentRuntimeError::ToolExecution { context });
-                        }
-                    }
+                Ok(None) => Ok(CallStep::Submitted(AcceptedSubmission {
+                    payload,
+                    requesting_seq: batch.requesting_seq,
+                    tool_call_id: call.id.clone(),
+                })),
+                Ok(Some(launch)) => {
+                    launch_verifier(conn, deps, projection, batch, call, payload, launch).await
                 }
-                Ok(SubmissionOutcome::Bounced { diagnostics }) => {
-                    error_result(
-                        conn,
-                        deps,
-                        projection,
-                        batch.requesting_seq,
-                        call,
-                        diagnostics,
-                    )
-                    .await?
-                }
-                Err(ToolFailure::Recoverable(recoverable)) => {
+                Err(ToolFailure::Recoverable(recoverable)) => Ok(commit_to_step(
                     error_result(
                         conn,
                         deps,
@@ -1535,26 +1706,100 @@ async fn execute_batch(
                         call,
                         recoverable.render(),
                     )
-                    .await?
-                }
+                    .await?,
+                )),
                 Err(ToolFailure::System { context }) => {
-                    return Err(AgentRuntimeError::ToolExecution { context });
+                    Err(AgentRuntimeError::ToolExecution { context })
                 }
             }
-        } else {
-            execute_ordinary(conn, deps, projection, batch.requesting_seq, call).await?
-        };
-        if matches!(commit, ResultCommit::FenceConflict) {
-            tracing::warn!(
-                thread_id = %deps.thread.id(),
-                call_id = %call.id,
-                "the tool-result fence refused an append; re-reading the log",
-            );
-            return Ok(BatchOutcome::Reproject);
         }
+        Ok(SubmissionOutcome::Bounced { diagnostics }) => Ok(commit_to_step(
+            error_result(
+                conn,
+                deps,
+                projection,
+                batch.requesting_seq,
+                call,
+                diagnostics,
+            )
+            .await?,
+        )),
+        Err(ToolFailure::Recoverable(recoverable)) => Ok(commit_to_step(
+            error_result(
+                conn,
+                deps,
+                projection,
+                batch.requesting_seq,
+                call,
+                recoverable.render(),
+            )
+            .await?,
+        )),
+        Err(ToolFailure::System { context }) => Err(AgentRuntimeError::ToolExecution { context }),
     }
-    projection.tail = None;
-    Ok(BatchOutcome::Completed)
+}
+
+/// Launches a validators-accepted submission's verifier child, or commits
+/// the validated `payload` directly when the verify budget is spent (the
+/// validators are the correctness gate; the verifier is the quality lever).
+// The launch's full pipeline context; a params struct would only move the
+// same arguments behind a name.
+#[allow(clippy::too_many_arguments)]
+async fn launch_verifier(
+    conn: &mut PgConnection,
+    deps: &TurnLoopDependencies<'_>,
+    projection: &Projection,
+    batch: &PendingBatch,
+    call: &RecordedToolCall,
+    payload: serde_json::Value,
+    launch: VerifierLaunch,
+) -> Result<CallStep, AgentRuntimeError> {
+    if deps
+        .budgets
+        .max_child_launches
+        .is_some_and(|cap| projection.child_launches >= cap)
+    {
+        return Ok(CallStep::Submitted(AcceptedSubmission {
+            payload,
+            requesting_seq: batch.requesting_seq,
+            tool_call_id: call.id.clone(),
+        }));
+    }
+    // The heartbeat stops before the suspension clears the claim, lest a
+    // beat in flight race a spurious ownership-lost signal.
+    deps.pump.abort();
+    let child = ChildLaunch {
+        pipeline_stage: launch.pipeline_stage,
+        binding_version_id: launch.binding_version_id,
+        principal_id: deps.thread.principal_id(),
+        // The parent's job, so the child's spend meters to it without a
+        // lineage walk.
+        job_id: deps.attribution.owner.job_id(),
+        format_version: deps.thread.format_version(),
+    };
+    match suspend_with_child(
+        conn,
+        deps.thread,
+        deps.task_id,
+        deps.claim_token,
+        batch.requesting_seq,
+        &call.id,
+        child,
+        &launch.child_input,
+    )
+    .await?
+    {
+        SuspendWithChildOutcome::Launched(_) => Ok(CallStep::Suspended),
+        SuspendWithChildOutcome::CancelIntervened => Ok(CallStep::CancelIntervened),
+    }
+}
+
+/// Maps a fenced result commit onto the batch's call step.
+fn commit_to_step(commit: ResultCommit) -> CallStep {
+    match commit {
+        ResultCommit::Committed => CallStep::Committed,
+        ResultCommit::FenceConflict => CallStep::FenceConflict,
+    }
 }
 
 /// Executes one ordinary call under the two-phase contract: provider

--- a/crates/tribal-domain/src/agent_thread.rs
+++ b/crates/tribal-domain/src/agent_thread.rs
@@ -13,7 +13,7 @@ use typed_builder::TypedBuilder;
 
 use crate::{
     AgentBindingVersionId, AgentDriverTaskId, AgentThreadId, AgentThreadRecordId, JobId,
-    PrincipalId, TaskId, TaskType,
+    PrincipalId, TaskId, TaskType, span_attrs,
 };
 
 /// The serialisation shape of thread-owned structures (record `content`
@@ -153,6 +153,21 @@ pub enum AgentThreadSuspension {
         /// exhausted.
         unchanged_rechecks: u32,
     },
+}
+
+impl AgentThreadSuspension {
+    /// The stable telemetry label for the suspension cause: the value a
+    /// suspension-committed event carries on its
+    /// [`span_attrs::SUSPENSION_REASON`] field.
+    #[must_use]
+    pub fn reason_label(&self) -> &'static str {
+        match self {
+            Self::HumanInput { .. } => span_attrs::SUSPENSION_REASON_HUMAN,
+            Self::DeferredToolResults { .. } => span_attrs::SUSPENSION_REASON_DEFERRED,
+            Self::Timer => span_attrs::SUSPENSION_REASON_TIMER,
+            Self::BudgetExhaustion { .. } => span_attrs::SUSPENSION_REASON_BUDGET,
+        }
+    }
 }
 
 // ---------------------------------------------------------------------------

--- a/crates/tribal-domain/src/gen_ai.rs
+++ b/crates/tribal-domain/src/gen_ai.rs
@@ -31,6 +31,11 @@ pub const PROVIDER_NAME: &str = "gen_ai.provider.name";
 /// Attribute key for the model named in the request.
 pub const REQUEST_MODEL: &str = "gen_ai.request.model";
 
+/// Attribute key correlating spans of one conversation. Carries the agent
+/// thread id, so a thread's traces stitch across the fresh root each claim
+/// opens.
+pub const CONVERSATION_ID: &str = "gen_ai.conversation.id";
+
 /// Attribute key for the sampling temperature sent in the request.
 pub const REQUEST_TEMPERATURE: &str = "gen_ai.request.temperature";
 
@@ -62,6 +67,12 @@ pub const OPERATION_CHAT: &str = "chat";
 
 /// [`OPERATION_NAME`] value for an embedding call.
 pub const OPERATION_EMBEDDINGS: &str = "embeddings";
+
+/// [`OPERATION_NAME`] value for a thread-advancing agent execution.
+pub const OPERATION_INVOKE_AGENT: &str = "invoke_agent";
+
+/// [`OPERATION_NAME`] value for a single tool call.
+pub const OPERATION_EXECUTE_TOOL: &str = "execute_tool";
 
 // ---------------------------------------------------------------------------
 // Token-type values

--- a/crates/tribal-domain/src/span_attrs.rs
+++ b/crates/tribal-domain/src/span_attrs.rs
@@ -145,3 +145,184 @@ pub const TAG_RESOLUTION_SEMANTIC_MATCHED: &str = "tribal.tag_resolution.semanti
 
 /// Span field name for the highest similarity score observed during resolution.
 pub const TAG_RESOLUTION_BEST_SIMILARITY: &str = "tribal.tag_resolution.best_similarity";
+
+// ---------------------------------------------------------------------------
+// Agentic runtime spans and lifecycle events
+// ---------------------------------------------------------------------------
+
+/// Span field name for the executor a thread-advancing execution runs
+/// under: a `StageExecutorKind` wire string.
+pub const EXECUTOR: &str = "tribal.executor";
+
+/// Span field name flagging an `invoke_agent` that resumed a committed log
+/// rather than rendering a fresh opening.
+pub const THREAD_RESUMED: &str = "tribal.thread.resumed";
+
+/// Span field name for the log seq a resumed execution re-entered at.
+pub const RESUMED_AT_SEQ: &str = "tribal.resumed_at_seq";
+
+/// Span field name for the committed assistant turns a resume replayed.
+pub const TURNS_REPLAYED: &str = "tribal.turns_replayed";
+
+/// Span field name for a committed turn's index (its record seq).
+pub const TURN_INDEX: &str = "tribal.turn.index";
+
+/// Span field name for the running count of committed assistant turns.
+pub const ASSISTANT_TURNS: &str = "tribal.assistant_turns";
+
+/// Span field name for a tool call's name on an `execute_tool` span.
+pub const TOOL_NAME: &str = "tribal.tool.name";
+
+/// Span field name for the tool call identifier its result answers.
+pub const TOOL_CALL_ID: &str = "tribal.tool.call_id";
+
+/// Span field name for an `execute_tool` span's outcome classification.
+pub const TOOL_OUTCOME: &str = "tribal.tool.outcome";
+
+/// Span field name flagging the distinguished completion tool.
+pub const TOOL_IS_SUBMIT: &str = "tribal.tool.is_submit";
+
+/// Span field name for a submission evaluation's outcome.
+pub const SUBMISSION_OUTCOME: &str = "tribal.submission.outcome";
+
+/// [`SUBMISSION_OUTCOME`] value: the submission passed every validator.
+pub const SUBMISSION_OUTCOME_ACCEPTED: &str = "accepted";
+
+/// [`SUBMISSION_OUTCOME`] value: a validator rejected it.
+pub const SUBMISSION_OUTCOME_BOUNCED: &str = "bounced";
+
+/// [`TOOL_OUTCOME`] value: a result record committed.
+pub const TOOL_OUTCOME_COMMITTED: &str = "committed";
+
+/// [`TOOL_OUTCOME`] value: the fence refused the append.
+pub const TOOL_OUTCOME_FENCE_CONFLICT: &str = "fence_conflict";
+
+/// [`TOOL_OUTCOME`] value: an accepted submission with no verifier.
+pub const TOOL_OUTCOME_SUBMITTED: &str = "submitted";
+
+/// [`TOOL_OUTCOME`] value: an accepted submission launched a verifier.
+pub const TOOL_OUTCOME_SUSPENDED: &str = "suspended";
+
+/// [`TOOL_OUTCOME`] value: a cancellation intent intervened at the suspend.
+pub const TOOL_OUTCOME_CANCEL_INTERVENED: &str = "cancel_intervened";
+
+/// Span field name for why a thread suspended: an `AgentThreadSuspension`
+/// wire string.
+pub const SUSPENSION_REASON: &str = "tribal.suspension.reason";
+
+/// [`SUSPENSION_REASON`] value: pending deferred tool results (a child launch).
+pub const SUSPENSION_REASON_DEFERRED: &str = "deferred_tool_results";
+
+/// [`SUSPENSION_REASON`] value: sleeping on a wake-at timer.
+pub const SUSPENSION_REASON_TIMER: &str = "timer";
+
+/// [`SUSPENSION_REASON`] value: an exhausted execution budget.
+pub const SUSPENSION_REASON_BUDGET: &str = "budget_exhausted";
+
+/// [`SUSPENSION_REASON`] value: awaiting human input.
+pub const SUSPENSION_REASON_HUMAN: &str = "human_input";
+
+/// Span field name for a suspension's scheduled wake instant.
+pub const WAKE_AT: &str = "tribal.wake_at";
+
+/// Span field name for consecutive unchanged budget re-checks.
+pub const UNCHANGED_RECHECKS: &str = "tribal.unchanged_rechecks";
+
+/// Span field name for a pre-call budget admission decision
+/// (`admitted`/`suspend`/`failed`).
+pub const BUDGET_DECISION: &str = "tribal.budget.decision";
+
+/// [`BUDGET_DECISION`] value: headroom exists; the call proceeds.
+pub const BUDGET_DECISION_ADMITTED: &str = "admitted";
+
+/// [`BUDGET_DECISION`] value: the budget is exhausted; the thread suspends.
+pub const BUDGET_DECISION_SUSPEND: &str = "suspend";
+
+/// [`BUDGET_DECISION`] value: the bounded re-checks ran dry; the thread fails.
+pub const BUDGET_DECISION_FAILED: &str = "failed";
+
+/// Span field name for the tokens the ledger accounts to a thread.
+pub const BUDGET_SPENT: &str = "tribal.budget.spent";
+
+/// Span field name for a binding's token cap.
+pub const BUDGET_CAP: &str = "tribal.budget.cap";
+
+/// Span field name for a launched child's content-addressed binding version.
+pub const CHILD_BINDING_VERSION: &str = "tribal.child.binding_version";
+
+/// Span field name for a launched child's pipeline stage.
+pub const CHILD_STAGE: &str = "tribal.child.stage";
+
+/// Span field name for the assistant message a deferred result answers.
+pub const REQUESTING_SEQ: &str = "tribal.requesting_seq";
+
+/// Span field name for a child terminal's outcome for its parent.
+pub const CHILD_TERMINAL_OUTCOME: &str = "tribal.child.terminal_outcome";
+
+/// [`CHILD_TERMINAL_OUTCOME`] value: the verdict woke and re-queued the parent.
+pub const CHILD_TERMINAL_HANDED_BACK: &str = "handed_back";
+
+/// [`CHILD_TERMINAL_OUTCOME`] value: the parent was no longer waiting.
+pub const CHILD_TERMINAL_PARENT_NOT_WAITING: &str = "parent_not_waiting";
+
+/// Span field name for a child execution's parent thread id.
+pub const PARENT_THREAD_ID: &str = "tribal.parent_thread_id";
+
+/// Span field name flagging an error-shaped hand-back (a child death).
+pub const TERMINAL_IS_ERROR: &str = "tribal.terminal.is_error";
+
+/// Span field name for the driver attempt a child terminal committed under.
+pub const DRIVER_ATTEMPT: &str = "tribal.driver.attempt";
+
+/// Span field name for the in-place conflict retries left when one fires.
+pub const CONFLICT_RETRY_REMAINING: &str = "tribal.conflict_retry.remaining";
+
+/// Span field name for the loop's concluding outcome
+/// (`submitted`/`suspended`/`cancel_intent`/`budget_failed`).
+pub const LOOP_OUTCOME: &str = "tribal.loop.outcome";
+
+/// [`LOOP_OUTCOME`] value: an accepted submission.
+pub const LOOP_OUTCOME_SUBMITTED: &str = "submitted";
+
+/// [`LOOP_OUTCOME`] value: a suspension committed.
+pub const LOOP_OUTCOME_SUSPENDED: &str = "suspended";
+
+/// [`LOOP_OUTCOME`] value: a durable cancellation intent was observed.
+pub const LOOP_OUTCOME_CANCEL_INTENT: &str = "cancel_intent";
+
+/// [`LOOP_OUTCOME`] value: a budget exhaustion failed the thread.
+pub const LOOP_OUTCOME_BUDGET_FAILED: &str = "budget_failed";
+
+// ---------------------------------------------------------------------------
+// Availability sweep
+// ---------------------------------------------------------------------------
+
+/// Span field name for suspended threads woken by an elapsed timer.
+pub const SWEEP_TIMER_WAKES: &str = "tribal.sweep.timer_wakes";
+
+/// Span field name for orphaned descendants the cascade janitor marked.
+pub const SWEEP_CASCADED: &str = "tribal.sweep.cascaded";
+
+/// Span field name for threads the cancel fallback terminated.
+pub const SWEEP_CANCELLED: &str = "tribal.sweep.cancelled";
+
+/// Span field name for stranded relation threads the sweep failed.
+pub const SWEEP_STUCK_RELATING: &str = "tribal.sweep.stuck_relating";
+
+/// Span field name for which sweep predicate a per-action event reports.
+pub const SWEEP_ACTION: &str = "tribal.sweep.action";
+
+/// Span field name for the count a sweep action converged.
+pub const SWEEP_ACTION_COUNT: &str = "tribal.sweep.action_count";
+
+/// [`SWEEP_ACTION`] value: the timer-wake predicate.
+pub const SWEEP_ACTION_TIMER_WAKE: &str = "timer_wake";
+
+/// [`SWEEP_ACTION`] value: the orphan-cascade janitor.
+pub const SWEEP_ACTION_ORPHAN_CASCADE: &str = "orphan_cascade";
+
+/// [`SWEEP_ACTION`] value: the cancel-fallback predicate.
+pub const SWEEP_ACTION_CANCEL_FALLBACK: &str = "cancel_fallback";
+
+/// [`SWEEP_ACTION`] value: the stuck-relating predicate.
+pub const SWEEP_ACTION_STUCK_RELATING: &str = "stuck_relating";

--- a/crates/tribal-telemetry/src/lib.rs
+++ b/crates/tribal-telemetry/src/lib.rs
@@ -16,8 +16,8 @@ pub use error::TelemetryError;
 pub use guard::TelemetryGuard;
 pub use propagation::{
     INVALID_SESSION_TRACE_ID, INVALID_TRACE_ID, TraceLink, current_span_id, current_trace_context,
-    current_trace_id, is_valid_trace_id, parent_span_from_trace_id, parent_span_from_traceparent,
-    trace_id_from_traceparent,
+    current_trace_id, is_valid_trace_id, link_span_to_ids, parent_span_from_trace_id,
+    parent_span_from_traceparent, trace_id_from_traceparent,
 };
 pub use recorder::{
     InferenceOperationRecord, MetricsRecorder, NoopMetricsRecorder, OtelMetricsRecorder,

--- a/crates/tribal-telemetry/src/propagation.rs
+++ b/crates/tribal-telemetry/src/propagation.rs
@@ -224,6 +224,37 @@ pub fn parent_span_from_trace_id(span: &tracing::Span, trace_id: &str) -> TraceL
     TraceLink::Linked
 }
 
+/// Adds a best-effort `OTel` span link from `span` to a (trace, span) a
+/// prior execution recorded, when both ids parse.
+///
+/// Unlike the parenting helpers, this leaves `span` rooted in its own
+/// trace and merely records a link to the other: a verifier child links
+/// to its launching parent without reparenting, since a suspension can
+/// outlive the parent's trace window and the durable parent linkage is
+/// the authority. The link is silently dropped when no OpenTelemetry
+/// layer is installed, so [`TraceLink::Linked`] reports only that the ids
+/// were valid.
+#[must_use]
+pub fn link_span_to_ids(span: &tracing::Span, trace_id: &str, span_id: &str) -> TraceLink {
+    if trace_id.len() != 32 || span_id.len() != 16 {
+        return TraceLink::Invalid;
+    }
+    let (Ok(tid), Ok(sid)) = (TraceId::from_hex(trace_id), SpanId::from_hex(span_id)) else {
+        return TraceLink::Invalid;
+    };
+    if tid == TraceId::INVALID || sid == SpanId::INVALID {
+        return TraceLink::Invalid;
+    }
+    span.add_link(SpanContext::new(
+        tid,
+        sid,
+        TraceFlags::SAMPLED,
+        true,
+        TraceState::default(),
+    ));
+    TraceLink::Linked
+}
+
 // ---------------------------------------------------------------------------
 // Tests
 // ---------------------------------------------------------------------------
@@ -430,6 +461,65 @@ mod tests {
         tracing::subscriber::with_default(subscriber, || {
             let span = tracing::info_span!("test_invalid_tid");
             assert!(parent_span_from_trace_id(&span, "not-a-trace-id").is_invalid());
+        });
+    }
+
+    // -- span linking -------------------------------------------------------
+
+    #[test]
+    fn test_link_span_to_valid_ids() {
+        let (subscriber, _provider) = otel_subscriber();
+        tracing::subscriber::with_default(subscriber, || {
+            let span = tracing::info_span!("test_link");
+            let result = link_span_to_ids(
+                &span,
+                "4bf92f3577b34da6a3ce929d0e0e4736",
+                "00f067aa0ba902b7",
+            );
+            assert_eq!(result, TraceLink::Linked);
+        });
+    }
+
+    #[test]
+    fn test_link_span_to_short_ids_is_invalid() {
+        let (subscriber, _provider) = otel_subscriber();
+        tracing::subscriber::with_default(subscriber, || {
+            let span = tracing::info_span!("test_link_short");
+            assert!(link_span_to_ids(&span, "4bf92f35", "00f067aa").is_invalid());
+        });
+    }
+
+    #[test]
+    fn test_link_span_to_non_hex_ids_is_invalid() {
+        let (subscriber, _provider) = otel_subscriber();
+        tracing::subscriber::with_default(subscriber, || {
+            let span = tracing::info_span!("test_link_non_hex");
+            // 32 and 16 characters, so the length guard passes and the
+            // hex parse is what rejects them.
+            assert!(
+                link_span_to_ids(
+                    &span,
+                    "zzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzz",
+                    "zzzzzzzzzzzzzzzz",
+                )
+                .is_invalid(),
+            );
+        });
+    }
+
+    #[test]
+    fn test_link_span_to_all_zero_ids_is_invalid() {
+        let (subscriber, _provider) = otel_subscriber();
+        tracing::subscriber::with_default(subscriber, || {
+            let span = tracing::info_span!("test_link_zero");
+            assert!(
+                link_span_to_ids(
+                    &span,
+                    "00000000000000000000000000000000",
+                    "0000000000000000",
+                )
+                .is_invalid(),
+            );
         });
     }
 }

--- a/crates/tribal-test-utils/Cargo.toml
+++ b/crates/tribal-test-utils/Cargo.toml
@@ -21,6 +21,7 @@ testcontainers.workspace = true
 thiserror.workspace = true
 tokio.workspace = true
 tracing.workspace = true
+tracing-subscriber.workspace = true
 uuid.workspace = true
 
 tribal-db = { workspace = true, features = ["test-helpers"] }

--- a/crates/tribal-test-utils/src/lib.rs
+++ b/crates/tribal-test-utils/src/lib.rs
@@ -21,6 +21,7 @@ mod setup;
 // in its expansion, which requires the module path to be public.
 pub mod snapshot;
 pub mod text;
+mod tracing_capture;
 
 pub use db::{TestContext, TestTransaction, lazy_pool, serial_lock, test_context};
 pub use error::TestDbError;
@@ -31,3 +32,4 @@ pub use mock::async_dispatch::*;
 pub use render::render_to_string;
 pub use seeding::*;
 pub use setup::*;
+pub use tracing_capture::{CapturedEvent, CapturedSpan, TracingCapture};

--- a/crates/tribal-test-utils/src/tracing_capture.rs
+++ b/crates/tribal-test-utils/src/tracing_capture.rs
@@ -1,0 +1,224 @@
+//! A thread-local capturing `tracing` subscriber for asserting that spans
+//! and events fire.
+//!
+//! Production code records observability through `tracing`; these tests
+//! install a subscriber over the current thread, run the instrumented code,
+//! and read back the spans (with their fields and contextual parent) and
+//! events. The capture is the registry plus one layer, so span parenting
+//! resolves the same way `tracing-opentelemetry` would see it.
+
+use std::{
+    collections::HashMap,
+    sync::{Arc, Mutex, PoisonError},
+};
+
+use tracing::{
+    Event, Subscriber,
+    field::{Field, Visit},
+    span,
+    subscriber::DefaultGuard,
+};
+use tracing_subscriber::{
+    Layer,
+    layer::{Context, SubscriberExt},
+    registry::LookupSpan,
+};
+
+/// One captured span: its name, the name of the span it was created under,
+/// and its fields (including any recorded after creation).
+#[derive(Clone, Debug)]
+pub struct CapturedSpan {
+    /// The static span name.
+    pub name: String,
+    /// The contextually enclosing span's name, when one was entered.
+    pub parent: Option<String>,
+    /// The span's fields, rendered to strings.
+    pub fields: HashMap<String, String>,
+}
+
+impl CapturedSpan {
+    /// The string value of one field, when present.
+    #[must_use]
+    pub fn field(&self, key: &str) -> Option<&str> {
+        self.fields.get(key).map(String::as_str)
+    }
+}
+
+/// One captured event: its message and its fields.
+#[derive(Clone, Debug)]
+pub struct CapturedEvent {
+    /// The event's message (the `message` field).
+    pub message: String,
+    /// The event's other fields, rendered to strings.
+    pub fields: HashMap<String, String>,
+}
+
+impl CapturedEvent {
+    /// The string value of one field, when present.
+    #[must_use]
+    pub fn field(&self, key: &str) -> Option<&str> {
+        self.fields.get(key).map(String::as_str)
+    }
+}
+
+#[derive(Default)]
+struct Store {
+    spans: Vec<CapturedSpan>,
+    /// Span id (as `u64`) to its index in `spans`, so a later field
+    /// recording merges into the right span.
+    index: HashMap<u64, usize>,
+    events: Vec<CapturedEvent>,
+}
+
+/// A handle to the captured spans and events of one installed subscriber.
+pub struct TracingCapture {
+    store: Arc<Mutex<Store>>,
+}
+
+impl TracingCapture {
+    /// Installs the capture as the current thread's default subscriber for
+    /// the returned guard's lifetime, and returns the handle to query.
+    #[must_use]
+    pub fn install() -> (Self, DefaultGuard) {
+        let store = Arc::new(Mutex::new(Store::default()));
+        let layer = CaptureLayer {
+            store: Arc::clone(&store),
+        };
+        let subscriber = tracing_subscriber::registry().with(layer);
+        let guard = tracing::subscriber::set_default(subscriber);
+        (Self { store }, guard)
+    }
+
+    /// Every captured span, in creation order.
+    #[must_use]
+    pub fn spans(&self) -> Vec<CapturedSpan> {
+        self.store
+            .lock()
+            .unwrap_or_else(PoisonError::into_inner)
+            .spans
+            .clone()
+    }
+
+    /// Every captured event, in emission order.
+    #[must_use]
+    pub fn events(&self) -> Vec<CapturedEvent> {
+        self.store
+            .lock()
+            .unwrap_or_else(PoisonError::into_inner)
+            .events
+            .clone()
+    }
+
+    /// The first captured span with the given name.
+    #[must_use]
+    pub fn span(&self, name: &str) -> Option<CapturedSpan> {
+        self.spans().into_iter().find(|span| span.name == name)
+    }
+
+    /// Every captured span with the given name.
+    #[must_use]
+    pub fn spans_named(&self, name: &str) -> Vec<CapturedSpan> {
+        self.spans()
+            .into_iter()
+            .filter(|span| span.name == name)
+            .collect()
+    }
+
+    /// The first captured event whose message equals `message`.
+    #[must_use]
+    pub fn event(&self, message: &str) -> Option<CapturedEvent> {
+        self.events()
+            .into_iter()
+            .find(|event| event.message == message)
+    }
+}
+
+struct CaptureLayer {
+    store: Arc<Mutex<Store>>,
+}
+
+impl<S> Layer<S> for CaptureLayer
+where
+    S: Subscriber + for<'a> LookupSpan<'a>,
+{
+    fn on_new_span(&self, attrs: &span::Attributes<'_>, id: &span::Id, ctx: Context<'_, S>) {
+        let mut visitor = FieldVisitor::default();
+        attrs.record(&mut visitor);
+        let parent = ctx
+            .current_span()
+            .id()
+            .and_then(|parent_id| ctx.span(parent_id))
+            .map(|parent| parent.name().to_owned());
+        let captured = CapturedSpan {
+            name: attrs.metadata().name().to_owned(),
+            parent,
+            fields: visitor.fields,
+        };
+        let mut store = self.store.lock().unwrap_or_else(PoisonError::into_inner);
+        let position = store.spans.len();
+        store.spans.push(captured);
+        store.index.insert(id.into_u64(), position);
+    }
+
+    fn on_record(&self, id: &span::Id, values: &span::Record<'_>, _ctx: Context<'_, S>) {
+        let mut visitor = FieldVisitor::default();
+        values.record(&mut visitor);
+        let mut store = self.store.lock().unwrap_or_else(PoisonError::into_inner);
+        if let Some(&position) = store.index.get(&id.into_u64()) {
+            store.spans[position].fields.extend(visitor.fields);
+        }
+    }
+
+    fn on_event(&self, event: &Event<'_>, _ctx: Context<'_, S>) {
+        let mut visitor = FieldVisitor::default();
+        event.record(&mut visitor);
+        let message = visitor.fields.remove("message").unwrap_or_default();
+        self.store
+            .lock()
+            .unwrap_or_else(PoisonError::into_inner)
+            .events
+            .push(CapturedEvent {
+                message,
+                fields: visitor.fields,
+            });
+    }
+}
+
+/// Renders every field value to a string, so `%Display`, `?Debug`, and the
+/// primitive recordings all read back uniformly.
+#[derive(Default)]
+struct FieldVisitor {
+    fields: HashMap<String, String>,
+}
+
+impl Visit for FieldVisitor {
+    fn record_debug(&mut self, field: &Field, value: &dyn std::fmt::Debug) {
+        self.fields
+            .insert(field.name().to_owned(), format!("{value:?}"));
+    }
+
+    fn record_str(&mut self, field: &Field, value: &str) {
+        self.fields
+            .insert(field.name().to_owned(), value.to_owned());
+    }
+
+    fn record_bool(&mut self, field: &Field, value: bool) {
+        self.fields
+            .insert(field.name().to_owned(), value.to_string());
+    }
+
+    fn record_i64(&mut self, field: &Field, value: i64) {
+        self.fields
+            .insert(field.name().to_owned(), value.to_string());
+    }
+
+    fn record_u64(&mut self, field: &Field, value: u64) {
+        self.fields
+            .insert(field.name().to_owned(), value.to_string());
+    }
+
+    fn record_f64(&mut self, field: &Field, value: f64) {
+        self.fields
+            .insert(field.name().to_owned(), value.to_string());
+    }
+}

--- a/crates/tribal-worker/src/worker/driver.rs
+++ b/crates/tribal-worker/src/worker/driver.rs
@@ -10,6 +10,7 @@
 
 use std::sync::Arc;
 
+use tracing::Instrument;
 use tribal_agent_runtime::{
     AgentRuntimeError, ChildTerminalOutcome, ParentResolution, RenderedConversation,
     adopt_conversation, commit_child_terminal, commit_deferred_death,
@@ -22,11 +23,13 @@ use tribal_db::{
 };
 use tribal_domain::{
     AgentDriverTask, AgentDriverTaskKind, AgentThread, AgentThreadId, AgentThreadRecordKind,
-    AgentThreadStatus, AgentThreadSuspension, ErrorOutcome, StageParameters, UsageOwner,
+    AgentThreadStatus, AgentThreadSuspension, ErrorOutcome, StageExecutorKind, StageParameters,
+    UsageOwner, gen_ai, span_attrs,
 };
 use tribal_inference::{
     CompletionRequest, Message, PermitWait, ResponseFormat, Role, UsageAttribution,
 };
+use tribal_telemetry::link_span_to_ids;
 
 use crate::{
     error::StageError,
@@ -152,6 +155,46 @@ impl Worker {
         let mut conn = self.acquire_driver_conn().await?;
 
         let child = self.run_child_thread(&mut conn, task, claim_token).await?;
+
+        // The runtime root for this one-shot child execution. It opens a
+        // fresh trace; the thread id rides `gen_ai.conversation.id` to
+        // stitch the child's traces, and the durable parent linkage carries
+        // the lineage.
+        let span = tracing::info_span!(
+            "invoke_agent",
+            { gen_ai::OPERATION_NAME } = gen_ai::OPERATION_INVOKE_AGENT,
+            { gen_ai::CONVERSATION_ID } = %child.id(),
+            { span_attrs::STAGE } = child.pipeline_stage().as_str(),
+            { span_attrs::EXECUTOR } = StageExecutorKind::OneShot.as_str(),
+            { span_attrs::PARENT_THREAD_ID } = child.parent_thread_id().map(|id| id.to_string()),
+            { span_attrs::DRIVER_ATTEMPT } = task.attempt(),
+            // A child never replays a committed turn log; a re-drive after a
+            // reclaim is the closest analogue to a resume.
+            { span_attrs::THREAD_RESUMED } = task.attempt() > 0,
+        );
+        self.run_child(conn, task, claim_token, deadline, child)
+            .instrument(span)
+            .await
+    }
+
+    /// Runs one verifier child to its terminal under the child's
+    /// `invoke_agent` span: the cancel-superseded short-circuit, the model
+    /// call, and the hand-back to its parent.
+    async fn run_child(
+        &self,
+        mut conn: sqlx::pool::PoolConnection<sqlx::Postgres>,
+        task: &AgentDriverTask,
+        claim_token: uuid::Uuid,
+        deadline: tokio::time::Instant,
+        child: AgentThread,
+    ) -> Result<(), StageError> {
+        // Best-effort: link this child's root to the parent's enclosing
+        // span context, captured durably on the child's input record at
+        // launch. Never depended on; the parent's trace window may have
+        // closed by the time the driver runs the child.
+        if let Some((trace_id, span_id)) = child_launch_context(&mut conn, &child).await {
+            let _ = link_span_to_ids(&tracing::Span::current(), &trace_id, &span_id);
+        }
 
         // A cancellation intent supersedes the run: the cascade (or an
         // operator) marked this child while it queued. Hand the
@@ -572,6 +615,24 @@ fn child_attribution(child: &AgentThread, attempt: u32) -> UsageAttribution {
         user_prompt_version_id: None,
         trace_id: tribal_telemetry::current_trace_id(),
     }
+}
+
+/// The trace and span ids the parent recorded on the child's input record
+/// at launch: the parent's enclosing `invoke_agent` span context, for a
+/// best-effort link. Both ids must be present; a best-effort read returns
+/// `None` on any miss.
+async fn child_launch_context(
+    conn: &mut sqlx::PgConnection,
+    child: &AgentThread,
+) -> Option<(String, String)> {
+    let records = PgAgentThreadRecordRepository
+        .find_by_thread_id(conn, child.id())
+        .await
+        .ok()?;
+    let input = records
+        .iter()
+        .find(|record| record.kind() == AgentThreadRecordKind::Input)?;
+    Some((input.trace_id()?.to_owned(), input.span_id()?.to_owned()))
 }
 
 fn driver_runtime_error(context: &str, source: AgentRuntimeError) -> StageError {

--- a/crates/tribal-worker/src/worker/thread_sweep.rs
+++ b/crates/tribal-worker/src/worker/thread_sweep.rs
@@ -8,13 +8,14 @@
 //! wake-at deadline this sweep drives, or a terminal outcome whose
 //! cancel-fallback this sweep performs.
 
+use tracing::Instrument;
 use tribal_agent_runtime::{BUDGET_RECHECK_CAUSE, ResolveOutcome, resolve_stage_thread};
 use tribal_config::AgentsConfig;
 use tribal_db::{
     AgentBindingVersionRepository, AgentThreadRepository, PgAgentBindingVersionRepository,
     PgAgentThreadRepository,
 };
-use tribal_domain::{AgentThread, AgentThreadSuspension, StageExecutorKind};
+use tribal_domain::{AgentThread, AgentThreadSuspension, StageExecutorKind, span_attrs};
 
 use crate::{
     definition::current_stage_budgets,
@@ -47,9 +48,17 @@ impl Worker {
     /// The janitor runs before the cancel fallback so an orphan it marks
     /// this cycle is disposed the same cycle rather than the next.
     pub(crate) async fn run_thread_sweep(&self) -> ThreadSweepStats {
+        self.run_thread_sweep_inner()
+            .instrument(thread_sweep_span())
+            .await
+    }
+
+    async fn run_thread_sweep_inner(&self) -> ThreadSweepStats {
         let mut stats = ThreadSweepStats::default();
         let Ok(mut conn) = self.pool().acquire().await else {
             tracing::warn!("pool acquire failed for the thread sweep");
+            // The cycle still carries its (zero) counts on the span.
+            record_sweep_outcome(&stats);
             return stats;
         };
 
@@ -57,7 +66,49 @@ impl Worker {
         stats.cascaded = sweep_orphan_cascade(&mut conn).await;
         stats.cancelled = sweep_cancel_fallback(self, &mut conn).await;
         stats.stuck_relating = sweep_stuck_relating(self, &mut conn).await;
+
+        record_sweep_outcome(&stats);
         stats
+    }
+}
+
+/// The availability sweep's per-cycle span. Its convergence counts are
+/// recorded as the cycle completes, so they read off one coherent span.
+fn thread_sweep_span() -> tracing::Span {
+    tracing::info_span!(
+        "tribal.thread_sweep",
+        { span_attrs::SWEEP_TIMER_WAKES } = tracing::field::Empty,
+        { span_attrs::SWEEP_CASCADED } = tracing::field::Empty,
+        { span_attrs::SWEEP_CANCELLED } = tracing::field::Empty,
+        { span_attrs::SWEEP_STUCK_RELATING } = tracing::field::Empty,
+    )
+}
+
+/// Records the cycle's counts on the enclosing sweep span and emits a
+/// per-action event for each predicate that converged anything.
+fn record_sweep_outcome(stats: &ThreadSweepStats) {
+    let span = tracing::Span::current();
+    span.record(span_attrs::SWEEP_TIMER_WAKES, stats.timer_wakes);
+    span.record(span_attrs::SWEEP_CASCADED, stats.cascaded);
+    span.record(span_attrs::SWEEP_CANCELLED, stats.cancelled);
+    span.record(span_attrs::SWEEP_STUCK_RELATING, stats.stuck_relating);
+    emit_sweep_action(span_attrs::SWEEP_ACTION_TIMER_WAKE, stats.timer_wakes);
+    emit_sweep_action(span_attrs::SWEEP_ACTION_ORPHAN_CASCADE, stats.cascaded);
+    emit_sweep_action(span_attrs::SWEEP_ACTION_CANCEL_FALLBACK, stats.cancelled);
+    emit_sweep_action(
+        span_attrs::SWEEP_ACTION_STUCK_RELATING,
+        stats.stuck_relating,
+    );
+}
+
+/// Emits a per-action sweep event when the predicate converged anything.
+fn emit_sweep_action(action: &'static str, count: u32) {
+    if count > 0 {
+        tracing::info!(
+            { span_attrs::SWEEP_ACTION } = action,
+            { span_attrs::SWEEP_ACTION_COUNT } = count,
+            "thread sweep converged an action",
+        );
     }
 }
 
@@ -104,9 +155,6 @@ async fn sweep_timer_wakes(agents: &AgentsConfig, conn: &mut sqlx::PgConnection)
             }
         }
     }
-    if woken > 0 {
-        tracing::info!(woken, "timer wakes resolved");
-    }
     woken
 }
 
@@ -143,15 +191,7 @@ async fn sweep_orphan_cascade(conn: &mut sqlx::PgConnection) -> u32 {
         .cascade_cancel_to_orphans(conn, SWEEP_BATCH, coupling::CANCEL_CASCADE_REQUESTED_BY)
         .await
     {
-        Ok(count) => {
-            if count > 0 {
-                tracing::info!(
-                    count,
-                    "orphan cascade marked descendants of terminal parents"
-                );
-            }
-            u32::try_from(count).unwrap_or(u32::MAX)
-        }
+        Ok(count) => u32::try_from(count).unwrap_or(u32::MAX),
         Err(e) => {
             tracing::warn!(error = %e, "orphan-cascade scan failed");
             0
@@ -265,9 +305,9 @@ mod tests {
     };
     use tribal_domain::{AGENT_THREAD_FORMAT_VERSION, AgentThreadRecordKind, GitRemote, TaskType};
     use tribal_test_utils::{
-        a_new_job, a_new_principal, a_new_project, a_new_prompt_version, a_new_system_fingerprint,
-        a_new_task, an_agent_definition, insert_prompt_version, serial_lock, test_context,
-        upsert_system_fingerprint,
+        TracingCapture, a_new_job, a_new_principal, a_new_project, a_new_prompt_version,
+        a_new_system_fingerprint, a_new_task, an_agent_definition, insert_prompt_version,
+        serial_lock, test_context, upsert_system_fingerprint,
     };
 
     use super::*;
@@ -427,5 +467,43 @@ mod tests {
         assert!(timer_wake.content().get("unchanged_rechecks").is_none());
 
         tribal_test_utils::truncate_all_tables(&mut conn).await;
+    }
+
+    /// The sweep cycle records its four convergence counts on one
+    /// `tribal.thread_sweep` span and emits a per-action event only for the
+    /// predicates that converged anything.
+    #[tokio::test]
+    async fn test_sweep_cycle_records_counts_and_non_zero_actions() {
+        let (capture, _capture) = TracingCapture::install();
+        let stats = ThreadSweepStats {
+            timer_wakes: 2,
+            cascaded: 0,
+            cancelled: 1,
+            stuck_relating: 0,
+        };
+        thread_sweep_span().in_scope(|| record_sweep_outcome(&stats));
+
+        let span = capture
+            .span("tribal.thread_sweep")
+            .expect("the sweep opens one span");
+        assert_eq!(span.field(span_attrs::SWEEP_TIMER_WAKES), Some("2"));
+        assert_eq!(span.field(span_attrs::SWEEP_CASCADED), Some("0"));
+        assert_eq!(span.field(span_attrs::SWEEP_CANCELLED), Some("1"));
+        assert_eq!(span.field(span_attrs::SWEEP_STUCK_RELATING), Some("0"));
+
+        let actions: Vec<_> = capture
+            .events()
+            .into_iter()
+            .filter(|event| event.message == "thread sweep converged an action")
+            .collect();
+        assert_eq!(actions.len(), 2, "only non-zero actions emit an event");
+        assert!(actions.iter().any(|event| {
+            event.field(span_attrs::SWEEP_ACTION) == Some("timer_wake")
+                && event.field(span_attrs::SWEEP_ACTION_COUNT) == Some("2")
+        }));
+        assert!(actions.iter().any(|event| {
+            event.field(span_attrs::SWEEP_ACTION) == Some("cancel_fallback")
+                && event.field(span_attrs::SWEEP_ACTION_COUNT) == Some("1")
+        }));
     }
 }

--- a/crates/tribal-worker/tests/worker/turn_loop.rs
+++ b/crates/tribal-worker/tests/worker/turn_loop.rs
@@ -9,6 +9,7 @@ use std::sync::{
 
 use async_trait::async_trait;
 use sqlx::PgConnection;
+use tracing::Instrument;
 use tribal_agent_runtime::{
     AcceptedSubmission, Admission, BUDGET_RECHECK_CAUSE, BudgetFailure, ChildTerminalOutcome,
     HeartbeatPump, LoopOutcome, ParentResolution, RecheckPolicy, RecordedMessage,
@@ -24,10 +25,10 @@ use tribal_db::{
 use tribal_domain::{
     AgentBindingVersionId, AgentThread, AgentThreadId, AgentThreadRecordKind, AgentThreadStatus,
     AgentThreadSuspension, ExecutionBudgets, ExecutionSpend, RecoverableToolFailure,
-    ToolDescriptor, ToolExecutionMode, ToolFailure, ToolSafetyTier, UsageOwner,
+    ToolDescriptor, ToolExecutionMode, ToolFailure, ToolSafetyTier, UsageOwner, gen_ai, span_attrs,
 };
 use tribal_inference::UsageAttribution;
-use tribal_test_utils::a_tool_call_response;
+use tribal_test_utils::{TracingCapture, a_tool_call_response};
 
 use super::common::*;
 
@@ -2049,6 +2050,239 @@ async fn test_post_acceptance_drift_injects_diagnostics_and_continues() {
                 tribal_inference::Message::User { content } if content.contains("superseded")
             )),
         "the drift diagnostics reach the model's re-decision as a user turn",
+    );
+
+    teardown(ctx).await;
+}
+
+// ---------------------------------------------------------------------------
+// Observability
+// ---------------------------------------------------------------------------
+
+/// A fresh claim opens one `invoke_agent` span carrying the thread id and
+/// the loop executor, emits a turn-committed event per turn and a single
+/// loop-outcome event, and nests an `execute_tool` span under it per call.
+#[tokio::test]
+async fn test_observability_instruments_a_fresh_claim() {
+    let _guard = serial_lock().await;
+    let ctx = test_context().await;
+    let harness = loop_harness(
+        ctx,
+        "obs-fresh",
+        vec![
+            a_tool_call_response(&[("call_0", "lookup_note", serde_json::json!({}))]),
+            submit_response("call_1", TOOL_ITEM_ID),
+        ],
+    )
+    .await;
+
+    let attribution = harness.attribution();
+    let (capture, _capture) = TracingCapture::install();
+    // The worker runs the loop inside its per-claim stage span; mirror that
+    // so the nesting can be asserted.
+    let stage_span = tracing::info_span!("tribal.task.extraction");
+    let outcome = run_turn_loop(harness.deps(
+        an_opening(),
+        &attribution,
+        &MembershipPipeline,
+        ExecutionBudgets::default(),
+    ))
+    .instrument(stage_span)
+    .await
+    .expect("the loop runs");
+    assert!(matches!(outcome, LoopOutcome::Submitted(_)));
+
+    let invoke = capture
+        .span("invoke_agent")
+        .expect("a fresh claim opens an invoke_agent span");
+    let thread_id = harness.thread.id().to_string();
+    assert_eq!(
+        invoke.field(gen_ai::CONVERSATION_ID),
+        Some(thread_id.as_str()),
+    );
+    assert_eq!(invoke.field(span_attrs::EXECUTOR), Some("built_in_loop"));
+    assert_eq!(invoke.field(span_attrs::THREAD_RESUMED), Some("false"));
+    assert_eq!(
+        invoke.parent.as_deref(),
+        Some("tribal.task.extraction"),
+        "invoke_agent nests under the per-claim stage span",
+    );
+
+    let turns = capture
+        .events()
+        .into_iter()
+        .filter(|event| event.message == "agentic turn committed")
+        .count();
+    assert_eq!(turns, 2, "one turn-committed event per committed turn");
+
+    let outcome_event = capture
+        .event("agentic loop reached an outcome")
+        .expect("a loop-outcome event fires once");
+    assert_eq!(
+        outcome_event.field(span_attrs::LOOP_OUTCOME),
+        Some("submitted"),
+    );
+
+    let tools = capture.spans_named("execute_tool");
+    assert!(
+        tools
+            .iter()
+            .any(|span| span.field(span_attrs::TOOL_NAME) == Some("lookup_note")),
+        "the ordinary tool call opens an execute_tool span",
+    );
+    assert!(
+        tools
+            .iter()
+            .any(|span| span.field(span_attrs::TOOL_IS_SUBMIT) == Some("true")),
+        "the submit call is flagged on its execute_tool span",
+    );
+    assert!(
+        tools
+            .iter()
+            .all(|span| span.parent.as_deref() == Some("invoke_agent")),
+        "every execute_tool span nests under invoke_agent",
+    );
+
+    teardown(ctx).await;
+}
+
+/// The verifier round trip is observable end to end: the launch and its
+/// deferred suspension on the way out, the hand-back and child-terminal on
+/// the way in, and a second `invoke_agent` flagged as a resume.
+#[tokio::test]
+async fn test_observability_instruments_the_verifier_round_trip_and_resume() {
+    let _guard = serial_lock().await;
+    let ctx = test_context().await;
+    let child_binding = a_child_binding(ctx).await;
+    let harness = loop_harness(
+        ctx,
+        "obs-verify",
+        vec![submit_response("call_0", OPENING_ITEM_ID)],
+    )
+    .await;
+    let pipeline = VerifyingPipeline { child_binding };
+
+    let (capture, _capture) = TracingCapture::install();
+
+    let attribution = harness.attribution();
+    let outcome = run_turn_loop(harness.deps(
+        an_opening(),
+        &attribution,
+        &pipeline,
+        ExecutionBudgets::default(),
+    ))
+    .await
+    .expect("the loop runs");
+    assert!(matches!(outcome, LoopOutcome::Suspended));
+
+    let launched = capture
+        .event("agentic verifier child launched")
+        .expect("a child-launched event fires");
+    assert_eq!(launched.field(span_attrs::CHILD_STAGE), Some("extraction"));
+    assert!(
+        launched.field(span_attrs::CHILD_BINDING_VERSION).is_some(),
+        "the launch event carries the child binding version",
+    );
+    let deferred = capture
+        .event("agentic thread suspended on a deferred tool result")
+        .expect("the deferred suspension is observable");
+    assert_eq!(
+        deferred.field(span_attrs::SUSPENSION_REASON),
+        Some("deferred_tool_results"),
+    );
+
+    {
+        let mut conn = raw_conn(ctx).await;
+        hand_back_verdict(&mut conn, harness.thread.id(), r#"{"accepted": true}"#).await;
+    }
+
+    let terminal = capture
+        .event("agentic child terminal committed")
+        .expect("a child-terminal-committed event fires post-commit");
+    assert_eq!(
+        terminal.field(span_attrs::CHILD_TERMINAL_OUTCOME),
+        Some("handed_back"),
+    );
+    assert_eq!(terminal.field(span_attrs::TERMINAL_IS_ERROR), Some("false"));
+
+    let (task, thread) = reclaim_parent(ctx, &harness).await;
+    let resumed = LoopHarness {
+        task,
+        thread,
+        ..harness
+    };
+    let attribution = resumed.attribution();
+    let outcome = run_turn_loop(resumed.deps(
+        an_opening(),
+        &attribution,
+        &pipeline,
+        ExecutionBudgets::default(),
+    ))
+    .await
+    .expect("the loop resumes");
+    assert!(matches!(outcome, LoopOutcome::Submitted(_)));
+
+    let invokes = capture.spans_named("invoke_agent");
+    assert_eq!(invokes.len(), 2, "one invoke_agent span per claim");
+    assert_eq!(invokes[0].field(span_attrs::THREAD_RESUMED), Some("false"));
+    assert_eq!(invokes[1].field(span_attrs::THREAD_RESUMED), Some("true"));
+    assert!(
+        capture
+            .event("agentic thread resumed from its committed log")
+            .is_some(),
+        "the resume boundary emits one event",
+    );
+
+    teardown(ctx).await;
+}
+
+/// A spend exhaustion is observable as a budget-admission decision and a
+/// typed suspension with its wake instant.
+#[tokio::test]
+async fn test_observability_instruments_a_budget_suspension() {
+    let _guard = serial_lock().await;
+    let ctx = test_context().await;
+    let harness = loop_harness(
+        ctx,
+        "obs-budget",
+        vec![a_completion_response("an expensive thought")],
+    )
+    .await;
+
+    let attribution = harness.attribution();
+    let (capture, _capture) = TracingCapture::install();
+    let outcome = run_turn_loop(
+        harness.deps(
+            an_opening(),
+            &attribution,
+            &MembershipPipeline,
+            ExecutionBudgets::builder()
+                .max_total_tokens(Some(1))
+                .build(),
+        ),
+    )
+    .await
+    .expect("the loop runs");
+    assert!(matches!(outcome, LoopOutcome::Suspended));
+
+    let admission = capture
+        .event("budget exhausted; suspending")
+        .expect("a budget-admission event fires");
+    assert_eq!(
+        admission.field(span_attrs::BUDGET_DECISION),
+        Some("suspend")
+    );
+
+    let suspended = capture
+        .event("agentic thread suspended")
+        .expect("a suspension-committed event fires");
+    assert_eq!(
+        suspended.field(span_attrs::SUSPENSION_REASON),
+        Some("budget_exhausted"),
+    );
+    assert!(
+        suspended.field(span_attrs::WAKE_AT).is_some(),
+        "a budget suspension carries its wake instant",
     );
 
     teardown(ctx).await;


### PR DESCRIPTION
Closes tribal-memory/cortex#11.

The agentic runtime's success path was invisible to its own telemetry: lifecycle transitions surfaced only on fault, and no per-execution span tied a turn's inference, tool calls, and commit together. This builds the missing success-path visibility on top of the landed GenAI inference and embedding telemetry.

## What this adds

- An `invoke_agent` span per thread-advancing execution, nested under the worker's per-claim stage span, carrying the thread id as `gen_ai.conversation.id` plus the stage, task, executor kind, and a resume flag. One-shot stages are unchanged.
- An `execute_tool` span per tool call, with `chat` and `embeddings` nesting under `invoke_agent`.
- Lifecycle events for thread resume, turn commit, submission evaluation, suspension, child launch, child terminal, deferred death, budget admission, and loop outcome, each carrying ids and metadata only.
- A `tribal.thread_sweep` span per availability-sweep cycle with its four convergence counts and a per-action event for each non-zero predicate.

## Notes

- Reason, decision, and outcome values are typed enums rendered to `tribal.*` wire-string constants, so they are queryable and cannot drift.
- A verifier child carries its parent thread id and a best-effort span link to the parent's launch context, on top of the durable parent linkage; the link is never depended on.
- No content (claim text, candidate text, justifications, rendered prompts) reaches any span or event.
- No schema change: the record trace and span columns already exist.
- Lifecycle metrics and a content opt-in are out of scope; the events carry the fields a later metrics pass would aggregate.

Tests assert the spans and events via a capturing subscriber for a fresh claim, a resume, a verifier round trip, a budget suspension, and a sweep cycle.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/tribal-memory/tribal/pull/224?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

