### PR TITLE
[FIX] Use content-based matching in cross_batch_relations E2E test assertion

### DIFF
--- a/crates/tribal-e2e/tests/e2e/cross_batch_relations.rs
+++ b/crates/tribal-e2e/tests/e2e/cross_batch_relations.rs
@@ -4,10 +4,7 @@ use tribal_test_utils::item;
 
 use crate::harness::{
     assertions::assert_success,
-    fixtures::{
-        ExtractionFixture, ReferenceSpec, RelationFixture, SimilarItemSpec, candidate, hint, novel,
-        relate,
-    },
+    fixtures::{ExtractionFixture, ReferenceSpec, RelationFixture, candidate, hint, novel, relate},
     server::TestHarness,
     tool_call::tool_result_json,
 };
@@ -19,16 +16,7 @@ use crate::harness::{
 /// Theme: Canopy's event sourcing architecture — a new performance
 /// fact supports the original architecture decision, and a companion
 /// monitoring heuristic is extracted alongside it.
-// QUARANTINED (~20% flaky): a pre-existing async-ordering non-determinism in the
-// worker pipeline, surfaced by per-test-database isolation. The triage stage's
-// similar-item search context depends on the order in which this job's own
-// candidates and the seeded item become visible; the previous persistent shared
-// database happened to stabilise that order. Confirmed NOT an HNSW/index issue
-// (reproduces with exact search) and NOT introduced by the test-harness change
-// (reproduces on the prior commit). Re-enable once the pipeline ordering is
-// deterministic.
 #[tokio::test]
-#[ignore = "flaky: pre-existing worker-pipeline ordering non-determinism; see comment"]
 async fn test_cross_batch_relations() {
     let mut harness = TestHarness::init(|setup| {
         // Anthropic triage exercises the Anthropic envelope abstraction.
@@ -99,14 +87,15 @@ async fn test_cross_batch_relations() {
             m.on_content_repeat_last(
                 "storage costs",
                 &[novel()
-                    // The seeded decision is the sole search hit, at index 0.
-                    .similar_item(SimilarItemSpec {
-                        context_index: 0,
-                        suggested_relation: "supports",
-                        justification: "Storage savings validate the event sourcing decision",
-                    })
-                    .build()
-                    .into()],
+                    // Reference the seeded decision by content; the responder
+                    // resolves its index from the actual search results, so the
+                    // mock is robust to similar-item ordering.
+                    .similar_item_by_content(
+                        "Meridian chose event sourcing",
+                        "supports",
+                        "Storage savings validate the event sourcing decision",
+                    )
+                    .build_resolved()],
             );
             m.on_content_repeat_last("compaction lag", &[novel().build().into()]);
         })

--- a/crates/tribal-e2e/tests/harness/fixtures/triage.rs
+++ b/crates/tribal-e2e/tests/harness/fixtures/triage.rs
@@ -1,4 +1,9 @@
+use std::sync::Arc;
+
 use serde_json::{Value, json};
+use wiremock::Request;
+
+use crate::harness::mocks::MockResponse;
 
 // ---------------------------------------------------------------------------
 // Spec types
@@ -10,6 +15,21 @@ pub struct SimilarItemSpec<'a> {
     pub context_index: u32,
     pub suggested_relation: &'a str,
     pub justification: &'a str,
+}
+
+/// How a similar item is located in the triage prompt's numbered list.
+enum SimilarItemRef {
+    /// A fixed zero-based position.
+    Index(u32),
+    /// A unique substring of the item's content, resolved to its position from
+    /// the request body at serve time.
+    Content(String),
+}
+
+struct SimilarItemEntry {
+    item: SimilarItemRef,
+    suggested_relation: String,
+    justification: String,
 }
 
 // ---------------------------------------------------------------------------
@@ -46,32 +66,139 @@ pub fn duplicate(matched_index: u32) -> TriageFixtureBuilder {
 pub struct TriageFixtureBuilder {
     decision: String,
     matched_index: Option<u32>,
-    similar_items: Vec<Value>,
+    similar_items: Vec<SimilarItemEntry>,
 }
 
 impl TriageFixtureBuilder {
-    /// Adds a similar item classification.
+    /// Adds a similar item classification referenced by its zero-based index
+    /// in the prompt's numbered list.
     #[must_use]
     pub fn similar_item(mut self, item: SimilarItemSpec<'_>) -> Self {
-        self.similar_items.push(json!({
-            "item": { "kind": "context_index", "context_index": item.context_index },
-            "suggested_relation": item.suggested_relation,
-            "justification": item.justification,
-        }));
+        self.similar_items.push(SimilarItemEntry {
+            item: SimilarItemRef::Index(item.context_index),
+            suggested_relation: item.suggested_relation.to_owned(),
+            justification: item.justification.to_owned(),
+        });
+        self
+    }
+
+    /// Adds a similar item referenced by a unique substring of its content
+    /// rather than by position. The index is resolved from the triage request
+    /// at serve time via [`build_resolved`](Self::build_resolved), so the
+    /// fixture does not depend on the non-deterministic ordering of
+    /// equal-distance semantic-search results.
+    #[must_use]
+    pub fn similar_item_by_content(
+        mut self,
+        content_substring: &str,
+        suggested_relation: &str,
+        justification: &str,
+    ) -> Self {
+        self.similar_items.push(SimilarItemEntry {
+            item: SimilarItemRef::Content(content_substring.to_owned()),
+            suggested_relation: suggested_relation.to_owned(),
+            justification: justification.to_owned(),
+        });
         self
     }
 
     /// Produces the fixture as `serde_json::Value`.
+    ///
+    /// # Panics
+    ///
+    /// Panics if any similar item was added via
+    /// [`similar_item_by_content`](Self::similar_item_by_content): resolving a
+    /// content reference needs the request body, so such fixtures must go
+    /// through [`build_resolved`](Self::build_resolved).
     #[must_use]
     pub fn build(self) -> Value {
-        let mut outcome = json!({ "decision": self.decision });
-        if let Some(index) = self.matched_index {
-            outcome["matched_item"] = json!({ "kind": "context_index", "context_index": index });
-        }
-
-        json!({
-            "outcome": outcome,
-            "similar_item_decisions": self.similar_items,
-        })
+        let similar_items = self
+            .similar_items
+            .iter()
+            .map(|entry| {
+                let index = match &entry.item {
+                    SimilarItemRef::Index(index) => *index,
+                    SimilarItemRef::Content(substring) => panic!(
+                        "similar_item_by_content({substring:?}) needs build_resolved(), not build()"
+                    ),
+                };
+                similar_item_json(index, &entry.suggested_relation, &entry.justification)
+            })
+            .collect();
+        triage_response(&self.decision, self.matched_index, similar_items)
     }
+
+    /// Produces a [`MockResponse`] whose content-referenced similar items are
+    /// resolved to their numbered positions from the triage request body at
+    /// serve time. Index-referenced items pass through unchanged.
+    #[must_use]
+    pub fn build_resolved(self) -> MockResponse {
+        MockResponse::DynamicFixture(Arc::new(move |request: &Request| {
+            let body = String::from_utf8_lossy(&request.body);
+            let similar_items = self
+                .similar_items
+                .iter()
+                .map(|entry| {
+                    let index = match &entry.item {
+                        SimilarItemRef::Index(index) => *index,
+                        SimilarItemRef::Content(substring) => {
+                            resolve_context_index(&body, substring)
+                        }
+                    };
+                    similar_item_json(index, &entry.suggested_relation, &entry.justification)
+                })
+                .collect();
+            triage_response(&self.decision, self.matched_index, similar_items)
+        }))
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+fn similar_item_json(context_index: u32, suggested_relation: &str, justification: &str) -> Value {
+    json!({
+        "item": { "kind": "context_index", "context_index": context_index },
+        "suggested_relation": suggested_relation,
+        "justification": justification,
+    })
+}
+
+fn triage_response(decision: &str, matched_index: Option<u32>, similar_items: Vec<Value>) -> Value {
+    let mut outcome = json!({ "decision": decision });
+    if let Some(index) = matched_index {
+        outcome["matched_item"] = json!({ "kind": "context_index", "context_index": index });
+    }
+    json!({
+        "outcome": outcome,
+        "similar_item_decisions": similar_items,
+    })
+}
+
+/// Resolves the zero-based index of the `### Item N` block whose content
+/// contains `substring`, by scanning the rendered triage prompt in the request
+/// body. The triage user prompt numbers each similar item as `### Item N`
+/// (`crates/tribal-worker/src/prompt/triage.rs`), so the nearest such header
+/// before the matched content gives its index.
+///
+/// # Panics
+///
+/// Panics if no item block contains `substring`, or its header cannot be
+/// parsed — both indicate a test-setup error, not something to paper over.
+fn resolve_context_index(body: &str, substring: &str) -> u32 {
+    const HEADER: &str = "### Item ";
+    let content_pos = body.find(substring).unwrap_or_else(|| {
+        panic!("triage request body does not contain similar-item content {substring:?}")
+    });
+    let header_pos = body[..content_pos].rfind(HEADER).unwrap_or_else(|| {
+        panic!("no '{HEADER}N' header precedes content {substring:?} in the triage request")
+    });
+    let digits: String = body[header_pos + HEADER.len()..]
+        .chars()
+        .take_while(|c| c.is_ascii_digit())
+        .collect();
+    digits
+        .parse()
+        .unwrap_or_else(|_| panic!("could not parse the index from the '{HEADER}' header"))
 }

--- a/crates/tribal-e2e/tests/harness/mocks/mounting.rs
+++ b/crates/tribal-e2e/tests/harness/mocks/mounting.rs
@@ -241,9 +241,12 @@ impl<'a> StageMountBuilder<'a> {
         }
     }
 
-    /// Attaches a response to a mock builder. A [`MockResponse::DynamicFixture`]
-    /// computes its body from the request at serve time; every other response
-    /// uses a static template.
+    /// Attaches a response to a mock builder, dispatching on its kind: a
+    /// [`MockResponse::DynamicFixture`] computes its body from the request at
+    /// serve time; a [`MockResponse::Fixture`] uses a static success envelope;
+    /// a [`MockResponse::Error`] returns the bare status. The match is
+    /// exhaustive, so a new variant is a compile error here rather than a
+    /// runtime surprise.
     fn attach(
         &self,
         builder: MockBuilder,
@@ -259,27 +262,11 @@ impl<'a> StageMountBuilder<'a> {
                     finish_template(&resolver(req), provider, streaming, delay_ms)
                 })
             }
-            _ => builder.respond_with(self.to_template(response, streaming, delay_ms)),
-        }
-    }
-
-    fn to_template(
-        &self,
-        response: &MockResponse,
-        streaming: bool,
-        delay_ms: Option<u64>,
-    ) -> ResponseTemplate {
-        match response {
-            MockResponse::Fixture(v) => finish_template(v, self.provider, streaming, delay_ms),
-            MockResponse::DynamicFixture(_) => {
-                unreachable!("dynamic fixtures are served via the respond_with closure in `attach`")
+            MockResponse::Fixture(content) => {
+                builder.respond_with(finish_template(content, self.provider, streaming, delay_ms))
             }
             MockResponse::Error(status) => {
-                let template = ResponseTemplate::new(*status);
-                match delay_ms {
-                    Some(ms) => template.set_delay(std::time::Duration::from_millis(ms)),
-                    None => template,
-                }
+                builder.respond_with(apply_delay(ResponseTemplate::new(*status), delay_ms))
             }
         }
     }
@@ -307,6 +294,11 @@ fn finish_template(
     } else {
         ResponseTemplate::new(200).set_body_json(wrap_completion(content, provider))
     };
+    apply_delay(template, delay_ms)
+}
+
+/// Applies the configured response delay, if any.
+fn apply_delay(template: ResponseTemplate, delay_ms: Option<u64>) -> ResponseTemplate {
     match delay_ms {
         Some(ms) => template.set_delay(std::time::Duration::from_millis(ms)),
         None => template,

--- a/crates/tribal-e2e/tests/harness/mocks/mounting.rs
+++ b/crates/tribal-e2e/tests/harness/mocks/mounting.rs
@@ -1,7 +1,9 @@
+use std::sync::Arc;
+
 use serde_json::Value;
 use tribal_domain::ProviderKind;
 use wiremock::{
-    Mock, MockBuilder, MockServer, ResponseTemplate,
+    Mock, MockBuilder, MockServer, Request, ResponseTemplate,
     matchers::{body_string_contains, method, path},
 };
 
@@ -29,11 +31,19 @@ impl From<&str> for ContentMatcher {
 // MockResponse
 // ---------------------------------------------------------------------------
 
+/// Resolves a stage-fixture `Value` from the incoming request body at serve
+/// time — e.g. picking a similar item's context index by matching its content
+/// in the rendered prompt, so the response does not depend on search ordering.
+pub type DynamicFixtureFn = Arc<dyn Fn(&Request) -> Value + Send + Sync>;
+
 /// A single entry in a mock response sequence.
 #[derive(Clone)]
 pub enum MockResponse {
     /// A successful response wrapping a stage fixture.
     Fixture(Value),
+    /// A successful response whose fixture is computed from the request body
+    /// at serve time.
+    DynamicFixture(DynamicFixtureFn),
     /// An HTTP error response with the given status code.
     Error(u16),
 }
@@ -214,31 +224,42 @@ impl<'a> StageMountBuilder<'a> {
         // declared (and so mounted) last: registered behind every
         // content-specific matcher, it shadows none of them.
         for entry in &self.entries {
-            let wrapped: Vec<ResponseTemplate> = entry
-                .responses
-                .iter()
-                .map(|r| self.to_template(r, entry.streaming, entry.delay_ms))
-                .collect();
-            let (final_response, prefix) = wrapped
-                .split_last()
-                .expect("non-empty responses checked on add");
-
-            for template in prefix {
-                self.build_when(endpoint, &entry.matcher)
-                    .respond_with(template.clone())
-                    .up_to_n_times(1)
-                    .mount(self.server)
-                    .await;
+            let last = entry.responses.len() - 1;
+            for (i, response) in entry.responses.iter().enumerate() {
+                let mock = self.attach(
+                    self.build_when(endpoint, &entry.matcher),
+                    response,
+                    entry.streaming,
+                    entry.delay_ms,
+                );
+                if i == last && entry.repeat_last {
+                    mock.mount(self.server).await;
+                } else {
+                    mock.up_to_n_times(1).mount(self.server).await;
+                }
             }
+        }
+    }
 
-            let final_mock = self
-                .build_when(endpoint, &entry.matcher)
-                .respond_with(final_response.clone());
-            if entry.repeat_last {
-                final_mock.mount(self.server).await;
-            } else {
-                final_mock.up_to_n_times(1).mount(self.server).await;
+    /// Attaches a response to a mock builder. A [`MockResponse::DynamicFixture`]
+    /// computes its body from the request at serve time; every other response
+    /// uses a static template.
+    fn attach(
+        &self,
+        builder: MockBuilder,
+        response: &MockResponse,
+        streaming: bool,
+        delay_ms: Option<u64>,
+    ) -> Mock {
+        match response {
+            MockResponse::DynamicFixture(resolver) => {
+                let provider = self.provider;
+                let resolver = Arc::clone(resolver);
+                builder.respond_with(move |req: &Request| {
+                    finish_template(&resolver(req), provider, streaming, delay_ms)
+                })
             }
+            _ => builder.respond_with(self.to_template(response, streaming, delay_ms)),
         }
     }
 
@@ -248,20 +269,18 @@ impl<'a> StageMountBuilder<'a> {
         streaming: bool,
         delay_ms: Option<u64>,
     ) -> ResponseTemplate {
-        let template = match response {
-            MockResponse::Fixture(v) if streaming => {
-                let (body, content_type) = wrap_completion_stream(v, self.provider);
-                ResponseTemplate::new(200).set_body_raw(body, content_type)
+        match response {
+            MockResponse::Fixture(v) => finish_template(v, self.provider, streaming, delay_ms),
+            MockResponse::DynamicFixture(_) => {
+                unreachable!("dynamic fixtures are served via the respond_with closure in `attach`")
             }
-            MockResponse::Fixture(v) => {
-                let wrapped = wrap_completion(v, self.provider);
-                ResponseTemplate::new(200).set_body_json(wrapped)
+            MockResponse::Error(status) => {
+                let template = ResponseTemplate::new(*status);
+                match delay_ms {
+                    Some(ms) => template.set_delay(std::time::Duration::from_millis(ms)),
+                    None => template,
+                }
             }
-            MockResponse::Error(status) => ResponseTemplate::new(*status),
-        };
-        match delay_ms {
-            Some(ms) => template.set_delay(std::time::Duration::from_millis(ms)),
-            None => template,
         }
     }
 
@@ -271,5 +290,25 @@ impl<'a> StageMountBuilder<'a> {
             ContentMatcher::Any => base,
             ContentMatcher::Contains(s) => base.and(body_string_contains(s.clone())),
         }
+    }
+}
+
+/// Wraps a stage-fixture `Value` in the provider's success envelope (streaming
+/// or buffered), applying any configured delay.
+fn finish_template(
+    content: &Value,
+    provider: ProviderKind,
+    streaming: bool,
+    delay_ms: Option<u64>,
+) -> ResponseTemplate {
+    let template = if streaming {
+        let (body, content_type) = wrap_completion_stream(content, provider);
+        ResponseTemplate::new(200).set_body_raw(body, content_type)
+    } else {
+        ResponseTemplate::new(200).set_body_json(wrap_completion(content, provider))
+    };
+    match delay_ms {
+        Some(ms) => template.set_delay(std::time::Duration::from_millis(ms)),
+        None => template,
     }
 }


### PR DESCRIPTION
## What
Removes the `#[ignore]` on `cross_batch_relations` by fixing the root cause of its flakiness — no retries, sleeps, or loosened assertions.

## Why it flaked (~15–50%)
The test asserts a cross-batch `supports` relation from an ingested fact to a seeded decision. The triage fixture referenced the matched similar item by a hardcoded position (`context_index: 0`). But the e2e embedding mock returns one constant vector for every ingested candidate, so the sibling candidate ties at cosine distance 0 with the query and the seeded decision lands at a non-deterministic position (equal-distance ties break on random v4 UUIDs). Position 0 was a coin-flip. Per-test-database isolation surfaced this pre-existing ordering dependency.

## Fix — reference by content, not position
- `mocks/mounting.rs`: `MockResponse::DynamicFixture` — a response computed from the request body at serve time (wiremock's `Respond` closure).
- `fixtures/triage.rs`: `similar_item_by_content(...)` + `build_resolved()` — a serve-time responder finds the `### Item N` block containing the decision's text and emits that `N`.
- `cross_batch_relations.rs`: reference the decision by content; drop `#[ignore]`.

The real embed → search → triage → relation pipeline still runs end to end; only the mocked LLM's choice of index is made content-correct, as a real LLM would. The shared embedding mock is untouched, so no other e2e test changes behaviour.

## Verification
- `cross_batch_relations`: **40/40** runs green (was ~15–50% flaky).
- Full e2e suite: **28/28**, 0 skipped (un-quarantined, no regression).
- clippy `-D warnings` + nightly fmt clean.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/tribal-memory/tribal/pull/229?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

