### PR TITLE
[CHORE] Aggregate the agentic lifecycle into metrics

### DIFF
--- a/crates/tribal-agent-runtime/src/driver.rs
+++ b/crates/tribal-agent-runtime/src/driver.rs
@@ -42,7 +42,7 @@ use tribal_domain::{
     AgentThreadRecordKind, AgentThreadRecordSeq, AgentThreadStatus, AgentThreadSuspension,
     AgentThreadTerminal, CompletionResponse, JobId, PrincipalId, TaskId, TaskType, span_attrs,
 };
-use tribal_telemetry::{current_span_id, current_trace_id};
+use tribal_telemetry::{MetricsRecorder, current_span_id, current_trace_id};
 
 use crate::{
     AgentRuntimeError,
@@ -307,6 +307,7 @@ pub async fn commit_child_terminal(
     attempt: i32,
     child_response: &CompletionResponse,
     parent: &ParentResolution,
+    recorder: &dyn MetricsRecorder,
 ) -> Result<ChildTerminalOutcome, AgentRuntimeError> {
     // `hand_back` locks the parent thread before its task, the sanctioned
     // inversion of the global lock order it needs to read the parent's
@@ -332,6 +333,7 @@ pub async fn commit_child_terminal(
         {
             Err(e) if remaining > 0 && e.is_retryable() => {
                 remaining -= 1;
+                recorder.record_agent_conflict_retry();
                 tracing::warn!(
                     child_thread_id = %child.id(),
                     { span_attrs::CONFLICT_RETRY_REMAINING } = remaining,
@@ -339,6 +341,7 @@ pub async fn commit_child_terminal(
                 );
             }
             Ok(outcome) => {
+                recorder.record_agent_child_terminal(outcome.label(), false);
                 tracing::info!(
                     child_thread_id = %child.id(),
                     { span_attrs::CHILD_TERMINAL_OUTCOME } = outcome.label(),
@@ -411,6 +414,7 @@ pub async fn commit_deferred_death(
     driver_claim_token: uuid::Uuid,
     parent: &ParentResolution,
     error_message: &str,
+    recorder: &dyn MetricsRecorder,
 ) -> Result<ChildTerminalOutcome, AgentRuntimeError> {
     let mut txn = begin(conn, "beginning the deferred-death transaction").await?;
 
@@ -435,6 +439,7 @@ pub async fn commit_deferred_death(
     .await?;
 
     commit(txn, "committing the deferred-death transaction").await?;
+    recorder.record_agent_child_terminal(outcome.label(), true);
     tracing::warn!(
         child_thread_id = %child.id(),
         { span_attrs::CHILD_TERMINAL_OUTCOME } = outcome.label(),

--- a/crates/tribal-agent-runtime/src/turn_loop.rs
+++ b/crates/tribal-agent-runtime/src/turn_loop.rs
@@ -361,8 +361,10 @@ pub enum AdmissionDecision {
 }
 
 impl AdmissionDecision {
-    /// The telemetry label for a pre-call admission decision.
-    fn label(&self) -> &'static str {
+    /// The telemetry label for a pre-call admission decision, shared by the
+    /// loop and the one-shot bracket so both count the same wire strings.
+    #[must_use]
+    pub fn label(&self) -> &'static str {
         match self {
             Self::Proceed => span_attrs::BUDGET_DECISION_ADMITTED,
             Self::Suspend { .. } => span_attrs::BUDGET_DECISION_SUSPEND,

--- a/crates/tribal-agent-runtime/src/turn_loop.rs
+++ b/crates/tribal-agent-runtime/src/turn_loop.rs
@@ -40,7 +40,7 @@ use tribal_domain::{
 use tribal_inference::{
     CompletionRequest, InferenceGateway, Message, PermitWait, ToolWireDefinition, UsageAttribution,
 };
-use tribal_telemetry::{current_span_id, current_trace_id};
+use tribal_telemetry::{MetricsRecorder, current_span_id, current_trace_id};
 
 use crate::{
     AgentRuntimeError, SuspendOutcome, ToolRegistry,
@@ -587,6 +587,8 @@ pub struct TurnLoopDependencies<'a> {
     pub max_tokens: Option<u32>,
     /// The claim's outer deadline, bounding provider-permit waits.
     pub permit_deadline: tokio::time::Instant,
+    /// The sink for the loop's lifecycle metrics.
+    pub recorder: &'a dyn MetricsRecorder,
 }
 
 // ---------------------------------------------------------------------------
@@ -649,6 +651,7 @@ async fn run_turn_loop_inner(
                 .count(),
             "agentic thread resumed from its committed log",
         );
+        deps.recorder.record_agent_thread_resume();
     } else {
         begin_turn(
             &mut conn,
@@ -744,6 +747,8 @@ async fn run_turn_loop_inner(
         )
         .await?;
         emit_budget_admission(decision);
+        deps.recorder
+            .record_agent_budget_admission(decision.label());
         match decision {
             AdmissionDecision::Proceed => {}
             AdmissionDecision::Exhausted(cause) => {
@@ -766,6 +771,8 @@ async fn run_turn_loop_inner(
                 {
                     SuspendOutcome::Suspended => {
                         emit_suspension(&suspension, Some(wake_at), Some(unchanged_rechecks));
+                        deps.recorder
+                            .record_agent_suspension(suspension.reason_label());
                         LoopOutcome::Suspended
                     }
                     SuspendOutcome::CancelIntervened => LoopOutcome::CancelIntent,
@@ -1789,7 +1796,12 @@ async fn launch_verifier(
     )
     .await?
     {
-        SuspendWithChildOutcome::Launched(_) => Ok(CallStep::Suspended),
+        SuspendWithChildOutcome::Launched(_) => {
+            deps.recorder.record_agent_child_launch();
+            deps.recorder
+                .record_agent_suspension(span_attrs::SUSPENSION_REASON_DEFERRED);
+            Ok(CallStep::Suspended)
+        }
         SuspendWithChildOutcome::CancelIntervened => Ok(CallStep::CancelIntervened),
     }
 }

--- a/crates/tribal-telemetry/src/metrics.rs
+++ b/crates/tribal-telemetry/src/metrics.rs
@@ -32,6 +32,20 @@ pub const SEMAPHORE_ACQUIRE_WAIT_MS: &str = "tribal.semaphore.acquire_wait_ms";
 pub const JOB_DURATION_MS: &str = "tribal.job.duration_ms";
 /// Histogram: individual task duration in milliseconds.
 pub const TASK_DURATION_MS: &str = "tribal.task.duration_ms";
+/// Counter: agentic thread suspensions, by reason.
+pub const AGENT_SUSPENSIONS: &str = "tribal.agent.suspensions";
+/// Counter: pre-call budget admission decisions, by decision.
+pub const AGENT_BUDGET_ADMISSIONS: &str = "tribal.agent.budget.admissions";
+/// Counter: verifier child launches.
+pub const AGENT_CHILD_LAUNCHES: &str = "tribal.agent.child.launches";
+/// Counter: verifier child terminals, by outcome.
+pub const AGENT_CHILD_TERMINALS: &str = "tribal.agent.child.terminals";
+/// Counter: thread resumes from a committed log.
+pub const AGENT_THREAD_RESUMES: &str = "tribal.agent.thread.resumes";
+/// Counter: in-place child-terminal conflict retries.
+pub const AGENT_CONFLICT_RETRIES: &str = "tribal.agent.conflict_retries";
+/// Counter: availability-sweep actions converged, by kind.
+pub const AGENT_SWEEP_ACTIONS: &str = "tribal.agent.sweep.actions";
 
 // ---------------------------------------------------------------------------
 // Label key constants
@@ -79,6 +93,21 @@ pub struct Metrics {
     /// Client operation duration. Unit: seconds, per the `GenAI` client
     /// conventions.
     pub gen_ai_operation_duration: Histogram<f64>,
+    /// Agentic thread suspensions, labelled by `tribal.suspension.reason`.
+    pub agent_suspensions: Counter<u64>,
+    /// Pre-call budget admission decisions, labelled by `tribal.budget.decision`.
+    pub agent_budget_admissions: Counter<u64>,
+    /// Verifier child launches.
+    pub agent_child_launches: Counter<u64>,
+    /// Verifier child terminals, labelled by `tribal.child.terminal_outcome`
+    /// and `tribal.terminal.is_error`.
+    pub agent_child_terminals: Counter<u64>,
+    /// Thread resumes from a committed log.
+    pub agent_thread_resumes: Counter<u64>,
+    /// In-place child-terminal conflict retries.
+    pub agent_conflict_retries: Counter<u64>,
+    /// Availability-sweep actions converged, labelled by `tribal.sweep.action`.
+    pub agent_sweep_actions: Counter<u64>,
 }
 
 impl Metrics {
@@ -104,6 +133,13 @@ impl Metrics {
                 .f64_histogram(gen_ai::CLIENT_OPERATION_DURATION)
                 .with_unit("s")
                 .build(),
+            agent_suspensions: meter.u64_counter(AGENT_SUSPENSIONS).build(),
+            agent_budget_admissions: meter.u64_counter(AGENT_BUDGET_ADMISSIONS).build(),
+            agent_child_launches: meter.u64_counter(AGENT_CHILD_LAUNCHES).build(),
+            agent_child_terminals: meter.u64_counter(AGENT_CHILD_TERMINALS).build(),
+            agent_thread_resumes: meter.u64_counter(AGENT_THREAD_RESUMES).build(),
+            agent_conflict_retries: meter.u64_counter(AGENT_CONFLICT_RETRIES).build(),
+            agent_sweep_actions: meter.u64_counter(AGENT_SWEEP_ACTIONS).build(),
         }
     }
 

--- a/crates/tribal-telemetry/src/recorder.rs
+++ b/crates/tribal-telemetry/src/recorder.rs
@@ -83,6 +83,28 @@ pub trait MetricsRecorder: Send + Sync {
     /// Only `"queued"` and `"claimed"` statuses are recorded; other
     /// values are silently ignored.
     fn set_queue_gauge(&self, task_type: &str, status: &str, count: i64);
+
+    /// Records an agentic thread suspension, classed by reason.
+    fn record_agent_suspension(&self, reason: &str);
+
+    /// Records a pre-call budget admission decision.
+    fn record_agent_budget_admission(&self, decision: &str);
+
+    /// Records a verifier child launch.
+    fn record_agent_child_launch(&self);
+
+    /// Records a verifier child terminal, classed by outcome and whether
+    /// it crossed back an error (a child death).
+    fn record_agent_child_terminal(&self, outcome: &str, is_error: bool);
+
+    /// Records a thread resume from its committed log.
+    fn record_agent_thread_resume(&self);
+
+    /// Records an in-place child-terminal conflict retry.
+    fn record_agent_conflict_retry(&self);
+
+    /// Records `count` availability-sweep actions converged of one kind.
+    fn record_agent_sweep_action(&self, action: &str, count: u64);
 }
 
 /// Delegates through `Arc` so that `Arc<dyn MetricsRecorder>` satisfies
@@ -118,6 +140,34 @@ impl<T: MetricsRecorder + ?Sized> MetricsRecorder for Arc<T> {
 
     fn set_queue_gauge(&self, task_type: &str, status: &str, count: i64) {
         (**self).set_queue_gauge(task_type, status, count);
+    }
+
+    fn record_agent_suspension(&self, reason: &str) {
+        (**self).record_agent_suspension(reason);
+    }
+
+    fn record_agent_budget_admission(&self, decision: &str) {
+        (**self).record_agent_budget_admission(decision);
+    }
+
+    fn record_agent_child_launch(&self) {
+        (**self).record_agent_child_launch();
+    }
+
+    fn record_agent_child_terminal(&self, outcome: &str, is_error: bool) {
+        (**self).record_agent_child_terminal(outcome, is_error);
+    }
+
+    fn record_agent_thread_resume(&self) {
+        (**self).record_agent_thread_resume();
+    }
+
+    fn record_agent_conflict_retry(&self) {
+        (**self).record_agent_conflict_retry();
+    }
+
+    fn record_agent_sweep_action(&self, action: &str, count: u64) {
+        (**self).record_agent_sweep_action(action, count);
     }
 }
 
@@ -237,6 +287,55 @@ impl MetricsRecorder for OtelMetricsRecorder {
             _ => {}
         }
     }
+
+    fn record_agent_suspension(&self, reason: &str) {
+        self.metrics.agent_suspensions.add(
+            1,
+            &[KeyValue::new(
+                span_attrs::SUSPENSION_REASON,
+                reason.to_owned(),
+            )],
+        );
+    }
+
+    fn record_agent_budget_admission(&self, decision: &str) {
+        self.metrics.agent_budget_admissions.add(
+            1,
+            &[KeyValue::new(
+                span_attrs::BUDGET_DECISION,
+                decision.to_owned(),
+            )],
+        );
+    }
+
+    fn record_agent_child_launch(&self) {
+        self.metrics.agent_child_launches.add(1, &[]);
+    }
+
+    fn record_agent_child_terminal(&self, outcome: &str, is_error: bool) {
+        self.metrics.agent_child_terminals.add(
+            1,
+            &[
+                KeyValue::new(span_attrs::CHILD_TERMINAL_OUTCOME, outcome.to_owned()),
+                KeyValue::new(span_attrs::TERMINAL_IS_ERROR, is_error),
+            ],
+        );
+    }
+
+    fn record_agent_thread_resume(&self) {
+        self.metrics.agent_thread_resumes.add(1, &[]);
+    }
+
+    fn record_agent_conflict_retry(&self) {
+        self.metrics.agent_conflict_retries.add(1, &[]);
+    }
+
+    fn record_agent_sweep_action(&self, action: &str, count: u64) {
+        self.metrics.agent_sweep_actions.add(
+            count,
+            &[KeyValue::new(span_attrs::SWEEP_ACTION, action.to_owned())],
+        );
+    }
 }
 
 // ---------------------------------------------------------------------------
@@ -257,6 +356,13 @@ impl MetricsRecorder for NoopMetricsRecorder {
     fn record_task_dead_lettered(&self, _task_type: &str) {}
     fn record_job_completed(&self, _outcome: &str, _duration_ms: Option<f64>) {}
     fn set_queue_gauge(&self, _task_type: &str, _status: &str, _count: i64) {}
+    fn record_agent_suspension(&self, _reason: &str) {}
+    fn record_agent_budget_admission(&self, _decision: &str) {}
+    fn record_agent_child_launch(&self) {}
+    fn record_agent_child_terminal(&self, _outcome: &str, _is_error: bool) {}
+    fn record_agent_thread_resume(&self) {}
+    fn record_agent_conflict_retry(&self) {}
+    fn record_agent_sweep_action(&self, _action: &str, _count: u64) {}
 }
 
 /// Creates a no-op recorder for use in tests.
@@ -284,6 +390,13 @@ mod tests {
         recorder.record_job_completed("success", Some(1200.0));
         recorder.record_job_completed("failure", None);
         recorder.set_queue_gauge("extraction", "queued", 5);
+        recorder.record_agent_suspension("budget_exhausted");
+        recorder.record_agent_budget_admission("admitted");
+        recorder.record_agent_child_launch();
+        recorder.record_agent_child_terminal("handed_back", false);
+        recorder.record_agent_thread_resume();
+        recorder.record_agent_conflict_retry();
+        recorder.record_agent_sweep_action("timer_wake", 3);
     }
 
     #[test]
@@ -325,5 +438,12 @@ mod tests {
         recorder.set_queue_gauge("triage", "queued", 3);
         recorder.set_queue_gauge("extraction", "claimed", 1);
         recorder.set_queue_gauge("relation", "completed", 10);
+        recorder.record_agent_suspension("deferred_tool_results");
+        recorder.record_agent_budget_admission("suspend");
+        recorder.record_agent_child_launch();
+        recorder.record_agent_child_terminal("parent_not_waiting", true);
+        recorder.record_agent_thread_resume();
+        recorder.record_agent_conflict_retry();
+        recorder.record_agent_sweep_action("cancel_fallback", 0);
     }
 }

--- a/crates/tribal-worker/src/stages/common.rs
+++ b/crates/tribal-worker/src/stages/common.rs
@@ -467,26 +467,35 @@ impl Worker {
             delay_seconds: DEFAULT_AGENTIC_RECHECK_DELAY_SECONDS,
             bound: DEFAULT_AGENTIC_RECHECK_BOUND,
         };
-        match decide_admission(conn, thread, &budgets, recheck, carried)
+        let decision = decide_admission(conn, thread, &budgets, recheck, carried)
             .await
-            .map_err(|source| map_runtime_error(stage, "admitting the call", source))?
-        {
+            .map_err(|source| map_runtime_error(stage, "admitting the call", source))?;
+        self.metrics()
+            .record_agent_budget_admission(decision.label());
+        match decision {
             AdmissionDecision::Proceed => Ok(false),
             AdmissionDecision::Suspend { unchanged_rechecks } => {
                 let wake_at = chrono::Utc::now()
                     + chrono::Duration::seconds(i64::from(recheck.delay_seconds));
+                let suspension = AgentThreadSuspension::BudgetExhaustion { unchanged_rechecks };
                 let outcome = suspend_stage_thread(
                     conn,
                     thread,
                     task.id(),
                     claim_token,
-                    &AgentThreadSuspension::BudgetExhaustion { unchanged_rechecks },
+                    &suspension,
                     Some(wake_at),
                 )
                 .await
                 .map_err(|source| map_runtime_error(stage, "suspending on the budget", source))?;
-                if matches!(outcome, SuspendOutcome::CancelIntervened) {
-                    self.dispose_intervened(task, thread).await?;
+                match outcome {
+                    SuspendOutcome::Suspended => {
+                        self.metrics()
+                            .record_agent_suspension(suspension.reason_label());
+                    }
+                    SuspendOutcome::CancelIntervened => {
+                        self.dispose_intervened(task, thread).await?;
+                    }
                 }
                 Ok(true)
             }

--- a/crates/tribal-worker/src/stages/extraction_loop.rs
+++ b/crates/tribal-worker/src/stages/extraction_loop.rs
@@ -120,6 +120,7 @@ impl Worker {
                 temperature: narrow_temperature(parameters.temperature),
                 max_tokens: parameters.max_tokens,
                 permit_deadline: deadline,
+                recorder: self.metrics(),
             })
             .await
             .map_err(|source| {

--- a/crates/tribal-worker/src/stages/relation_loop.rs
+++ b/crates/tribal-worker/src/stages/relation_loop.rs
@@ -147,6 +147,7 @@ impl Worker {
                 temperature: narrow_temperature(parameters.temperature),
                 max_tokens: parameters.max_tokens,
                 permit_deadline: deadline,
+                recorder: self.metrics(),
             })
             .await
             .map_err(|source| {

--- a/crates/tribal-worker/src/stages/triage_loop.rs
+++ b/crates/tribal-worker/src/stages/triage_loop.rs
@@ -163,6 +163,7 @@ impl Worker {
                 temperature: narrow_temperature(parameters.temperature),
                 max_tokens: parameters.max_tokens,
                 permit_deadline: deadline,
+                recorder: self.metrics(),
             })
             .await
             .map_err(|source| map_runtime_error(STAGE_TRIAGE, "running the triage loop", source))?;

--- a/crates/tribal-worker/src/worker/driver.rs
+++ b/crates/tribal-worker/src/worker/driver.rs
@@ -286,6 +286,7 @@ impl Worker {
             clamp_to_i32(task.attempt()),
             &response,
             &parent,
+            self.metrics(),
         )
         .await
         .map_err(|source| driver_runtime_error("committing the child terminal", source))?;
@@ -453,8 +454,16 @@ impl Worker {
                 return;
             }
         };
-        if let Err(e) =
-            commit_deferred_death(&mut conn, &child, task.id(), claim_token, &parent, message).await
+        if let Err(e) = commit_deferred_death(
+            &mut conn,
+            &child,
+            task.id(),
+            claim_token,
+            &parent,
+            message,
+            self.metrics(),
+        )
+        .await
         {
             if matches!(e, AgentRuntimeError::DrivingTaskNotBlocked { .. }) {
                 // The parent is in an unmodelled non-blocked state, so the

--- a/crates/tribal-worker/src/worker/thread_sweep.rs
+++ b/crates/tribal-worker/src/worker/thread_sweep.rs
@@ -16,6 +16,7 @@ use tribal_db::{
     PgAgentThreadRepository,
 };
 use tribal_domain::{AgentThread, AgentThreadSuspension, StageExecutorKind, span_attrs};
+use tribal_telemetry::MetricsRecorder;
 
 use crate::{
     definition::current_stage_budgets,
@@ -58,7 +59,7 @@ impl Worker {
         let Ok(mut conn) = self.pool().acquire().await else {
             tracing::warn!("pool acquire failed for the thread sweep");
             // The cycle still carries its (zero) counts on the span.
-            record_sweep_outcome(&stats);
+            record_sweep_outcome(self.metrics(), &stats);
             return stats;
         };
 
@@ -67,7 +68,7 @@ impl Worker {
         stats.cancelled = sweep_cancel_fallback(self, &mut conn).await;
         stats.stuck_relating = sweep_stuck_relating(self, &mut conn).await;
 
-        record_sweep_outcome(&stats);
+        record_sweep_outcome(self.metrics(), &stats);
         stats
     }
 }
@@ -84,31 +85,47 @@ fn thread_sweep_span() -> tracing::Span {
     )
 }
 
-/// Records the cycle's counts on the enclosing sweep span and emits a
-/// per-action event for each predicate that converged anything.
-fn record_sweep_outcome(stats: &ThreadSweepStats) {
+/// Records the cycle's counts on the enclosing sweep span, emits a
+/// per-action event, and counts a per-action metric for each predicate
+/// that converged anything.
+fn record_sweep_outcome(recorder: &dyn MetricsRecorder, stats: &ThreadSweepStats) {
     let span = tracing::Span::current();
     span.record(span_attrs::SWEEP_TIMER_WAKES, stats.timer_wakes);
     span.record(span_attrs::SWEEP_CASCADED, stats.cascaded);
     span.record(span_attrs::SWEEP_CANCELLED, stats.cancelled);
     span.record(span_attrs::SWEEP_STUCK_RELATING, stats.stuck_relating);
-    emit_sweep_action(span_attrs::SWEEP_ACTION_TIMER_WAKE, stats.timer_wakes);
-    emit_sweep_action(span_attrs::SWEEP_ACTION_ORPHAN_CASCADE, stats.cascaded);
-    emit_sweep_action(span_attrs::SWEEP_ACTION_CANCEL_FALLBACK, stats.cancelled);
     emit_sweep_action(
+        recorder,
+        span_attrs::SWEEP_ACTION_TIMER_WAKE,
+        stats.timer_wakes,
+    );
+    emit_sweep_action(
+        recorder,
+        span_attrs::SWEEP_ACTION_ORPHAN_CASCADE,
+        stats.cascaded,
+    );
+    emit_sweep_action(
+        recorder,
+        span_attrs::SWEEP_ACTION_CANCEL_FALLBACK,
+        stats.cancelled,
+    );
+    emit_sweep_action(
+        recorder,
         span_attrs::SWEEP_ACTION_STUCK_RELATING,
         stats.stuck_relating,
     );
 }
 
-/// Emits a per-action sweep event when the predicate converged anything.
-fn emit_sweep_action(action: &'static str, count: u32) {
+/// Emits a per-action sweep event and counts the metric when the predicate
+/// converged anything.
+fn emit_sweep_action(recorder: &dyn MetricsRecorder, action: &'static str, count: u32) {
     if count > 0 {
         tracing::info!(
             { span_attrs::SWEEP_ACTION } = action,
             { span_attrs::SWEEP_ACTION_COUNT } = count,
             "thread sweep converged an action",
         );
+        recorder.record_agent_sweep_action(action, u64::from(count));
     }
 }
 
@@ -475,13 +492,14 @@ mod tests {
     #[tokio::test]
     async fn test_sweep_cycle_records_counts_and_non_zero_actions() {
         let (capture, _capture) = TracingCapture::install();
+        let recorder = tribal_telemetry::noop_recorder();
         let stats = ThreadSweepStats {
             timer_wakes: 2,
             cascaded: 0,
             cancelled: 1,
             stuck_relating: 0,
         };
-        thread_sweep_span().in_scope(|| record_sweep_outcome(&stats));
+        thread_sweep_span().in_scope(|| record_sweep_outcome(recorder.as_ref(), &stats));
 
         let span = capture
             .span("tribal.thread_sweep")

--- a/crates/tribal-worker/tests/worker/driver.rs
+++ b/crates/tribal-worker/tests/worker/driver.rs
@@ -262,6 +262,7 @@ async fn test_child_terminal_hands_the_verdict_back_to_the_parent() {
         0,
         &response,
         &a_parent_resolution(&sp),
+        noop_recorder().as_ref(),
     )
     .await
     .expect("child terminal");
@@ -339,6 +340,7 @@ async fn test_a_stale_driver_token_rolls_the_whole_terminal_back() {
         0,
         &response,
         &a_parent_resolution(&sp),
+        noop_recorder().as_ref(),
     )
     .await
     .expect_err("a stale driver token is rejected");
@@ -394,6 +396,7 @@ async fn test_a_hand_back_rolls_back_when_the_parent_task_is_not_blocked() {
         0,
         &response,
         &a_parent_resolution(&sp),
+        noop_recorder().as_ref(),
     )
     .await
     .expect_err("a non-blocked parent task rolls the hand-back back");
@@ -456,6 +459,7 @@ async fn test_child_terminal_discards_when_the_parent_is_no_longer_waiting() {
         0,
         &response,
         &a_parent_resolution(&sp),
+        noop_recorder().as_ref(),
     )
     .await
     .expect("child terminal against a terminal parent");
@@ -991,6 +995,7 @@ async fn test_deferred_death_crosses_the_failure_into_the_parent() {
         token,
         &a_parent_resolution(&sp),
         "the verifier exhausted its retries",
+        noop_recorder().as_ref(),
     )
     .await
     .expect("deferred death");

--- a/crates/tribal-worker/tests/worker/turn_loop.rs
+++ b/crates/tribal-worker/tests/worker/turn_loop.rs
@@ -4,7 +4,7 @@
 
 use std::sync::{
     Arc,
-    atomic::{AtomicU32, Ordering},
+    atomic::{AtomicU32, AtomicU64, Ordering},
 };
 
 use async_trait::async_trait;
@@ -28,6 +28,7 @@ use tribal_domain::{
     ToolDescriptor, ToolExecutionMode, ToolFailure, ToolSafetyTier, UsageOwner, gen_ai, span_attrs,
 };
 use tribal_inference::UsageAttribution;
+use tribal_telemetry::{InferenceOperationRecord, MetricsRecorder};
 use tribal_test_utils::{TracingCapture, a_tool_call_response};
 
 use super::common::*;
@@ -74,6 +75,43 @@ impl HeartbeatPump for TestPump {
         self.aborts
             .fetch_add(1, std::sync::atomic::Ordering::SeqCst);
     }
+}
+
+/// Counts the lifecycle metric calls the loop and driver make, so a test
+/// can prove the metrics fire rather than only that the recorder accepts
+/// them.
+#[derive(Default)]
+struct CountingRecorder {
+    suspensions: AtomicU64,
+    budget_admissions: AtomicU64,
+    child_launches: AtomicU64,
+    thread_resumes: AtomicU64,
+}
+
+impl MetricsRecorder for CountingRecorder {
+    fn record_pool_acquire(&self, _pool: &str, _elapsed: Duration) {}
+    fn record_semaphore_acquire(&self, _provider_key: &str, _elapsed: Duration) {}
+    fn record_inference_operation(&self, _record: &InferenceOperationRecord<'_>) {}
+    fn record_task_completed(&self, _task_type: &str, _duration_ms: f64) {}
+    fn record_task_retried(&self, _task_type: &str) {}
+    fn record_task_dead_lettered(&self, _task_type: &str) {}
+    fn record_job_completed(&self, _outcome: &str, _duration_ms: Option<f64>) {}
+    fn set_queue_gauge(&self, _task_type: &str, _status: &str, _count: i64) {}
+    fn record_agent_suspension(&self, _reason: &str) {
+        self.suspensions.fetch_add(1, Ordering::SeqCst);
+    }
+    fn record_agent_budget_admission(&self, _decision: &str) {
+        self.budget_admissions.fetch_add(1, Ordering::SeqCst);
+    }
+    fn record_agent_child_launch(&self) {
+        self.child_launches.fetch_add(1, Ordering::SeqCst);
+    }
+    fn record_agent_child_terminal(&self, _outcome: &str, _is_error: bool) {}
+    fn record_agent_thread_resume(&self) {
+        self.thread_resumes.fetch_add(1, Ordering::SeqCst);
+    }
+    fn record_agent_conflict_retry(&self) {}
+    fn record_agent_sweep_action(&self, _action: &str, _count: u64) {}
 }
 
 fn a_descriptor(name: &str) -> ToolDescriptor {
@@ -295,6 +333,7 @@ struct LoopHarness {
     submit_descriptor: ToolDescriptor,
     pump: TestPump,
     job_id: tribal_domain::JobId,
+    recorder: Arc<dyn tribal_telemetry::MetricsRecorder>,
 }
 
 impl LoopHarness {
@@ -324,6 +363,7 @@ impl LoopHarness {
             temperature: None,
             max_tokens: None,
             permit_deadline: tokio::time::Instant::now() + Duration::from_secs(30),
+            recorder: self.recorder.as_ref(),
         }
     }
 
@@ -455,6 +495,7 @@ async fn loop_harness(
             .build(),
         pump: TestPump::default(),
         job_id,
+        recorder: noop_recorder(),
     }
 }
 
@@ -1382,6 +1423,7 @@ async fn hand_back_verdict(conn: &mut PgConnection, parent_id: AgentThreadId, ve
             requesting_seq,
             tool_call_id,
         },
+        noop_recorder().as_ref(),
     )
     .await
     .expect("hand the verdict back");
@@ -1447,6 +1489,7 @@ async fn kill_child_via_deferred_death(
             tool_call_id,
         },
         message,
+        noop_recorder().as_ref(),
     )
     .await
     .expect("the deferred death crosses back");
@@ -2154,12 +2197,14 @@ async fn test_observability_instruments_the_verifier_round_trip_and_resume() {
     let _guard = serial_lock().await;
     let ctx = test_context().await;
     let child_binding = a_child_binding(ctx).await;
-    let harness = loop_harness(
+    let mut harness = loop_harness(
         ctx,
         "obs-verify",
         vec![submit_response("call_0", OPENING_ITEM_ID)],
     )
     .await;
+    let counter = Arc::new(CountingRecorder::default());
+    harness.recorder = counter.clone();
     let pipeline = VerifyingPipeline { child_binding };
 
     let (capture, _capture) = TracingCapture::install();
@@ -2189,6 +2234,16 @@ async fn test_observability_instruments_the_verifier_round_trip_and_resume() {
     assert_eq!(
         deferred.field(span_attrs::SUSPENSION_REASON),
         Some("deferred_tool_results"),
+    );
+    assert_eq!(
+        counter.child_launches.load(Ordering::SeqCst),
+        1,
+        "the child launch is counted",
+    );
+    assert_eq!(
+        counter.suspensions.load(Ordering::SeqCst),
+        1,
+        "the deferred suspension is counted",
     );
 
     {
@@ -2232,6 +2287,11 @@ async fn test_observability_instruments_the_verifier_round_trip_and_resume() {
             .is_some(),
         "the resume boundary emits one event",
     );
+    assert_eq!(
+        counter.thread_resumes.load(Ordering::SeqCst),
+        1,
+        "the resume is counted",
+    );
 
     teardown(ctx).await;
 }
@@ -2242,12 +2302,14 @@ async fn test_observability_instruments_the_verifier_round_trip_and_resume() {
 async fn test_observability_instruments_a_budget_suspension() {
     let _guard = serial_lock().await;
     let ctx = test_context().await;
-    let harness = loop_harness(
+    let mut harness = loop_harness(
         ctx,
         "obs-budget",
         vec![a_completion_response("an expensive thought")],
     )
     .await;
+    let counter = Arc::new(CountingRecorder::default());
+    harness.recorder = counter.clone();
 
     let attribution = harness.attribution();
     let (capture, _capture) = TracingCapture::install();
@@ -2284,6 +2346,11 @@ async fn test_observability_instruments_a_budget_suspension() {
         suspended.field(span_attrs::WAKE_AT).is_some(),
         "a budget suspension carries its wake instant",
     );
+
+    // The admitted first turn and the suspend decision both count; the
+    // suspension counts once.
+    assert_eq!(counter.budget_admissions.load(Ordering::SeqCst), 2);
+    assert_eq!(counter.suspensions.load(Ordering::SeqCst), 1);
 
     teardown(ctx).await;
 }


### PR DESCRIPTION
Follow-up to tribal-memory/cortex#11, which added the agentic runtime's success-path spans and events but left their aggregation as a named follow-up.

This counts the lifecycle as OpenTelemetry metrics over the existing recorder, so a deployment can chart rates and totals without scraping logs.

## What this adds

- New counters on the metrics recorder: suspensions by reason, budget admissions by decision, child launches, child terminals (by outcome and error flag), thread resumes, conflict retries, and sweep actions by kind.
- The recorder is threaded into the turn loop, the child-terminal and deferred-death transitions, and the availability sweep, so each counter increments at the same site as its lifecycle event.

## Notes

- The metric attribute keys reuse the lifecycle event field keys, so a counter and the event it aggregates share one vocabulary and cannot drift.
- The admitted budget decision is a counter here even though its log sits at debug, so the dominant success path is visible without raising log volume.
- A counting recorder double asserts the loop fires the budget, suspension, child-launch, and resume metrics; the recorder methods carry their own unit coverage.

Full gate green: fmt, workspace clippy with warnings denied, the telemetry and worker suites, and the e2e suite.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/tribal-memory/tribal/pull/225?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

