### PR TITLE
fix(compose): expose the relation verifier toggle and correct its docs

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -41,13 +41,14 @@ ANTHROPIC_API_KEY=
 # Opt-in agentic execution, per stage: route a stage through the in-process
 # turn loop with stage-scoped tools (requires a tool-capable model). Each
 # stage is one_shot by default; the turn, token, and wall-clock budgets are
-# optional overrides. Only triage has a verifier (extraction and relation
-# verifiers are inert in this release).
+# optional overrides. The triage and relation loops have a verifier, on by
+# default; extraction has none.
 # TRIBAL_AGENTS__EXTRACTION__EXECUTOR=loop
 # TRIBAL_AGENTS__TRIAGE__EXECUTOR=loop
-# TRIBAL_AGENTS__TRIAGE__VERIFIER=true
+# TRIBAL_AGENTS__TRIAGE__VERIFIER=false
 # TRIBAL_AGENTS__TRIAGE__MAX_TURNS=8
 # TRIBAL_AGENTS__RELATION__EXECUTOR=loop
+# TRIBAL_AGENTS__RELATION__VERIFIER=false
 # TRIBAL_AGENTS__RELATION__MAX_TOTAL_TOKENS=200000
 # TRIBAL_AGENTS__RELATION__EXECUTION_DEADLINE_SECONDS=600
 # TRIBAL_INFERENCE__RELATION__PROVIDER=openai

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -69,17 +69,19 @@ services:
       - TRIBAL_INFERENCE__RELATION__BASE_URL=${TRIBAL_INFERENCE__RELATION__BASE_URL:-http://host.docker.internal:11434}
       # Opt-in agentic execution, per stage; the default reproduces the
       # launched one-shot behaviour exactly. Set a stage to loop to run its
-      # in-process turn loop instead. Only triage carries a verifier (default
-      # on under its loop, disabled with TRIBAL_AGENTS__TRIAGE__VERIFIER=false);
-      # the extraction and relation verifiers are inert in this release.
+      # in-process turn loop instead. The triage and relation loops carry a
+      # verifier, on by default and disabled per stage with
+      # TRIBAL_AGENTS__TRIAGE__VERIFIER=false or
+      # TRIBAL_AGENTS__RELATION__VERIFIER=false; extraction has no verifier.
       - TRIBAL_AGENTS__EXTRACTION__EXECUTOR=${TRIBAL_AGENTS__EXTRACTION__EXECUTOR:-one_shot}
       - TRIBAL_AGENTS__TRIAGE__EXECUTOR=${TRIBAL_AGENTS__TRIAGE__EXECUTOR:-one_shot}
       - TRIBAL_AGENTS__RELATION__EXECUTOR=${TRIBAL_AGENTS__RELATION__EXECUTOR:-one_shot}
-      # Optional overrides: the triage verifier toggle and each stage's turn,
-      # token, and deadline budgets. Bare pass-throughs, so an unset one is
-      # omitted from the container and the binary's default stands. Set any of
-      # them in .env to override (see .env.example).
+      # Optional overrides: the triage and relation verifier toggles and each
+      # stage's turn, token, and deadline budgets. Bare pass-throughs, so an
+      # unset one is omitted from the container and the binary's default
+      # stands. Set any of them in .env to override (see .env.example).
       - TRIBAL_AGENTS__TRIAGE__VERIFIER
+      - TRIBAL_AGENTS__RELATION__VERIFIER
       - TRIBAL_AGENTS__EXTRACTION__MAX_TURNS
       - TRIBAL_AGENTS__EXTRACTION__MAX_TOTAL_TOKENS
       - TRIBAL_AGENTS__EXTRACTION__EXECUTION_DEADLINE_SECONDS


### PR DESCRIPTION
The relation loop's verifier is on by default under the loop executor, the same as triage's, but the Docker Compose and `.env.example` comments still described the relation verifier as inert, and only the triage verifier had a host pass-through. A Docker operator running the relation stage under the loop therefore could not disable its verifier through the documented environment variables.

This change:

- adds a `TRIBAL_AGENTS__RELATION__VERIFIER` bare pass-through to `docker-compose.yml`, alongside the existing triage one
- corrects the comments in both `docker-compose.yml` and `.env.example` to match the shipped behaviour: the triage and relation loops verify by default, extraction has no verifier
- switches the `.env.example` example values to `=false`, the meaningful override now that the verifiers default on

No binary behaviour changes; this is documentation and a missing host pass-through.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/tribal-memory/tribal/pull/227?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

